### PR TITLE
Utxo coin lib II

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
   },
   "plugins": ["simple-import-sort"],
   "rules": {
-    "simple-import-sort/sort": "error"
+    "simple-import-sort/sort": "error",
+    "@typescript-eslint/camelcase": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "bip39": "^3.0.2",
-    "bitcoinforksjs-lib": "git://https://github.com/TheCharlatan/bitcoinjs-lib#altcoins",
+    "bitcoinforksjs-lib": "file://../bitcoinjs-lib",
     "bitcoinjs-lib": "^5.1.10",
     "bn.js": "^5.1.2",
     "groestlcoinjs-lib": "^5.1.10"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "typescript": "^3.9.6"
   },
   "dependencies": {
+    "bip32grs": "^2.0.5",
     "bip39": "^3.0.2",
     "bitcoinforksjs-lib": "file://../bitcoinjs-lib",
     "bitcoinjs-lib": "^5.1.10",

--- a/package.json
+++ b/package.json
@@ -57,12 +57,13 @@
     "typescript": "^3.9.6"
   },
   "dependencies": {
+    "bip32": "^2.0.5",
     "bip32grs": "^2.0.5",
     "bip39": "^3.0.2",
     "bitcoinforksjs-lib": "file://../bitcoinjs-lib",
-    "bitcoinjs-lib": "^5.1.10",
     "bn.js": "^5.1.2",
     "bs58grscheck": "^2.1.2",
+    "crypto-browserify": "git://github.com/decred/crypto-browserify.git#master-legacy",
     "wifgrs": "^2.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,26 +27,26 @@
     "*.{js,jsx,ts,tsx}": "eslint"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.4",
-    "@babel/preset-react": "^7.8.3",
+    "@babel/core": "^7.10.4",
+    "@babel/preset-react": "^7.10.4",
     "@types/chai": "^4.2.9",
     "@types/mocha": "^7.0.1",
-    "@types/react": "^16.9.22",
+    "@types/react": "^16.9.41",
     "@types/react-dom": "^16.9.5",
-    "@typescript-eslint/eslint-plugin": ">=2.0.0",
+    "@typescript-eslint/eslint-plugin": "^3.5.0",
     "@typescript-eslint/parser": "^2.0.0",
     "chai": "^4.2.0",
-    "eslint": ">=6.2.2",
+    "eslint": "^7.3.1",
     "eslint-config-standard-kit": ">=0.14.4",
-    "eslint-plugin-import": ">=2.18.0",
+    "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-node": ">=9.1.0",
-    "eslint-plugin-prettier": ">=3.0.0",
+    "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-promise": ">=4.2.1",
-    "eslint-plugin-react": ">=7.14.2",
+    "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-simple-import-sort": ">=4.0.0",
     "eslint-plugin-standard": ">=4.0.0",
     "husky": ">=3.0.0",
-    "lint-staged": ">=9.0.0",
+    "lint-staged": "^10.2.11",
     "mocha": "^7.0.1",
     "npm-run-all": "^4.1.5",
     "parcel": "^1.12.4",
@@ -54,10 +54,12 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "sucrase": "^3.12.1",
-    "typescript": "^3.8.2"
+    "typescript": "^3.9.6"
   },
   "dependencies": {
     "bip39": "^3.0.2",
-    "bitcoinjs-lib": "^5.1.10"
+    "bitcoinjs-lib": "^5.1.10",
+    "bn.js": "^5.1.2",
+    "groestlcoinjs-lib": "^5.1.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "bip32": "^2.0.5",
     "bip32grs": "^2.0.5",
     "bip39": "^3.0.2",
-    "bitcoinforksjs-lib": "file://../bitcoinjs-lib",
+    "bitcoinforksjs-lib": "git://github.com/TheCharlatan/bitcoinjs-lib.git#decredSupport",
     "bn.js": "^5.1.2",
     "bs58grscheck": "^2.1.2",
     "crypto-browserify": "git://github.com/decred/crypto-browserify.git#master-legacy",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@babel/preset-react": "^7.10.4",
     "@types/chai": "^4.2.9",
     "@types/mocha": "^7.0.1",
-    "@types/react": "^16.9.41",
+    "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.5",
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^2.0.0",
@@ -61,6 +61,7 @@
     "bitcoinforksjs-lib": "file://../bitcoinjs-lib",
     "bitcoinjs-lib": "^5.1.10",
     "bn.js": "^5.1.2",
-    "groestlcoinjs-lib": "^5.1.10"
+    "bs58grscheck": "^2.1.2",
+    "wifgrs": "^2.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "@types/mocha": "^7.0.1",
     "@types/react": "^16.9.41",
     "@types/react-dom": "^16.9.5",
-    "@typescript-eslint/eslint-plugin": "^3.5.0",
+    "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^2.0.0",
     "chai": "^4.2.0",
-    "eslint": "^7.3.1",
+    "eslint": "^7.4.0",
     "eslint-config-standard-kit": ">=0.14.4",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-node": ">=9.1.0",
@@ -58,8 +58,9 @@
   },
   "dependencies": {
     "bip39": "^3.0.2",
+    "bitcoinforksjs-lib": "git://https://github.com/TheCharlatan/bitcoinjs-lib#altcoins",
     "bitcoinjs-lib": "^5.1.10",
     "bn.js": "^5.1.2",
-    "groestlcoinjs-lib": "^5.1.7"
+    "groestlcoinjs-lib": "^5.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,9 @@
     "bitcoinforksjs-lib": "git://github.com/TheCharlatan/bitcoinjs-lib.git#altcoins",
     "bn.js": "^5.1.2",
     "bs58grscheck": "^2.1.2",
+    "bs58smartcheck": "^2.0.4",
     "crypto-browserify": "git://github.com/decred/crypto-browserify.git#master-legacy",
+    "wif-smart": "^2.0.0",
     "wifgrs": "^2.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "bip32": "^2.0.5",
     "bip32grs": "^2.0.5",
     "bip39": "^3.0.2",
-    "bitcoinforksjs-lib": "git://github.com/TheCharlatan/bitcoinjs-lib.git#decredSupport",
+    "bitcoinforksjs-lib": "git://github.com/TheCharlatan/bitcoinjs-lib.git#altcoins",
     "bn.js": "^5.1.2",
     "bs58grscheck": "^2.1.2",
     "crypto-browserify": "git://github.com/decred/crypto-browserify.git#master-legacy",

--- a/src/common/utxobased/keymanager/base.ts
+++ b/src/common/utxobased/keymanager/base.ts
@@ -23,16 +23,6 @@ export function base58Base(
     const payload = buffer.slice(0, -4)
     const checksum = buffer.slice(-4)
     const newChecksum = checksumFn(payload)
-    console.log(
-      buffer.toString('hex'),
-      buffer,
-      'payload: ',
-      payload,
-      'as included: ',
-      checksum,
-      'new checksum: ',
-      newChecksum
-    )
 
     if (
       (checksum[0] ^ newChecksum[0]) |

--- a/src/common/utxobased/keymanager/base.ts
+++ b/src/common/utxobased/keymanager/base.ts
@@ -1,0 +1,71 @@
+'use strict'
+
+import * as base58 from 'bs58'
+import { Buffer } from 'buffer'
+
+interface Base58BaseReturn {
+  encode: (payload: Buffer) => string
+  decode: (stringPayload: string | undefined) => Buffer
+  decodeUnsafe: (stringPayload: string) => Buffer | undefined
+}
+
+export function base58Base(
+  checksumFn: (buffer: Buffer) => Buffer
+): Base58BaseReturn {
+  // Encode a buffer as a base58-check encoded string
+  function encode(payload: Buffer): string {
+    const checksum: Buffer = checksumFn(payload)
+
+    return base58.encode(Buffer.concat([payload, checksum], payload.length + 4))
+  }
+
+  function decodeRaw(buffer: Buffer): Buffer | undefined {
+    const payload = buffer.slice(0, -4)
+    const checksum = buffer.slice(-4)
+    const newChecksum = checksumFn(payload)
+    console.log(
+      buffer.toString('hex'),
+      buffer,
+      'payload: ',
+      payload,
+      'as included: ',
+      checksum,
+      'new checksum: ',
+      newChecksum
+    )
+
+    if (
+      (checksum[0] ^ newChecksum[0]) |
+      (checksum[1] ^ newChecksum[1]) |
+      (checksum[2] ^ newChecksum[2]) |
+      (checksum[3] ^ newChecksum[3])
+    )
+      return
+
+    return payload
+  }
+
+  // Decode a base58-check encoded string to a buffer, no result if checksum is wrong
+  function decodeUnsafe(stringPayload: string): Buffer | undefined {
+    const buffer = base58.decodeUnsafe(stringPayload)
+    if (typeof buffer === 'undefined') return
+
+    return decodeRaw(buffer)
+  }
+
+  function decode(payload: string | undefined): Buffer {
+    if (typeof payload === 'undefined') {
+      throw new Error('Invalid base58 string')
+    }
+    const buffer = base58.decode(payload)
+    const bPayload = decodeRaw(buffer)
+    if (!bPayload) throw new Error('Invalid checksum')
+    return bPayload
+  }
+
+  return {
+    encode,
+    decode,
+    decodeUnsafe,
+  }
+}

--- a/src/common/utxobased/keymanager/bitcoincashUtils/bn.ts
+++ b/src/common/utxobased/keymanager/bitcoincashUtils/bn.ts
@@ -180,15 +180,15 @@ BN.prototype.toScriptNumBuffer = function () {
   })
 }
 
-BN.prototype.gt = function (b: BN) {
+BN.prototype.gt = function (b: any) {
   return this.cmp(b) > 0
 }
 
-BN.prototype.gte = function (b: BN) {
+BN.prototype.gte = function (b: any) {
   return this.cmp(b) >= 0
 }
 
-BN.prototype.lt = function (b: BN) {
+BN.prototype.lt = function (b: any) {
   return this.cmp(b) < 0
 }
 

--- a/src/common/utxobased/keymanager/bitcoincashUtils/bn.ts
+++ b/src/common/utxobased/keymanager/bitcoincashUtils/bn.ts
@@ -8,7 +8,7 @@ interface Opts {
   size?: number
 }
 
-const reversebuf = function(buf: Buffer): Buffer {
+const reversebuf = function (buf: Buffer): Buffer {
   const buf2 = Buffer.alloc(buf.length)
   for (let i = 0; i < buf.length; i++) {
     buf2[i] = buf[buf.length - 1 - i]
@@ -20,21 +20,21 @@ BN.Zero = new BN(0)
 BN.One = new BN(1)
 BN.Minus1 = new BN(-1)
 
-BN.fromNumber = function(n: number) {
+BN.fromNumber = function (n: number) {
   if (typeof n !== 'number') {
     throw new Error(`InvalidArgument: ${n} not a number`)
   }
   return new BN(n)
 }
 
-BN.fromString = function(str: string, base: number) {
+BN.fromString = function (str: string, base: number) {
   if (typeof str !== 'string') {
     throw new Error(`InvalidArgument: ${str} not a string`)
   }
   return new BN(str, base)
 }
 
-BN.fromBuffer = function(buf: Buffer, opts: Opts) {
+BN.fromBuffer = function (buf: Buffer, opts: Opts) {
   if (opts.endian === 'little') {
     buf = reversebuf(buf)
   }
@@ -47,7 +47,7 @@ BN.fromBuffer = function(buf: Buffer, opts: Opts) {
  * Instantiate a BigNumber from a "signed magnitude buffer"
  * (a buffer where the most significant bit represents the sign (0 = positive, -1 = negative))
  */
-BN.fromSM = function(buf: Buffer, opts: Opts) {
+BN.fromSM = function (buf: Buffer, opts: Opts) {
   let ret
   if (buf.length === 0) {
     return BN.fromBuffer(Buffer.from([0]))
@@ -68,11 +68,11 @@ BN.fromSM = function(buf: Buffer, opts: Opts) {
   return ret
 }
 
-BN.prototype.toNumber = function() {
+BN.prototype.toNumber = function () {
   return parseInt(this.toString(10), 10)
 }
 
-BN.prototype.toBuffer = function(opts: Opts) {
+BN.prototype.toBuffer = function (opts: Opts) {
   let buf, hex
   if (typeof opts.size !== 'undefined' && opts.size > 0) {
     hex = this.toString(16, 2)
@@ -96,7 +96,7 @@ BN.prototype.toBuffer = function(opts: Opts) {
   return buf
 }
 
-BN.prototype.toSMBigEndian = function() {
+BN.prototype.toSMBigEndian = function () {
   let buf: Buffer
   if (this.cmp(BN.Zero) === -1) {
     buf = this.neg().toBuffer()
@@ -118,7 +118,7 @@ BN.prototype.toSMBigEndian = function() {
   return buf
 }
 
-BN.prototype.toSM = function(opts: Opts) {
+BN.prototype.toSM = function (opts: Opts) {
   const endian = opts.endian ?? 'big'
   let buf = this.toSMBigEndian()
 
@@ -136,7 +136,7 @@ BN.prototype.toSM = function(opts: Opts) {
  * 4 bytes. We copy that behavior here. A third argument, `size`, is provided to
  * extend the hard limit of 4 bytes, as some usages require more than 4 bytes.
  */
-BN.fromScriptNumBuffer = function(
+BN.fromScriptNumBuffer = function (
   buf: Buffer,
   fRequireMinimal: boolean,
   size?: number
@@ -164,7 +164,7 @@ BN.fromScriptNumBuffer = function(
     }
   }
   return BN.fromSM(buf, {
-    endian: 'little'
+    endian: 'little',
   })
 }
 
@@ -174,29 +174,29 @@ BN.fromScriptNumBuffer = function(
  * performing a numerical operation that results in an overflow to more than 4
  * bytes).
  */
-BN.prototype.toScriptNumBuffer = function() {
+BN.prototype.toScriptNumBuffer = function () {
   return this.toSM({
-    endian: 'little'
+    endian: 'little',
   })
 }
 
-BN.prototype.gt = function(b: BN) {
+BN.prototype.gt = function (b: BN) {
   return this.cmp(b) > 0
 }
 
-BN.prototype.gte = function(b: BN) {
+BN.prototype.gte = function (b: BN) {
   return this.cmp(b) >= 0
 }
 
-BN.prototype.lt = function(b: BN) {
+BN.prototype.lt = function (b: BN) {
   return this.cmp(b) < 0
 }
 
-BN.trim = function(buf: Buffer, natlen: number) {
+BN.trim = function (buf: Buffer, natlen: number) {
   return buf.slice(natlen - buf.length, buf.length)
 }
 
-BN.pad = function(buf: Buffer, natlen: number, size: number) {
+BN.pad = function (buf: Buffer, natlen: number, size: number) {
   const rbuf = Buffer.alloc(size)
   for (let i = 0; i < buf.length; i++) {
     rbuf[rbuf.length - 1 - i] = buf[buf.length - 1 - i]

--- a/src/common/utxobased/keymanager/bitcoincashUtils/cashAddress.ts
+++ b/src/common/utxobased/keymanager/bitcoincashUtils/cashAddress.ts
@@ -6,19 +6,19 @@ import { Buffer } from 'buffer'
 import { decode, encode } from './base32'
 import BN from './bn'
 
-export enum cashaddrPrefixEnum {
+export enum CashaddrPrefixEnum {
   mainnet = 'bitcoincash',
-  testnet = 'bitcoincashtestnet'
+  testnet = 'bitcoincashtestnet',
 }
 
-export enum cashaddrTypeEnum {
+export enum CashaddrTypeEnum {
   pubkeyhash = 'pubkeyhash',
-  scripthash = 'scripthash'
+  scripthash = 'scripthash',
 }
 
 export interface BitcoinCashScriptHash {
   scriptHash: Buffer
-  type: cashaddrTypeEnum
+  type: CashaddrTypeEnum
 }
 
 const GENERATOR = [
@@ -26,8 +26,8 @@ const GENERATOR = [
   0x79b76d99e2,
   0xf33e5fb3c4,
   0xae2eabe2a8,
-  0x1e4f43e470
-].map(x => new BN(x))
+  0x1e4f43e470,
+].map((x) => new BN(x))
 
 // returns a BN object, which is not typed yet. Logs as <BN: dc0f07f285>
 const polymod = (data: number[]): any => {
@@ -106,8 +106,8 @@ const prefixToArray = (prefix: any): number[] => {
 
 export const hashToCashAddress = (
   scriptHash: string,
-  type: cashaddrTypeEnum,
-  prefix: cashaddrPrefixEnum
+  type: CashaddrTypeEnum,
+  prefix: CashaddrPrefixEnum
 ): string => {
   // Not any, but a BN object
   function checksumToArray(checksum: any): number[] {
@@ -122,9 +122,9 @@ export const hashToCashAddress = (
 
   function getTypeBits(type: string): number {
     switch (type) {
-      case cashaddrTypeEnum.pubkeyhash:
+      case CashaddrTypeEnum.pubkeyhash:
         return 0
-      case cashaddrTypeEnum.scripthash:
+      case CashaddrTypeEnum.scripthash:
         return 8
       default:
         throw new Error('Invalid type:' + type)
@@ -234,7 +234,7 @@ export const cashAddressToHash = (address: string): BitcoinCashScriptHash => {
       throw new Error(`InvalidArgument: ${address} has invalid checksum`)
     }
   } else {
-    const netNames = Object.values(cashaddrPrefixEnum)
+    const netNames = Object.values(CashaddrPrefixEnum)
     let i = netNames.shift()
     while (prefix === null && typeof i !== 'undefined') {
       const p = i
@@ -260,12 +260,12 @@ export const cashAddressToHash = (address: string): BitcoinCashScriptHash => {
     throw new Error(`InvalidArgument: ${address} has invalid hash size`)
   }
 
-  function getType(versionByte: number): cashaddrTypeEnum {
+  function getType(versionByte: number): CashaddrTypeEnum {
     switch (versionByte & 120) {
       case 0:
-        return cashaddrTypeEnum.pubkeyhash
+        return CashaddrTypeEnum.pubkeyhash
       case 8:
-        return cashaddrTypeEnum.scripthash
+        return CashaddrTypeEnum.scripthash
       default:
         throw new Error(
           'Invalid address type in version byte: ' + versionByte.toString()
@@ -276,7 +276,7 @@ export const cashAddressToHash = (address: string): BitcoinCashScriptHash => {
   const type = getType(versionByte)
   const info: BitcoinCashScriptHash = {
     scriptHash: Buffer.from(hash),
-    type: type
+    type: type,
   }
   return info
 }

--- a/src/common/utxobased/keymanager/bitcoincashUtils/checkdatasig.ts
+++ b/src/common/utxobased/keymanager/bitcoincashUtils/checkdatasig.ts
@@ -1,0 +1,45 @@
+const OP_CHECKDATASIGVERIFY = 'bb'
+const OP_CHECKDATASIG = 'ba'
+const OP_CHECKSIG = 'ac'
+const CDS_SIGNATURE =
+  '30440220256c12175e809381f97637933ed6ab97737d263eaaebca6add21bced67fd12a402205ce29ecc1369d6fc1b51977ed38faaf41119e3be1d7edfafd7cfaf0b6061bd07'
+const CDS_MESSAGE = ''
+const CDS_PUBKEY =
+  '038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508'
+
+const hexToVarByte = (hex: string): string => {
+  const len = hex.length / 2
+  const str = len.toString(16)
+  const hexLen = str.length % 2 === 0 ? str : `0${str}`
+  return hexLen + hex
+}
+
+const cds = (
+  cdsSigs: string,
+  cdsMsg: string,
+  cdsPubKey: string,
+  pubKey: string
+): string[] => {
+  const cdsSuffix = `${hexToVarByte(pubKey)}${OP_CHECKSIG}`
+  const cdsPrefix = `${hexToVarByte(cdsSigs)}${hexToVarByte(
+    cdsMsg
+  )}${hexToVarByte(cdsPubKey)}`
+  return [cdsPrefix, cdsSuffix]
+}
+
+export const cdsScriptTemplates = {
+  replayProtection: (pubKey: string) =>
+    cds(CDS_SIGNATURE, CDS_MESSAGE, CDS_PUBKEY, pubKey).join(
+      OP_CHECKDATASIGVERIFY
+    ),
+  checkdatasig: (pubKey: any) => (
+    cdsSig: string = '',
+    cdsMsg: string = '',
+    cdsPubKey: string = ''
+  ) => cds(cdsSig, cdsMsg, cdsPubKey, pubKey).join(OP_CHECKDATASIG),
+  checkdatasigverify: (pubKey: any) => (
+    cdsSig: string = '',
+    cdsMsg: string = '',
+    cdsPubKey: string = ''
+  ) => cds(cdsSig, cdsMsg, cdsPubKey, pubKey).join(OP_CHECKDATASIGVERIFY),
+}

--- a/src/common/utxobased/keymanager/coin.ts
+++ b/src/common/utxobased/keymanager/coin.ts
@@ -19,6 +19,9 @@ export interface Coin {
   coinType: number
   sighash?: number
   sighashFunction?: (Hash: Buffer) => Buffer
+  bs58DecodeFunc?: (payload: string | undefined) => Buffer
+  bs58EncodeFunc?: (payload: any) => string
+  wifEncodeFunc?: (prefix: any, key: any, compressed: any) => string
   mainnetConstants: CoinPrefixes
   testnetConstants: CoinPrefixes
 }

--- a/src/common/utxobased/keymanager/coin.ts
+++ b/src/common/utxobased/keymanager/coin.ts
@@ -16,6 +16,9 @@ export interface CoinPrefixes {
 export interface Coin {
   name: string
   segwit: boolean
+  coinType: number
+  sighash?: number
+  sighashFunction?: (Hash: Buffer) => Buffer
   mainnetConstants: CoinPrefixes
   testnetConstants: CoinPrefixes
 }

--- a/src/common/utxobased/keymanager/coinmapper.ts
+++ b/src/common/utxobased/keymanager/coinmapper.ts
@@ -41,12 +41,12 @@ const coinClasses: Coin[] = [
   new Uniformfiscalobject(),
   new Vertcoin(),
   new Zcoin(),
-  new ZCash()
+  new ZCash(),
 ]
 
 export function getCoinFromString(coinName: string): Coin {
   const selectedCoin: Coin | undefined = coinClasses.find(
-    coin => coin.name === coinName
+    (coin) => coin.name === coinName
   )
   if (typeof selectedCoin === 'undefined') {
     throw new Error('Could not find coin ' + coinName)

--- a/src/common/utxobased/keymanager/coinmapper.ts
+++ b/src/common/utxobased/keymanager/coinmapper.ts
@@ -20,7 +20,7 @@ import { Vertcoin } from './coins/vertcoin'
 import { ZCash } from './coins/zcash'
 import { Zcoin } from './coins/zcoin'
 
-const coinClasses: Coin[] = [
+export const coinClasses: Coin[] = [
   new Litecoin(),
   new Bitcoin(),
   new BitcoinCash(),

--- a/src/common/utxobased/keymanager/coins/badcoin.ts
+++ b/src/common/utxobased/keymanager/coins/badcoin.ts
@@ -3,13 +3,14 @@ import { Coin } from '../coin'
 export class Badcoin implements Coin {
   name = 'badcoin'
   segwit = false
+  coinType = 324
   mainnetConstants = {
     messagePrefix: '\x18Badcoin Signed Message:\n',
     wif: 0xb0,
     legacyXPriv: 0x06c4abc9,
     legacyXPub: 0x06c4abc8,
     pubkeyHash: 0x1c,
-    scriptHash: 0x19
+    scriptHash: 0x19,
   }
 
   testnetConstants = {
@@ -18,6 +19,6 @@ export class Badcoin implements Coin {
     legacyXPriv: 0x04358394,
     legacyXPub: 0x043587cf,
     pubkeyHash: 0x6f,
-    scriptHash: 0xc4
+    scriptHash: 0xc4,
   }
 }

--- a/src/common/utxobased/keymanager/coins/bitcoin.ts
+++ b/src/common/utxobased/keymanager/coins/bitcoin.ts
@@ -3,6 +3,8 @@ import { Coin } from '../coin'
 export class Bitcoin implements Coin {
   name = 'bitcoin'
   segwit = true
+  coinType = 0
+
   mainnetConstants = {
     messagePrefix: '\x1Bitcoin Signed Message:\n',
     wif: 0x80,
@@ -14,7 +16,7 @@ export class Bitcoin implements Coin {
     segwitXPub: 0x04b24746,
     pubkeyHash: 0x00,
     scriptHash: 0x05,
-    bech32: 'bc'
+    bech32: 'bc',
   }
 
   testnetConstants = {
@@ -28,6 +30,6 @@ export class Bitcoin implements Coin {
     segwitXPub: 0x045f1cf6,
     pubkeyHash: 0x6f,
     scriptHash: 0xc4,
-    bech32: 'tb'
+    bech32: 'tb',
   }
 }

--- a/src/common/utxobased/keymanager/coins/bitcoincash.ts
+++ b/src/common/utxobased/keymanager/coins/bitcoincash.ts
@@ -1,8 +1,13 @@
+import * as bitcoin from 'bitcoinforksjs-lib'
+
 import { Coin } from '../coin'
 
 export class BitcoinCash implements Coin {
   name = 'bitcoincash'
   segwit = false
+  sighash = bitcoin.Psbt.BCH_SIGHASH_ALL
+  coinType = 145
+
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0x80,
@@ -10,7 +15,7 @@ export class BitcoinCash implements Coin {
     legacyXPub: 0x0488b21e,
     pubkeyHash: 0x00,
     scriptHash: 0x05,
-    cashaddr: 'bitcoincash'
+    cashaddr: 'bitcoincash',
   }
 
   testnetConstants = {
@@ -20,6 +25,6 @@ export class BitcoinCash implements Coin {
     legacyXPub: 0x043587cf,
     pubkeyHash: 0x6f,
     scriptHash: 0xc4,
-    cashaddr: 'bitcoincashtestnet'
+    cashaddr: 'bitcoincashtestnet',
   }
 }

--- a/src/common/utxobased/keymanager/coins/bitcoingold.ts
+++ b/src/common/utxobased/keymanager/coins/bitcoingold.ts
@@ -1,8 +1,13 @@
+import * as bitcoin from 'bitcoinforksjs-lib'
+
 import { Coin } from '../coin'
 
 export class Bitcoingold implements Coin {
   name = 'bitcoingold'
   segwit = true
+  sighash = bitcoin.Psbt.BTG_SIGHASH_ALL
+  coinType = 156
+
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Gold Signed Message:\n',
     wif: 0x80,
@@ -14,7 +19,7 @@ export class Bitcoingold implements Coin {
     segwitXPub: 0x04b24746,
     pubkeyHash: 0x26,
     scriptHash: 0x17,
-    bech32: 'btg'
+    bech32: 'btg',
   }
 
   testnetConstants = {
@@ -28,6 +33,6 @@ export class Bitcoingold implements Coin {
     segwitXPub: 0x045f1cf6,
     pubkeyHash: 0x6f,
     scriptHash: 0xc4,
-    bech32: 'btg'
+    bech32: 'btg',
   }
 }

--- a/src/common/utxobased/keymanager/coins/bitcoinsv.ts
+++ b/src/common/utxobased/keymanager/coins/bitcoinsv.ts
@@ -3,13 +3,15 @@ import { Coin } from '../coin'
 export class BitcoinSV implements Coin {
   name = 'bitcoinsv'
   segwit = false
+  coinType = 236
+
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0x80,
     legacyXPriv: 0x0488ade4,
     legacyXPub: 0x0488b21e,
     pubkeyHash: 0x00,
-    scriptHash: 0x05
+    scriptHash: 0x05,
   }
 
   testnetConstants = {
@@ -18,6 +20,6 @@ export class BitcoinSV implements Coin {
     legacyXPriv: 0x04358394,
     legacyXPub: 0x043587cf,
     pubkeyHash: 0x6f,
-    scriptHash: 0xc4
+    scriptHash: 0xc4,
   }
 }

--- a/src/common/utxobased/keymanager/coins/dash.ts
+++ b/src/common/utxobased/keymanager/coins/dash.ts
@@ -3,13 +3,14 @@ import { Coin } from '../coin'
 export class Dash implements Coin {
   name = 'dash'
   segwit = false
+  coinType = 5
   mainnetConstants = {
     messagePrefix: 'unused',
     wif: 0xcc,
     legacyXPriv: 0x02fe52f8,
     legacyXPub: 0x02fe52cc,
     pubkeyHash: 0x4c,
-    scriptHash: 0x10
+    scriptHash: 0x10,
   }
 
   testnetConstants = {
@@ -18,6 +19,6 @@ export class Dash implements Coin {
     legacyXPriv: 0x04358394,
     legacyXPub: 0x043587cf,
     pubkeyHash: 0x6f,
-    scriptHash: 0xc4
+    scriptHash: 0xc4,
   }
 }

--- a/src/common/utxobased/keymanager/coins/decred.ts
+++ b/src/common/utxobased/keymanager/coins/decred.ts
@@ -1,9 +1,14 @@
+import * as cryptob from 'crypto-browserify'
+
+import * as base58 from '../base'
 import { Coin } from '../coin'
 
 export class Decred implements Coin {
   name = 'decred'
   segwit = true
   coinType = 42
+  bs58DecodeFunc = base58.base58Base(doubleblake256).decode
+  bs58EncodeFunc = base58.base58Base(doubleblake256).encode
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0x22de,
@@ -31,4 +36,12 @@ export class Decred implements Coin {
     scriptHash: 0x0efc,
     bech32: 'tb',
   }
+}
+
+function doubleblake256(buffer: Buffer): Buffer {
+  return blake256(blake256(buffer))
+}
+
+function blake256(buffer: Buffer): Buffer {
+  return cryptob.createHash('blake256').update(buffer).digest()
 }

--- a/src/common/utxobased/keymanager/coins/decred.ts
+++ b/src/common/utxobased/keymanager/coins/decred.ts
@@ -5,8 +5,9 @@ import { Coin } from '../coin'
 
 export class Decred implements Coin {
   name = 'decred'
-  segwit = true
+  segwit = false
   coinType = 42
+  sighashFunction = blake256
   bs58DecodeFunc = base58.base58Base(doubleblake256).decode
   bs58EncodeFunc = base58.base58Base(doubleblake256).encode
   mainnetConstants = {
@@ -14,13 +15,8 @@ export class Decred implements Coin {
     wif: 0x22de,
     legacyXPriv: 0x02fda4e8,
     legacyXPub: 0x02fda926,
-    wrappedSegwitXPriv: 0x049d7878,
-    wrappedSegwitXPub: 0x049d7cb2,
-    segwitXPriv: 0x04b2430c,
-    segwitXPub: 0x04b24746,
     pubkeyHash: 0x073f,
     scriptHash: 0x071a,
-    bech32: 'bc',
   }
 
   testnetConstants = {
@@ -28,13 +24,8 @@ export class Decred implements Coin {
     wif: 0x230e,
     legacyXPriv: 0x04358394,
     legacyXPub: 0x043587cf,
-    wrappedSegwitXPriv: 0x044a4e28,
-    wrappedSegwitXPub: 0x044a5262,
-    segwitXPriv: 0x045f18bc,
-    segwitXPub: 0x045f1cf6,
     pubkeyHash: 0x0f21,
     scriptHash: 0x0efc,
-    bech32: 'tb',
   }
 }
 

--- a/src/common/utxobased/keymanager/coins/decred.ts
+++ b/src/common/utxobased/keymanager/coins/decred.ts
@@ -3,6 +3,7 @@ import { Coin } from '../coin'
 export class Decred implements Coin {
   name = 'decred'
   segwit = true
+  coinType = 42
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0x22de,
@@ -14,7 +15,7 @@ export class Decred implements Coin {
     segwitXPub: 0x04b24746,
     pubkeyHash: 0x073f,
     scriptHash: 0x071a,
-    bech32: 'bc'
+    bech32: 'bc',
   }
 
   testnetConstants = {
@@ -28,6 +29,6 @@ export class Decred implements Coin {
     segwitXPub: 0x045f1cf6,
     pubkeyHash: 0x0f21,
     scriptHash: 0x0efc,
-    bech32: 'tb'
+    bech32: 'tb',
   }
 }

--- a/src/common/utxobased/keymanager/coins/digibyte.ts
+++ b/src/common/utxobased/keymanager/coins/digibyte.ts
@@ -3,6 +3,7 @@ import { Coin } from '../coin'
 export class Digibyte implements Coin {
   name = 'digibyte'
   segwit = true
+  coinType = 20
   mainnetConstants = {
     messagePrefix: '\x18Digibyte Signed Message:\n',
     wif: 0x80,
@@ -14,7 +15,7 @@ export class Digibyte implements Coin {
     segwitXPub: 0x04b24746,
     pubkeyHash: 0x1e,
     scriptHash: 0x3f,
-    bech32: 'dgb'
+    bech32: 'dgb',
   }
 
   testnetConstants = {
@@ -28,6 +29,6 @@ export class Digibyte implements Coin {
     segwitXPub: 0x045f1cf6,
     pubkeyHash: 0x6f,
     scriptHash: 0xc4,
-    bech32: 'tb'
+    bech32: 'tb',
   }
 }

--- a/src/common/utxobased/keymanager/coins/dogecoin.ts
+++ b/src/common/utxobased/keymanager/coins/dogecoin.ts
@@ -3,13 +3,14 @@ import { Coin } from '../coin'
 export class Dogecoin implements Coin {
   name = 'dogecoin'
   segwit = false
+  coinType = 3
   mainnetConstants = {
     messagePrefix: '\x18Dogecoin Signed Message:\n',
     wif: 0x9e,
     legacyXPriv: 0x02fac398,
     legacyXPub: 0x02facafd,
     pubkeyHash: 0x1e,
-    scriptHash: 0x16
+    scriptHash: 0x16,
   }
 
   testnetConstants = {
@@ -18,6 +19,6 @@ export class Dogecoin implements Coin {
     legacyXPriv: 0x04358394,
     legacyXPub: 0x043587cf,
     pubkeyHash: 0x6f,
-    scriptHash: 0xc4
+    scriptHash: 0xc4,
   }
 }

--- a/src/common/utxobased/keymanager/coins/eboost.ts
+++ b/src/common/utxobased/keymanager/coins/eboost.ts
@@ -5,11 +5,11 @@ export class EBoost implements Coin {
   segwit = false
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
-    wif: 0xb0,
+    wif: 0xdc,
     legacyXPriv: 0x0488ade4,
     legacyXPub: 0x0488b21e,
     pubkeyHash: 0x5c,
-    scriptHash: 0x05
+    scriptHash: 0x05,
   }
 
   testnetConstants = {
@@ -19,6 +19,6 @@ export class EBoost implements Coin {
     legacyXPub: 0x043587cf,
 
     pubkeyHash: 0x6f,
-    scriptHash: 0xc4
+    scriptHash: 0xc4,
   }
 }

--- a/src/common/utxobased/keymanager/coins/eboost.ts
+++ b/src/common/utxobased/keymanager/coins/eboost.ts
@@ -3,6 +3,7 @@ import { Coin } from '../coin'
 export class EBoost implements Coin {
   name = 'eboost'
   segwit = false
+  coinType = 324
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0xdc,

--- a/src/common/utxobased/keymanager/coins/feathercoin.ts
+++ b/src/common/utxobased/keymanager/coins/feathercoin.ts
@@ -3,6 +3,7 @@ import { Coin } from '../coin'
 export class Feathercoin implements Coin {
   name = 'feathercoin'
   segwit = true
+  coinType = 8
   mainnetConstants = {
     messagePrefix: '\x18Feathercoin Signed Message:\n',
     wif: 0x8e,
@@ -14,7 +15,7 @@ export class Feathercoin implements Coin {
     segwitXPub: 0x04b24746,
     pubkeyHash: 0x0e,
     scriptHash: 0x05,
-    bech32: 'fc'
+    bech32: 'fc',
   }
 
   testnetConstants = {
@@ -28,6 +29,6 @@ export class Feathercoin implements Coin {
     segwitXPub: 0x045f1cf6,
     pubkeyHash: 0x6f,
     scriptHash: 0xc4,
-    bech32: 'tb'
+    bech32: 'tb',
   }
 }

--- a/src/common/utxobased/keymanager/coins/groestlcoin.ts
+++ b/src/common/utxobased/keymanager/coins/groestlcoin.ts
@@ -1,10 +1,14 @@
+import { crypto } from 'bitcoinforksjs-lib'
+
 import { Coin } from '../coin'
 
 export class Groestlcoin implements Coin {
   name = 'groestlcoin'
   segwit = true
+  coinType = 17
+  sighashFunction = crypto.sha256
   mainnetConstants = {
-    messagePrefix: '\x19Groestlcoin Signed Message:\n',
+    messagePrefix: '\x1cGroestlCoin Signed Message:\n',
     wif: 0x80,
     legacyXPriv: 0x0488ade4,
     legacyXPub: 0x0488b21e,
@@ -18,7 +22,7 @@ export class Groestlcoin implements Coin {
   }
 
   testnetConstants = {
-    messagePrefix: '\x19Groestlcoin Signed Message:\n',
+    messagePrefix: '\x1cGroestlCoin Signed Message:\n',
     wif: 0xef,
     legacyXPriv: 0x04358394,
     legacyXPub: 0x043587cf,

--- a/src/common/utxobased/keymanager/coins/groestlcoin.ts
+++ b/src/common/utxobased/keymanager/coins/groestlcoin.ts
@@ -1,4 +1,6 @@
 import { crypto } from 'bitcoinforksjs-lib'
+import * as base58grs from 'bs58grscheck'
+import * as wifgrs from 'wifgrs'
 
 import { Coin } from '../coin'
 
@@ -7,6 +9,9 @@ export class Groestlcoin implements Coin {
   segwit = true
   coinType = 17
   sighashFunction = crypto.sha256
+  bs58DecodeFunc = base58grs.decode
+  bs58EncodeFunc = base58grs.encode
+  wifEncodeFunc = wifgrs.encode
   mainnetConstants = {
     messagePrefix: '\x1cGroestlCoin Signed Message:\n',
     wif: 0x80,

--- a/src/common/utxobased/keymanager/coins/groestlcoin.ts
+++ b/src/common/utxobased/keymanager/coins/groestlcoin.ts
@@ -14,7 +14,7 @@ export class Groestlcoin implements Coin {
     segwitXPub: 0x04b24746,
     pubkeyHash: 0x24,
     scriptHash: 0x05,
-    bech32: 'grs'
+    bech32: 'grs',
   }
 
   testnetConstants = {
@@ -28,6 +28,6 @@ export class Groestlcoin implements Coin {
     segwitXPub: 0x045f1cf6,
     pubkeyHash: 0x6f,
     scriptHash: 0xc4,
-    bech32: 'tb'
+    bech32: 'tb',
   }
 }

--- a/src/common/utxobased/keymanager/coins/litecoin.ts
+++ b/src/common/utxobased/keymanager/coins/litecoin.ts
@@ -3,6 +3,7 @@ import { Coin } from '../coin'
 export class Litecoin implements Coin {
   name = 'litecoin'
   segwit = true
+  coinType = 2
   mainnetConstants = {
     messagePrefix: '\x19Litecoin Signed Message:\n',
     wif: 0xb0,
@@ -14,7 +15,7 @@ export class Litecoin implements Coin {
     segwitXPub: 0x04b24746,
     pubkeyHash: 0x30,
     scriptHash: 0x32,
-    bech32: 'ltc'
+    bech32: 'ltc',
   }
 
   testnetConstants = {
@@ -28,6 +29,6 @@ export class Litecoin implements Coin {
     segwitXPub: 0x045f1cf6,
     pubkeyHash: 0x6f,
     scriptHash: 0x3a,
-    bech32: 'tltc'
+    bech32: 'tltc',
   }
 }

--- a/src/common/utxobased/keymanager/coins/qtum.ts
+++ b/src/common/utxobased/keymanager/coins/qtum.ts
@@ -3,13 +3,14 @@ import { Coin } from '../coin'
 export class Qtum implements Coin {
   name = 'qtum'
   segwit = false
+  coinType = 2301
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0x80,
     legacyXPriv: 0x0488ade4,
     legacyXPub: 0x0488b21e,
     pubkeyHash: 0x3a,
-    scriptHash: 0x32
+    scriptHash: 0x32,
   }
 
   testnetConstants = {
@@ -18,6 +19,6 @@ export class Qtum implements Coin {
     legacyXPriv: 0x04358394,
     legacyXPub: 0x043587cf,
     pubkeyHash: 0x6f,
-    scriptHash: 0xc4
+    scriptHash: 0xc4,
   }
 }

--- a/src/common/utxobased/keymanager/coins/ravencoin.ts
+++ b/src/common/utxobased/keymanager/coins/ravencoin.ts
@@ -3,6 +3,7 @@ import { Coin } from '../coin'
 export class Ravencoin implements Coin {
   name = 'ravencoin'
   segwit = false
+  coinType = 175
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0x80,
@@ -10,7 +11,7 @@ export class Ravencoin implements Coin {
     legacyXPub: 0x0488b21e,
     pubkeyHash: 0x3c,
     scriptHash: 0x7a,
-    bech32: 'bc'
+    bech32: 'bc',
   }
 
   testnetConstants = {
@@ -19,6 +20,6 @@ export class Ravencoin implements Coin {
     legacyXPriv: 0x04358394,
     legacyXPub: 0x043587cf,
     pubkeyHash: 0x6f,
-    scriptHash: 0xc4
+    scriptHash: 0xc4,
   }
 }

--- a/src/common/utxobased/keymanager/coins/smartcash.ts
+++ b/src/common/utxobased/keymanager/coins/smartcash.ts
@@ -1,12 +1,20 @@
+import { crypto } from 'bitcoinforksjs-lib'
+import * as base58smart from 'bs58smartcheck'
+import * as wifsmart from 'wif-smart'
+
 import { Coin } from '../coin'
 
 export class Smartcash implements Coin {
   name = 'smartcash'
   segwit = false
   coinType = 224
+  sighashFunction = crypto.sha256
+  bs58DecodeFunc = base58smart.decode
+  bs58EncodeFunc = base58smart.encode
+  wifEncodeFunc = wifsmart.encode
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
-    wif: 0x80,
+    wif: 0xbf,
     legacyXPriv: 0x0488ade4,
     legacyXPub: 0x0488b21e,
     pubkeyHash: 0x3f,

--- a/src/common/utxobased/keymanager/coins/smartcash.ts
+++ b/src/common/utxobased/keymanager/coins/smartcash.ts
@@ -3,13 +3,14 @@ import { Coin } from '../coin'
 export class Smartcash implements Coin {
   name = 'smartcash'
   segwit = false
+  coinType = 224
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0x80,
     legacyXPriv: 0x0488ade4,
     legacyXPub: 0x0488b21e,
     pubkeyHash: 0x3f,
-    scriptHash: 0x12
+    scriptHash: 0x12,
   }
 
   testnetConstants = {
@@ -18,6 +19,6 @@ export class Smartcash implements Coin {
     legacyXPriv: 0x04358394,
     legacyXPub: 0x043587cf,
     pubkeyHash: 0x6f,
-    scriptHash: 0xc4
+    scriptHash: 0xc4,
   }
 }

--- a/src/common/utxobased/keymanager/coins/ufo.ts
+++ b/src/common/utxobased/keymanager/coins/ufo.ts
@@ -3,6 +3,7 @@ import { Coin } from '../coin'
 export class Uniformfiscalobject implements Coin {
   name = 'uniformfiscalobject'
   segwit = true
+  coinType = 202
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0x9b,

--- a/src/common/utxobased/keymanager/coins/ufo.ts
+++ b/src/common/utxobased/keymanager/coins/ufo.ts
@@ -14,7 +14,7 @@ export class Uniformfiscalobject implements Coin {
     segwitXPub: 0x04b24746,
     pubkeyHash: 0x1b,
     scriptHash: 0x44,
-    bech32: 'uf'
+    bech32: 'uf',
   }
 
   testnetConstants = {
@@ -28,6 +28,6 @@ export class Uniformfiscalobject implements Coin {
     segwitXPub: 0x045f1cf6,
     pubkeyHash: 0x6f,
     scriptHash: 0xc4,
-    bech32: 'tb'
+    bech32: 'tb',
   }
 }

--- a/src/common/utxobased/keymanager/coins/vertcoin.ts
+++ b/src/common/utxobased/keymanager/coins/vertcoin.ts
@@ -3,6 +3,7 @@ import { Coin } from '../coin'
 export class Vertcoin implements Coin {
   name = 'vertcoin'
   segwit = true
+  coinType = 28
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0x80,
@@ -14,7 +15,7 @@ export class Vertcoin implements Coin {
     segwitXPub: 0x0488b21e,
     pubkeyHash: 0x47,
     scriptHash: 0x05,
-    bech32: 'vtc'
+    bech32: 'vtc',
   }
 
   testnetConstants = {
@@ -28,6 +29,6 @@ export class Vertcoin implements Coin {
     segwitXPub: 0x045f1cf6,
     pubkeyHash: 0x6f,
     scriptHash: 0xc4,
-    bech32: 'tb'
+    bech32: 'tb',
   }
 }

--- a/src/common/utxobased/keymanager/coins/zcash.ts
+++ b/src/common/utxobased/keymanager/coins/zcash.ts
@@ -3,13 +3,14 @@ import { Coin } from '../coin'
 export class ZCash implements Coin {
   name = 'zcash'
   segwit = false
+  coinType = 133
   mainnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0x80,
     legacyXPriv: 0x0488ade4,
     legacyXPub: 0x0488b21e,
     pubkeyHash: 0x1cb8,
-    scriptHash: 0x1cbd
+    scriptHash: 0x1cbd,
   }
 
   testnetConstants = {
@@ -18,6 +19,6 @@ export class ZCash implements Coin {
     legacyXPriv: 0x04358394,
     legacyXPub: 0x043587cf,
     pubkeyHash: 0xef,
-    scriptHash: 0x1d25
+    scriptHash: 0x1d25,
   }
 }

--- a/src/common/utxobased/keymanager/coins/zcoin.ts
+++ b/src/common/utxobased/keymanager/coins/zcoin.ts
@@ -3,13 +3,14 @@ import { Coin } from '../coin'
 export class Zcoin implements Coin {
   name = 'zcoin'
   segwit = false
+  coinType = 136
   mainnetConstants = {
     messagePrefix: '\x18Zcoin Signed Message:\n',
     wif: 0xd2,
     legacyXPriv: 0x0488ade4,
     legacyXPub: 0x0488b21e,
     pubkeyHash: 0x52,
-    scriptHash: 0x7
+    scriptHash: 0x7,
   }
 
   testnetConstants = {
@@ -18,6 +19,6 @@ export class Zcoin implements Coin {
     legacyXPriv: 0x04358394,
     legacyXPub: 0x043587cf,
     pubkeyHash: 0x6f,
-    scriptHash: 0xc4
+    scriptHash: 0xc4,
   }
 }

--- a/src/common/utxobased/keymanager/declarations/base58grscheck.d.ts
+++ b/src/common/utxobased/keymanager/declarations/base58grscheck.d.ts
@@ -1,0 +1,1 @@
+declare module 'bs58grscheck'

--- a/src/common/utxobased/keymanager/declarations/bn.d.ts
+++ b/src/common/utxobased/keymanager/declarations/bn.d.ts
@@ -1,0 +1,1 @@
+declare module 'bn.js'

--- a/src/common/utxobased/keymanager/declarations/bs58.d.ts
+++ b/src/common/utxobased/keymanager/declarations/bs58.d.ts
@@ -1,0 +1,1 @@
+declare module 'bs58'

--- a/src/common/utxobased/keymanager/declarations/bs58smartcheck.d.ts
+++ b/src/common/utxobased/keymanager/declarations/bs58smartcheck.d.ts
@@ -1,0 +1,1 @@
+declare module 'bs58smartcheck'

--- a/src/common/utxobased/keymanager/declarations/crypto-browserify.d.ts
+++ b/src/common/utxobased/keymanager/declarations/crypto-browserify.d.ts
@@ -1,0 +1,1 @@
+declare module 'crypto-browserify'

--- a/src/common/utxobased/keymanager/declarations/wif-smart.d.ts
+++ b/src/common/utxobased/keymanager/declarations/wif-smart.d.ts
@@ -1,0 +1,1 @@
+declare module 'wif-smart'

--- a/src/common/utxobased/keymanager/declarations/wifgrs.d.ts
+++ b/src/common/utxobased/keymanager/declarations/wifgrs.d.ts
@@ -1,0 +1,1 @@
+declare module 'wifgrs'

--- a/test/bitcoincashkeymanager-test.ts
+++ b/test/bitcoincashkeymanager-test.ts
@@ -12,7 +12,7 @@ import {
   scriptPubkeyToAddress,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('bitcoin cash mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +24,7 @@ describe('bitcoin cash mnemonic to xprv test vectors as compared with iancoleman
       path: "m/44'/145'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(resultLegacy).to.equal(
       'xprv9xywTsqYa9uDLdJs8QpXf7xwRWgPw4rq5FtkcShsDoZTqfNQjVQ3dDCdyedXX3FqB18U8e8PfVMeFqkhzPGseKVMDjGe5rPdiUXMxy7BQNJ'
@@ -37,7 +37,7 @@ describe('bitcoin cash mnemonic to xprv test vectors as compared with iancoleman
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +52,7 @@ describe('bitcoin cash bip32 prefix tests for the conversion from xpriv to xpub'
         'xprv9xywTsqYa9uDLdJs8QpXf7xwRWgPw4rq5FtkcShsDoZTqfNQjVQ3dDCdyedXX3FqB18U8e8PfVMeFqkhzPGseKVMDjGe5rPdiUXMxy7BQNJ',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(resultLegacy).to.equals(
       'xpub6ByHsPNSQXTWZ7PLESMY2FufyYWtLXagSUpMQq7Un96SiThZH2iJB1X7pwviH1WtKVeDP6K8d6xxFzzoaFzF3s8BKCZx8oEDdDkNnp4owAZ'
@@ -65,7 +65,7 @@ describe('bitcoin cash bip32 prefix tests for the conversion from xpriv to xpub'
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,17 +87,17 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.cashaddrP2PKH
+      addressType: AddressTypeEnum.cashaddrP2PKH,
     }).scriptPubkey
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.cashaddrP2PKH,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(p2pkhAddress).to.equals(
       'bitcoincash:qqyx49mu0kkn9ftfj6hje6g2wfer34yfnq5tahq3q6'
@@ -106,7 +106,7 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
       address: 'bitcoincash:qqyx49mu0kkn9ftfj6hje6g2wfer34yfnq5tahq3q6',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.cashaddrP2PKH,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -119,17 +119,17 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.cashaddrP2PKH
+      addressType: AddressTypeEnum.cashaddrP2PKH,
     }).scriptPubkey
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Testnet,
       addressType: AddressTypeEnum.cashaddrP2PKH,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(p2pkhAddress).to.equals(
       'bitcoincashtestnet:qqaz6s295ncfs53m86qj0uw6sl8u2kuw0yjdsvk7h8'
@@ -138,7 +138,7 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
       address: 'bitcoincashtestnet:qqaz6s295ncfs53m86qj0uw6sl8u2kuw0yjdsvk7h8',
       network: NetworkEnum.Testnet,
       addressType: AddressTypeEnum.cashaddrP2PKH,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -150,12 +150,12 @@ describe('bitcoin cash from WIF to private key buffer to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -168,7 +168,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
       address: 'bitcoincash:qr9q6dsyfcxupz3zwf805mm2q7cwcnre4g60ww9wd5',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.cashaddrP2PKH,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
       '76a914ca0d36044e0dc08a22724efa6f6a07b0ec4c79aa88ac'
@@ -179,7 +179,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
       address: 'bchtest:qrall9d5uddv4yvdyms4wwfw59jr5twzsvashd0fst',
       network: NetworkEnum.Testnet,
       addressType: AddressTypeEnum.cashaddrP2PKH,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
       '76a914fbff95b4e35aca918d26e157392ea1643a2dc28388ac'
@@ -190,7 +190,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
       address: 'bitcoincash:pz689gnx6z7cnsfhq6jpxtx0k9hhcwulev5cpumfk0',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.cashaddrP2SH,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
       'a914b472a266d0bd89c13706a4132ccfb16f7c3b9fcb87'
@@ -201,7 +201,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
       address: 'bchtest:pq2wfeuppegjpnrg64ws8vmv7e4fatwzwq9rvngx8x',
       network: NetworkEnum.Testnet,
       addressType: AddressTypeEnum.cashaddrP2SH,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
       'a91414e4e7810e5120cc68d55d03b36cf66a9eadc27087'
@@ -215,7 +215,7 @@ describe('bitcoin cash guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bitcoincash:qr9q6dsyfcxupz3zwf805mm2q7cwcnre4g60ww9wd5',
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
       '76a914ca0d36044e0dc08a22724efa6f6a07b0ec4c79aa88ac'
@@ -225,7 +225,7 @@ describe('bitcoin cash guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bchtest:qrall9d5uddv4yvdyms4wwfw59jr5twzsvashd0fst',
       network: NetworkEnum.Testnet,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
       '76a914fbff95b4e35aca918d26e157392ea1643a2dc28388ac'
@@ -235,7 +235,7 @@ describe('bitcoin cash guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bitcoincash:pz689gnx6z7cnsfhq6jpxtx0k9hhcwulev5cpumfk0',
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
       'a914b472a266d0bd89c13706a4132ccfb16f7c3b9fcb87'
@@ -245,7 +245,7 @@ describe('bitcoin cash guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bchtest:pq2wfeuppegjpnrg64ws8vmv7e4fatwzwq9rvngx8x',
       network: NetworkEnum.Testnet,
-      coin: 'bitcoincash'
+      coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
       'a91414e4e7810e5120cc68d55d03b36cf66a9eadc27087'

--- a/test/bitcoincashkeymanager-test.ts
+++ b/test/bitcoincashkeymanager-test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
+import { cdsScriptTemplates } from '../src/common/utxobased/keymanager/bitcoincashUtils/checkdatasig'
 import {
   addressToScriptPubkey,
   AddressTypeEnum,
@@ -12,6 +13,7 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  scriptPubkeyToP2SH,
   ScriptTypeEnum,
   signTx,
   TransactionInputTypeEnum,
@@ -324,7 +326,7 @@ describe('bitcoincash transaction creation and signing test', () => {
       ],
     }).psbt
     const hexTxSigned: string = signTx({
-      tx: base64Tx,
+      psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoincash',
     })
@@ -346,9 +348,10 @@ describe('bitcoincash replay protection transaction creation and signing test', 
     pubkey: privateKeyToPubkey(privateKey),
     scriptType: ScriptTypeEnum.p2pkh,
   }).scriptPubkey
-  const info = pubkeyToScriptPubkey({
-    pubkey: privateKeyToPubkey(privateKey),
-    scriptType: ScriptTypeEnum.replayProtectionP2SH,
+  const info = scriptPubkeyToP2SH({
+    scriptPubkey: cdsScriptTemplates.replayProtection(
+      privateKeyToPubkey(privateKey)
+    ),
   })
   const scriptPubkeyP2SH = info.scriptPubkey
   const redeemScript = info.redeemScript
@@ -403,7 +406,7 @@ describe('bitcoincash replay protection transaction creation and signing test', 
       ],
     }).psbt
     const hexTxSigned: string = signTx({
-      tx: base64Tx,
+      psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoincash',
     })

--- a/test/bitcoincashkeymanager-test.ts
+++ b/test/bitcoincashkeymanager-test.ts
@@ -5,11 +5,16 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
+  createTx,
   mnemonicToXPriv,
   NetworkEnum,
+  privateKeyToPubkey,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
+  signTx,
+  TransactionInputTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -91,7 +96,7 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.cashaddrP2PKH,
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
@@ -123,7 +128,7 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.cashaddrP2PKH,
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
@@ -249,6 +254,162 @@ describe('bitcoin cash guess script pubkeys from address', () => {
     })
     expect(scriptPubkey).to.equal(
       'a91414e4e7810e5120cc68d55d03b36cf66a9eadc27087'
+    )
+  })
+})
+
+describe('bitcoincash transaction creation and signing test', () => {
+  // key with control on the unspent output and used to sign the transaction
+  const wifKey = 'L2uPYXe17xSTqbCjZvL2DsyXPCbXspvcu5mHLDYUgzdUbZGSKrSr'
+  const privateKey = wifToPrivateKey({
+    wifKey,
+    network: NetworkEnum.Mainnet,
+    coin: 'bitcoin',
+  })
+  const scriptPubkey: string = pubkeyToScriptPubkey({
+    pubkey: privateKeyToPubkey(privateKey),
+    scriptType: ScriptTypeEnum.p2pkh,
+  }).scriptPubkey
+  const address: string = scriptPubkeyToAddress({
+    scriptPubkey: scriptPubkey,
+    network: NetworkEnum.Mainnet,
+    coin: 'bitcoin',
+    addressType: AddressTypeEnum.p2pkh,
+  })
+  it('Create transaction with one legacy input and one output', () => {
+    /*
+      This here is the rawtransaction as assembled below:
+      0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d9452e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48ca17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc5660209e761da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec631e5e1e66009ce3710ceea5b1ad13ffffffff01905f0100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000
+      The test case deconstructs the value, script pubkey and locktime values to show some deserialized values.
+      This deserialization is not required in the usual form from the caller.
+      It is enough to pass the full previous rawtransaction.
+    */
+    const base64Tx: string = createTx({
+      network: NetworkEnum.Mainnet,
+      coin: 'bitcoincash',
+      rbf: false,
+      inputs: [
+        {
+          type: TransactionInputTypeEnum.Legacy,
+          prevTxid:
+            '7d067b4a697a09d2c3cff7d4d9506c9955e93bff41bf82d439da7d030382bc3e',
+          // prev_tx only for non segwit inputs
+          prevTx:
+            '0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d9' +
+            '452e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48' +
+            'ca17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc566020' +
+            '9e761da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec' +
+            '631e5e1e66009ce3710ceea5b1ad13ffffffff01' +
+            // value in satoshis (Int64LE) = 0x015f90 = 90000
+            '905f010000000000' +
+            // scriptPubkey length
+            '19' +
+            // scriptPubkey
+            scriptPubkey +
+            // locktime
+            '00000000',
+          index: 0,
+        },
+      ],
+      outputs: [
+        {
+          scriptPubkey: addressToScriptPubkey({
+            address: address,
+            network: NetworkEnum.Mainnet,
+            addressType: AddressTypeEnum.p2pkh,
+            coin: 'bitcoin',
+          }),
+          amount: 80000,
+        },
+      ],
+    }).psbt
+    const hexTxSigned: string = signTx({
+      tx: base64Tx,
+      privateKeys: [privateKey],
+      coin: 'bitcoincash',
+    })
+    expect(hexTxSigned).to.equal(
+      '02000000013ebc8203037dda39d482bf41ff3be955996c50d9d4f7cfc3d2097a694a7b067d000000006a473044022041e30e01f06523646374a356a61238da09f67cfbb5017ff7df47be7c5d1fc1bf0220788ed258f1b6d9c2b28d49c10909cd2cf48f49139c1bb9fe6bfd102f9bf4e44141210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f455ffffffff0180380100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000'
+    )
+  })
+})
+
+describe('bitcoincash replay protection transaction creation and signing test', () => {
+  // key with control on the unspent output and used to sign the transaction
+  const wifKey = 'L2uPYXe17xSTqbCjZvL2DsyXPCbXspvcu5mHLDYUgzdUbZGSKrSr'
+  const privateKey = wifToPrivateKey({
+    wifKey,
+    network: NetworkEnum.Mainnet,
+    coin: 'bitcoin',
+  })
+  const scriptPubkey: string = pubkeyToScriptPubkey({
+    pubkey: privateKeyToPubkey(privateKey),
+    scriptType: ScriptTypeEnum.p2pkh,
+  }).scriptPubkey
+  const info = pubkeyToScriptPubkey({
+    pubkey: privateKeyToPubkey(privateKey),
+    scriptType: ScriptTypeEnum.replayProtectionP2SH,
+  })
+  const scriptPubkeyP2SH = info.scriptPubkey
+  const redeemScript = info.redeemScript
+  const address: string = scriptPubkeyToAddress({
+    scriptPubkey: scriptPubkey,
+    network: NetworkEnum.Mainnet,
+    coin: 'bitcoin',
+    addressType: AddressTypeEnum.p2pkh,
+  })
+  it('Create transaction with one legacy input and one output', () => {
+    /*
+      This here is the rawtransaction as assembled below:
+      0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d9452e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48ca17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc5660209e761da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec631e5e1e66009ce3710ceea5b1ad13ffffffff01905f0100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000
+      The test case deconstructs the value, script pubkey and locktime values to show some deserialized values.
+      This deserialization is not required in the usual form from the caller.
+      It is enough to pass the full previous rawtransaction.
+    */
+    console.log(Buffer.from(scriptPubkeyP2SH, 'hex').byteLength)
+    const base64Tx: string = createTx({
+      network: NetworkEnum.Mainnet,
+      coin: 'bitcoincash',
+      rbf: false,
+      inputs: [
+        {
+          type: TransactionInputTypeEnum.Legacy,
+          prevTxid:
+            'E69BED1EBB212A4C2116989D9A543EBC8BA11DD753B2D1F69A963D796EC0950C',
+          prevTx:
+            '0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d9' +
+            '452e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48' +
+            'ca17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc566020' +
+            '9e761da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec' +
+            '631e5e1e66009ce3710ceea5b1ad13ffffffff01' +
+            '905f010000000000' +
+            // psh scriptPubkey size
+            '17' +
+            scriptPubkeyP2SH +
+            '00000000',
+          index: 0,
+          redeemScript: redeemScript,
+        },
+      ],
+      outputs: [
+        {
+          scriptPubkey: addressToScriptPubkey({
+            address: address,
+            network: NetworkEnum.Mainnet,
+            addressType: AddressTypeEnum.p2pkh,
+            coin: 'bitcoin',
+          }),
+          amount: 80000,
+        },
+      ],
+    }).psbt
+    const hexTxSigned: string = signTx({
+      tx: base64Tx,
+      privateKeys: [privateKey],
+      coin: 'bitcoincash',
+    })
+    expect(hexTxSigned).to.equal(
+      '02000000010c95c06e793d969af6d1b253d71da18bbc3e549a9d9816214c2a21bb1eed9be600000000fa4730440220398da49dabcb8bde7b004d62b7a4f50e0c8b74e5f0f99ebb86ce2932ba3df05e02200ba98a43fa4f67f6252b04f586660ed934ee1ef2c3de6cca3ec3b407c93b095c41210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f4554c8e4630440220256c12175e809381f97637933ed6ab97737d263eaaebca6add21bced67fd12a402205ce29ecc1369d6fc1b51977ed38faaf41119e3be1d7edfafd7cfaf0b6061bd070021038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508bb210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f455acffffffff0180380100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000'
     )
   })
 })

--- a/test/bitcoincashkeymanager-test.ts
+++ b/test/bitcoincashkeymanager-test.ts
@@ -366,7 +366,6 @@ describe('bitcoincash replay protection transaction creation and signing test', 
       This deserialization is not required in the usual form from the caller.
       It is enough to pass the full previous rawtransaction.
     */
-    console.log(Buffer.from(scriptPubkeyP2SH, 'hex').byteLength)
     const base64Tx: string = createTx({
       network: NetworkEnum.Mainnet,
       coin: 'bitcoincash',

--- a/test/bitcoingoldkeymanager-test.ts
+++ b/test/bitcoingoldkeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('bitcoin gold mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +25,7 @@ describe('bitcoin gold mnemonic to xprv test vectors as compared with iancoleman
       path: "m/44'/156'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(resultLegacy).to.equal(
       'xprv9xwq8XoNMYibm1tgqx9MknBEhV2piDRtYrVLdbRFHaQiYc8Y3yxhWVBui2Pcw6GK1GjhMMsY9qnJAAFEW5QhvvQP8wCyBRMnnGCSADhBBY5'
@@ -37,7 +38,7 @@ describe('bitcoin gold mnemonic to xprv test vectors as compared with iancoleman
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +53,7 @@ describe('bitcoin gold bip32 prefix tests for the conversion from xpriv to xpub'
         'xprv9xwq8XoNMYibm1tgqx9MknBEhV2piDRtYrVLdbRFHaQiYc8Y3yxhWVBui2Pcw6GK1GjhMMsY9qnJAAFEW5QhvvQP8wCyBRMnnGCSADhBBY5',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(resultLegacy).to.equals(
       'xpub6BwBY3LGBvGtyVy9wygN7v7yFWsK7g9jv5QwRyprquwhRQTgbXGx4HWPZHRnF5ueji94Dztce4k3RJnt2ir3xWBS7y6bDk8ryS8vKXyoYPL'
@@ -65,7 +66,7 @@ describe('bitcoin gold bip32 prefix tests for the conversion from xpriv to xpub'
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,25 +88,25 @@ describe('bitcoin gold xpub to address tests;  generate valid addresses by calli
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(p2pkhAddress).to.equals('GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -118,24 +119,24 @@ describe('bitcoin gold xpub to address tests;  generate valid addresses by calli
       type: BIP43PurposeTypeEnum.WrappedSegwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKHP2SH,
-      addressType: AddressTypeEnum.p2wpkhp2sh
+      scriptType: ScriptTypeEnum.p2wpkhp2sh,
     }).scriptPubkey
     const p2wpkhp2shAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKHP2SH,
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'bitcoingold'
+      addressType: AddressTypeEnum.p2sh,
+      coin: 'bitcoingold',
     })
     expect(p2wpkhp2shAddress).to.equals('AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: 'AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'bitcoingold'
+      addressType: AddressTypeEnum.p2sh,
+      coin: 'bitcoingold',
     })
     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
   })
@@ -148,17 +149,17 @@ describe('bitcoin gold xpub to address tests;  generate valid addresses by calli
       type: BIP43PurposeTypeEnum.Segwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKH,
-      addressType: AddressTypeEnum.p2wpkh
+      scriptType: ScriptTypeEnum.p2wpkh,
     }).scriptPubkey
     const p2wpkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(p2wpkhAddress).to.equals(
       'btg1qkwnu2phwvard2spr2n0a9d84x590ahywl3yacu'
@@ -167,7 +168,7 @@ describe('bitcoin gold xpub to address tests;  generate valid addresses by calli
       address: 'btg1qkwnu2phwvard2spr2n0a9d84x590ahywl3yacu',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
   })
@@ -179,12 +180,12 @@ describe('bitcoin gold from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -196,7 +197,7 @@ describe('bitcoin gold guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9',
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(scriptPubkey).to.equal(
       '76a914e21fb547704ff606ba769b9d6d7985f4cca760f788ac'
@@ -206,7 +207,7 @@ describe('bitcoin gold guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn',
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(scriptPubkey).to.equal(
       'a9142fdadae8827ecedb668946c073ebbb0482820c6387'
@@ -217,7 +218,7 @@ describe('bitcoin gold guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'btg1qkwnu2phwvard2spr2n0a9d84x590ahywl3yacu',
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoingold'
+      coin: 'bitcoingold',
     })
     expect(scriptPubkey).to.equal(
       '0014b3a7c506ee6746d5402354dfd2b4f5350afedc8e'

--- a/test/bitcoinkeymanager-test.ts
+++ b/test/bitcoinkeymanager-test.ts
@@ -6,6 +6,7 @@ import {
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
   createTx,
+  legacySeedToPrivateKey,
   mnemonicToXPriv,
   NetworkEnum,
   privateKeyToPubkey,
@@ -13,6 +14,7 @@ import {
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   scriptPubkeyToElectrumScriptHash,
+  ScriptTypeEnum,
   signTx,
   TransactionInputTypeEnum,
   TxInput,
@@ -203,7 +205,7 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
 
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh,
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
@@ -234,19 +236,19 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
     })
     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKHP2SH,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
+      scriptType: ScriptTypeEnum.p2wpkhp2sh,
     }).scriptPubkey
     const p2wpkhp2shAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKHP2SH,
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
+      addressType: AddressTypeEnum.p2sh,
       coin: 'bitcoin',
     })
     expect(p2wpkhp2shAddress).to.equals('37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
+      addressType: AddressTypeEnum.p2sh,
       coin: 'bitcoin',
     })
     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
@@ -264,7 +266,7 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
     })
     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKH,
-      addressType: AddressTypeEnum.p2wpkh,
+      scriptType: ScriptTypeEnum.p2wpkh,
     }).scriptPubkey
     const p2wpkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKH,
@@ -282,6 +284,22 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
       coin: 'bitcoin',
     })
     expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
+  })
+})
+
+describe('bitcoin from bip32 seed to private key', () => {
+  it('generate a wif key from a bip32 seed', () => {
+    const seed =
+      '1dafe5a826590b3f9558dd9e1ab1d8b86fda83a4bcc3aeeb95d81f0ab95c3d62'
+    const privateKey = legacySeedToPrivateKey({ seed, index: 0 })
+    const wifKey = privateKeyToWIF({
+      privateKey: privateKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'bitcoin',
+    })
+    expect(wifKey).to.equal(
+      'L4XwV2KLfsWYzaHbZRBGfrYBabYVCRUz8N6juyUDbMxYBPAeVdug'
+    )
   })
 })
 
@@ -422,19 +440,19 @@ describe('bitcoin transaction creation and signing test', () => {
   })
   const scriptPubkey: string = pubkeyToScriptPubkey({
     pubkey: privateKeyToPubkey(privateKey),
-    addressType: AddressTypeEnum.p2pkh,
+    scriptType: ScriptTypeEnum.p2pkh,
   }).scriptPubkey
   const segwitScriptPubkey: string = pubkeyToScriptPubkey({
     pubkey: privateKeyToPubkey(privateKey),
-    addressType: AddressTypeEnum.p2wpkh,
+    scriptType: ScriptTypeEnum.p2wpkh,
   }).scriptPubkey
   const wrappedSegwitScriptPubkey: string = pubkeyToScriptPubkey({
     pubkey: privateKeyToPubkey(privateKey),
-    addressType: AddressTypeEnum.p2wpkhp2sh,
+    scriptType: ScriptTypeEnum.p2wpkhp2sh,
   }).scriptPubkey
   const wrappedSegwitRedeemScript: string | undefined = pubkeyToScriptPubkey({
     pubkey: privateKeyToPubkey(privateKey),
-    addressType: AddressTypeEnum.p2wpkhp2sh,
+    scriptType: ScriptTypeEnum.p2wpkhp2sh,
   }).redeemScript
   const address: string = scriptPubkeyToAddress({
     scriptPubkey: scriptPubkey,
@@ -452,7 +470,7 @@ describe('bitcoin transaction creation and signing test', () => {
     scriptPubkey: wrappedSegwitScriptPubkey,
     network: NetworkEnum.Mainnet,
     coin: 'bitcoin',
-    addressType: AddressTypeEnum.p2wpkhp2sh,
+    addressType: AddressTypeEnum.p2sh,
   })
 
   it('Create transaction with one legacy input and one output', () => {
@@ -504,6 +522,7 @@ describe('bitcoin transaction creation and signing test', () => {
     const hexTxSigned: string = signTx({
       tx: base64Tx,
       privateKeys: [privateKey],
+      coin: 'bitcoin',
     })
     expect(hexTxSigned).to.equal(
       '02000000013ebc8203037dda39d482bf41ff3be955996c50d9d4f7cfc3d2097a694a7' +
@@ -547,6 +566,7 @@ describe('bitcoin transaction creation and signing test', () => {
     const rawtransaction: string = signTx({
       tx: base64Tx,
       privateKeys: [privateKey],
+      coin: 'bitcoin',
     })
 
     expect(rawtransaction).to.equal(
@@ -574,6 +594,7 @@ describe('bitcoin transaction creation and signing test', () => {
     const segwitRawTransaction: string = signTx({
       tx: segwitTx,
       privateKeys: Array(nOutputs).fill(privateKey),
+      coin: 'bitcoin',
     })
 
     expect(segwitRawTransaction).to.equal(
@@ -640,7 +661,7 @@ describe('bitcoin transaction creation and signing test', () => {
       scriptPubkey: addressToScriptPubkey({
         address: wrappedSegwitAddress,
         network: NetworkEnum.Mainnet,
-        addressType: AddressTypeEnum.p2wpkhp2sh,
+        addressType: AddressTypeEnum.p2sh,
         coin: 'bitcoin',
       }),
       amount: 200,
@@ -656,6 +677,7 @@ describe('bitcoin transaction creation and signing test', () => {
     const rawtransaction: string = signTx({
       tx: base64Tx,
       privateKeys: [privateKey, privateKey, privateKey],
+      coin: 'bitcoin',
     })
     expect(rawtransaction).to.equal(
       '020000000001033ebc8203037dda39d482bf41ff3be955996c50d9d4f7cfc3d2097a694a7b067d000000006b483045022100c10c70dab0e8e88a67bb013d276b88b3d5a52d3cb3ec53aa7d2e7c4704e89dc602207fabdfa3b55b196da7792de9fe436535501fce2fe76439d5361bd5d9dd69bd0901210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f455ffffffffb385ee16c29a8148e7e99187a293e96fcf9a16e4967d3afc8f7838024dfa268b0100000000ffffffff9e5d335ec9133a9e5ed426d08c421273594b82ab9876b5beb66716384688f2e901000000171600148bbc95d2709c71607c60ee3f097c1217482f518dffffffff03c8000000000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88acc8000000000000001600148bbc95d2709c71607c60ee3f097c1217482f518dc80000000000000017a9142427d83a84e5793ce6f6efc33020d844dd217dbb8700024730440220008a9738e8acdc002ae4bb415ff7368161057ed9b22fd8b671c5acbb47379a69022045ab99fa73730fa367d3972d41b26b4ef337b34c4e593c4f47800ed4ee1c64fd01210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f4550247304402201d4f3ee993cfb468dc41387ac618081c36c49ebc9db528155b51d346382c347802201d1c07201f80df3e6e86195444532b6be86e9a429a7eb5a0ae268df9760a974601210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f45500000000'
@@ -701,6 +723,7 @@ describe('bitcoin transaction creation and signing test', () => {
     const hexTxSigned: string = signTx({
       tx: base64Tx,
       privateKeys: [privateKey],
+      coin: 'bitcoin',
     })
 
     const txInputs: TxInput[] = Array(nOutputs)
@@ -723,6 +746,7 @@ describe('bitcoin transaction creation and signing test', () => {
     const hexTxMultiSigned: string = signTx({
       tx: base64TxMulti,
       privateKeys: Array(nOutputs).fill(privateKey),
+      coin: 'bitcoin',
     })
 
     expect(hexTxMultiSigned).to.equal(

--- a/test/bitcoinkeymanager-test.ts
+++ b/test/bitcoinkeymanager-test.ts
@@ -19,7 +19,7 @@ import {
   TxOutput,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 and some generated cases to test xpub prefix bytes', () => {
@@ -31,7 +31,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
       path: "m/84'/0'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Segwit,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultSegwit).to.equal(
       'zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE'
@@ -44,7 +44,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
       path: "m/84'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Segwit,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultSegwitTestnet).to.equal(
       'vprv9K7GLAaERuM58PVvbk1sMo7wzVCoPwzZpVXLRBmum93gL5pSqQCAAvZjtmz93nnnYMr9i2FwG2fqrwYLRgJmDDwFjGiamGsbRMJ5Y6siJ8H'
@@ -57,7 +57,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
       path: "m/49'/0'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultWrappedSegwit).to.equal(
       'yprvAHwhK6RbpuS3dgCYHM5jc2ZvEKd7Bi61u9FVhYMpgMSuZS613T1xxQeKTffhrHY79hZ5PsskBjcc6C2V7DrnsMsNaGDaWev3GLRQRgV7hxF'
@@ -70,7 +70,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
       path: "m/49'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultWrappedSegwitTestnet).to.equal(
       'uprv91G7gZkzehuMVxDJTYE6tLivdF8e4rvzSu1LFfKw3b2Qx1Aj8vpoFnHdfUZ3hmi9jsvPifmZ24RTN2KhwB8BfMLTVqaBReibyaFFcTP1s9n'
@@ -83,7 +83,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
       path: "m/44'/0'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultLegacy).to.equal(
       'xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb'
@@ -96,7 +96,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -111,7 +111,7 @@ describe('bitcoin bip32 prefix tests for the conversion from xpriv to xpub', () 
         'zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Segwit,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultSegwit).to.equals(
       'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs'
@@ -124,7 +124,7 @@ describe('bitcoin bip32 prefix tests for the conversion from xpriv to xpub', () 
         'vprv9K7GLAaERuM58PVvbk1sMo7wzVCoPwzZpVXLRBmum93gL5pSqQCAAvZjtmz93nnnYMr9i2FwG2fqrwYLRgJmDDwFjGiamGsbRMJ5Y6siJ8H',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Segwit,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultSegwitTestnet).to.equals(
       'vpub5Y6cjg78GGuNLsaPhmYsiw4gYX3HoQiRBiSwDaBXKUafCt9bNwWQiitDk5VZ5BVxYnQdwoTyXSs2JHRPAgjAvtbBrf8ZhDYe2jWAqvZVnsc'
@@ -137,7 +137,7 @@ describe('bitcoin bip32 prefix tests for the conversion from xpriv to xpub', () 
         'yprvAHwhK6RbpuS3dgCYHM5jc2ZvEKd7Bi61u9FVhYMpgMSuZS613T1xxQeKTffhrHY79hZ5PsskBjcc6C2V7DrnsMsNaGDaWev3GLRQRgV7hxF',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultWrappedSegwit).to.equals(
       'ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP'
@@ -150,7 +150,7 @@ describe('bitcoin bip32 prefix tests for the conversion from xpriv to xpub', () 
         'uprv91G7gZkzehuMVxDJTYE6tLivdF8e4rvzSu1LFfKw3b2Qx1Aj8vpoFnHdfUZ3hmi9jsvPifmZ24RTN2KhwB8BfMLTVqaBReibyaFFcTP1s9n',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultWrappedSegwitTestnet).to.equals(
       'upub5EFU65HtV5TeiSHmZZm7FUffBGy8UKeqp7vw43jYbvZPpoVsgU93oac7Wk3u6moKegAEWtGNF8DehrnHtv21XXEMYRUocHqguyjknFHYfgY'
@@ -163,7 +163,7 @@ describe('bitcoin bip32 prefix tests for the conversion from xpriv to xpub', () 
         'xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultLegacy).to.equals(
       'xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj'
@@ -176,7 +176,7 @@ describe('bitcoin bip32 prefix tests for the conversion from xpriv to xpub', () 
         'tprv8fVU32aAEuEPeH1WYx3LhXtSFZTRaFqjbFNPaJZ9R8fCVja44tSaUPZEKGpMK6McUDkWWMvRiVfKR3Wzei6AmLoTNYHMAZ9KtvVTLZZdhvA',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDCBWBScQPGv4Xk3JSbhw6wYYpayMjb2eAYyArpbSqQTbLDpphHGAetB6VQgVeftLML8vDSUEWcC2xDi3qJJ3YCDChJDvqVzpgoYSuT52MhJ'
@@ -198,27 +198,26 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
-    console.log(pubkeyP2PKH)
 
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      addressType: AddressTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(p2pkhAddress).to.equals('1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: '1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -231,24 +230,24 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
       type: BIP43PurposeTypeEnum.WrappedSegwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKHP2SH,
-      addressType: AddressTypeEnum.p2wpkhp2sh
+      addressType: AddressTypeEnum.p2wpkhp2sh,
     }).scriptPubkey
     const p2wpkhp2shAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKHP2SH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(p2wpkhp2shAddress).to.equals('37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
   })
@@ -261,17 +260,17 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
       type: BIP43PurposeTypeEnum.Segwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKH,
-      addressType: AddressTypeEnum.p2wpkh
+      addressType: AddressTypeEnum.p2wpkh,
     }).scriptPubkey
     const p2wpkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(p2wpkhAddress).to.equals(
       'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'
@@ -280,7 +279,7 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
       address: 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
   })
@@ -292,12 +291,12 @@ describe('bitcoin from WIF to private key buffer to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -310,7 +309,7 @@ describe('bitcoin get script pubkeys from address', () => {
       address: '1KRMKfeZcmosxALVYESdPNez1AP1mEtywp',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkey).to.equal(
       '76a914ca0d36044e0dc08a22724efa6f6a07b0ec4c79aa88ac'
@@ -321,7 +320,7 @@ describe('bitcoin get script pubkeys from address', () => {
       address: 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkey).to.equal(
       '0014c0cebcd6c3d3ca8c75dc5ec62ebe55330ef910e2'
@@ -332,7 +331,7 @@ describe('bitcoin get script pubkeys from address', () => {
       address: '2Mu9hifsg4foPLkyo9i1isPWTobnNmXL3Qk',
       network: NetworkEnum.Testnet,
       addressType: AddressTypeEnum.p2sh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkey).to.equal(
       'a91414e4e7810e5120cc68d55d03b36cf66a9eadc27087'
@@ -343,7 +342,7 @@ describe('bitcoin get script pubkeys from address', () => {
       address: 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7',
       network: NetworkEnum.Testnet,
       addressType: AddressTypeEnum.p2wsh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkey).to.equal(
       '00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262'
@@ -357,7 +356,7 @@ describe('bitcoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: '1KRMKfeZcmosxALVYESdPNez1AP1mEtywp',
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkey).to.equal(
       '76a914ca0d36044e0dc08a22724efa6f6a07b0ec4c79aa88ac'
@@ -367,7 +366,7 @@ describe('bitcoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu',
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkey).to.equal(
       '0014c0cebcd6c3d3ca8c75dc5ec62ebe55330ef910e2'
@@ -377,7 +376,7 @@ describe('bitcoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: '2Mu9hifsg4foPLkyo9i1isPWTobnNmXL3Qk',
       network: NetworkEnum.Testnet,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkey).to.equal(
       'a91414e4e7810e5120cc68d55d03b36cf66a9eadc27087'
@@ -387,7 +386,7 @@ describe('bitcoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7',
       network: NetworkEnum.Testnet,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkey).to.equal(
       '00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262'
@@ -401,7 +400,7 @@ describe('bitcoin address to electrum script hash', () => {
       address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     })
     expect(scriptPubkey).to.equal(
       '76a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1888ac'
@@ -419,41 +418,41 @@ describe('bitcoin transaction creation and signing test', () => {
   const privateKey = wifToPrivateKey({
     wifKey,
     network: NetworkEnum.Mainnet,
-    coin: 'bitcoin'
+    coin: 'bitcoin',
   })
   const scriptPubkey: string = pubkeyToScriptPubkey({
     pubkey: privateKeyToPubkey(privateKey),
-    addressType: AddressTypeEnum.p2pkh
+    addressType: AddressTypeEnum.p2pkh,
   }).scriptPubkey
   const segwitScriptPubkey: string = pubkeyToScriptPubkey({
     pubkey: privateKeyToPubkey(privateKey),
-    addressType: AddressTypeEnum.p2wpkh
+    addressType: AddressTypeEnum.p2wpkh,
   }).scriptPubkey
   const wrappedSegwitScriptPubkey: string = pubkeyToScriptPubkey({
     pubkey: privateKeyToPubkey(privateKey),
-    addressType: AddressTypeEnum.p2wpkhp2sh
+    addressType: AddressTypeEnum.p2wpkhp2sh,
   }).scriptPubkey
   const wrappedSegwitRedeemScript: string | undefined = pubkeyToScriptPubkey({
     pubkey: privateKeyToPubkey(privateKey),
-    addressType: AddressTypeEnum.p2wpkhp2sh
+    addressType: AddressTypeEnum.p2wpkhp2sh,
   }).redeemScript
   const address: string = scriptPubkeyToAddress({
     scriptPubkey: scriptPubkey,
     network: NetworkEnum.Mainnet,
     coin: 'bitcoin',
-    addressType: AddressTypeEnum.p2pkh
+    addressType: AddressTypeEnum.p2pkh,
   })
   const segwitAddress: string = scriptPubkeyToAddress({
     scriptPubkey: segwitScriptPubkey,
     network: NetworkEnum.Mainnet,
     coin: 'bitcoin',
-    addressType: AddressTypeEnum.p2wpkh
+    addressType: AddressTypeEnum.p2wpkh,
   })
   const wrappedSegwitAddress: string = scriptPubkeyToAddress({
     scriptPubkey: wrappedSegwitScriptPubkey,
     network: NetworkEnum.Mainnet,
     coin: 'bitcoin',
-    addressType: AddressTypeEnum.p2wpkhp2sh
+    addressType: AddressTypeEnum.p2wpkhp2sh,
   })
 
   it('Create transaction with one legacy input and one output', () => {
@@ -487,8 +486,8 @@ describe('bitcoin transaction creation and signing test', () => {
             scriptPubkey +
             // locktime
             '00000000',
-          index: 0
-        }
+          index: 0,
+        },
       ],
       outputs: [
         {
@@ -496,15 +495,15 @@ describe('bitcoin transaction creation and signing test', () => {
             address: '1KRMKfeZcmosxALVYESdPNez1AP1mEtywp',
             network: NetworkEnum.Mainnet,
             addressType: AddressTypeEnum.p2pkh,
-            coin: 'bitcoin'
+            coin: 'bitcoin',
           }),
-          amount: 80000
-        }
-      ]
-    })
+          amount: 80000,
+        },
+      ],
+    }).psbt
     const hexTxSigned: string = signTx({
       tx: base64Tx,
-      privateKeys: [privateKey]
+      privateKeys: [privateKey],
     })
     expect(hexTxSigned).to.equal(
       '02000000013ebc8203037dda39d482bf41ff3be955996c50d9d4f7cfc3d2097a694a7' +
@@ -524,13 +523,8 @@ describe('bitcoin transaction creation and signing test', () => {
         '7d067b4a697a09d2c3cff7d4d9506c9955e93bff41bf82d439da7d030382bc3e',
       // prev_tx only for non segwit inputs
       prevTx:
-        '0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d94' +
-        '52e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48ca' +
-        '17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc5660209e7' +
-        '61da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec631e' +
-        '5e1e66009ce3710ceea5b1ad13ffffffff01905f0100000000001976a9148bbc95d2' +
-        '709c71607c60ee3f097c1217482f518d88ac00000000',
-      index: 0
+        '0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d9452e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48ca17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc5660209e761da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec631e5e1e66009ce3710ceea5b1ad13ffffffff01905f0100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000',
+      index: 0,
     }
 
     const txOutput: TxOutput = {
@@ -538,21 +532,21 @@ describe('bitcoin transaction creation and signing test', () => {
         address: segwitAddress,
         network: NetworkEnum.Mainnet,
         addressType: AddressTypeEnum.p2wpkh,
-        coin: 'bitcoin'
+        coin: 'bitcoin',
       }),
-      amount: 200
+      amount: 200,
     }
 
     const base64Tx: string = createTx({
       inputs: [txInput],
       outputs: Array(nOutputs).fill(txOutput),
       network: NetworkEnum.Mainnet,
-      rbf: false
-    })
+      rbf: false,
+    }).psbt
 
     const rawtransaction: string = signTx({
       tx: base64Tx,
-      privateKeys: [privateKey]
+      privateKeys: [privateKey],
     })
 
     expect(rawtransaction).to.equal(
@@ -567,7 +561,7 @@ describe('bitcoin transaction creation and signing test', () => {
           '8b26fa4d0238788ffc3a7d96e4169acf6fe993a28791e9e748819ac216ee85b3',
         prevScriptPubkey: segwitScriptPubkey,
         index: i,
-        value: 200
+        value: 200,
       }
     }
 
@@ -575,11 +569,11 @@ describe('bitcoin transaction creation and signing test', () => {
       inputs: txInputs,
       outputs: [txOutput],
       network: NetworkEnum.Mainnet,
-      rbf: false
-    })
+      rbf: false,
+    }).psbt
     const segwitRawTransaction: string = signTx({
       tx: segwitTx,
-      privateKeys: Array(nOutputs).fill(privateKey)
+      privateKeys: Array(nOutputs).fill(privateKey),
     })
 
     expect(segwitRawTransaction).to.equal(
@@ -600,7 +594,7 @@ describe('bitcoin transaction creation and signing test', () => {
         '61da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec631e' +
         '5e1e66009ce3710ceea5b1ad13ffffffff01905f0100000000001976a9148bbc95d2' +
         '709c71607c60ee3f097c1217482f518d88ac00000000',
-      index: 0
+      index: 0,
     }
 
     const txInputSegwit: TxInput = {
@@ -609,7 +603,7 @@ describe('bitcoin transaction creation and signing test', () => {
         '8b26fa4d0238788ffc3a7d96e4169acf6fe993a28791e9e748819ac216ee85b3',
       prevScriptPubkey: segwitScriptPubkey,
       index: 1,
-      value: 200
+      value: 200,
     }
 
     const txInputWrappedSegwit: TxInput = {
@@ -619,7 +613,7 @@ describe('bitcoin transaction creation and signing test', () => {
       prevScriptPubkey: wrappedSegwitScriptPubkey,
       redeemScript: wrappedSegwitRedeemScript,
       index: 1,
-      value: 200
+      value: 200,
     }
 
     const txOutputLegacy: TxOutput = {
@@ -627,9 +621,9 @@ describe('bitcoin transaction creation and signing test', () => {
         address: address,
         network: NetworkEnum.Mainnet,
         addressType: AddressTypeEnum.p2pkh,
-        coin: 'bitcoin'
+        coin: 'bitcoin',
       }),
-      amount: 200
+      amount: 200,
     }
 
     const txOutputSegwit: TxOutput = {
@@ -637,9 +631,9 @@ describe('bitcoin transaction creation and signing test', () => {
         address: segwitAddress,
         network: NetworkEnum.Mainnet,
         addressType: AddressTypeEnum.p2wpkh,
-        coin: 'bitcoin'
+        coin: 'bitcoin',
       }),
-      amount: 200
+      amount: 200,
     }
 
     const txOutputWrappedSegwit: TxOutput = {
@@ -647,21 +641,21 @@ describe('bitcoin transaction creation and signing test', () => {
         address: wrappedSegwitAddress,
         network: NetworkEnum.Mainnet,
         addressType: AddressTypeEnum.p2wpkhp2sh,
-        coin: 'bitcoin'
+        coin: 'bitcoin',
       }),
-      amount: 200
+      amount: 200,
     }
 
     const base64Tx: string = createTx({
       inputs: [txInputLegacy, txInputSegwit, txInputWrappedSegwit],
       outputs: [txOutputLegacy, txOutputSegwit, txOutputWrappedSegwit],
       network: NetworkEnum.Mainnet,
-      rbf: false
-    })
+      rbf: false,
+    }).psbt
 
     const rawtransaction: string = signTx({
       tx: base64Tx,
-      privateKeys: [privateKey, privateKey, privateKey]
+      privateKeys: [privateKey, privateKey, privateKey],
     })
     expect(rawtransaction).to.equal(
       '020000000001033ebc8203037dda39d482bf41ff3be955996c50d9d4f7cfc3d2097a694a7b067d000000006b483045022100c10c70dab0e8e88a67bb013d276b88b3d5a52d3cb3ec53aa7d2e7c4704e89dc602207fabdfa3b55b196da7792de9fe436535501fce2fe76439d5361bd5d9dd69bd0901210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f455ffffffffb385ee16c29a8148e7e99187a293e96fcf9a16e4967d3afc8f7838024dfa268b0100000000ffffffff9e5d335ec9133a9e5ed426d08c421273594b82ab9876b5beb66716384688f2e901000000171600148bbc95d2709c71607c60ee3f097c1217482f518dffffffff03c8000000000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88acc8000000000000001600148bbc95d2709c71607c60ee3f097c1217482f518dc80000000000000017a9142427d83a84e5793ce6f6efc33020d844dd217dbb8700024730440220008a9738e8acdc002ae4bb415ff7368161057ed9b22fd8b671c5acbb47379a69022045ab99fa73730fa367d3972d41b26b4ef337b34c4e593c4f47800ed4ee1c64fd01210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f4550247304402201d4f3ee993cfb468dc41387ac618081c36c49ebc9db528155b51d346382c347802201d1c07201f80df3e6e86195444532b6be86e9a429a7eb5a0ae268df9760a974601210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f45500000000'
@@ -684,7 +678,7 @@ describe('bitcoin transaction creation and signing test', () => {
         '709c71607c60ee3f097c1217482f518d88ac00000000',
       index: 0,
       // prev_scriptPubkey only relevant for Segwit inputs, but keep mandatory for now before we start handling errors.
-      prevScriptPubkey: scriptPubkey
+      prevScriptPubkey: scriptPubkey,
     }
 
     const txOutput: TxOutput = {
@@ -692,21 +686,21 @@ describe('bitcoin transaction creation and signing test', () => {
         address: address,
         network: NetworkEnum.Mainnet,
         addressType: AddressTypeEnum.p2pkh,
-        coin: 'bitcoin'
+        coin: 'bitcoin',
       }),
-      amount: 200
+      amount: 200,
     }
 
     const base64Tx: string = createTx({
       inputs: [txInput],
       outputs: Array(nOutputs).fill(txOutput),
       network: NetworkEnum.Mainnet,
-      rbf: false
-    })
+      rbf: false,
+    }).psbt
 
     const hexTxSigned: string = signTx({
       tx: base64Tx,
-      privateKeys: [privateKey]
+      privateKeys: [privateKey],
     })
 
     const txInputs: TxInput[] = Array(nOutputs)
@@ -716,19 +710,19 @@ describe('bitcoin transaction creation and signing test', () => {
         prevTxid:
           '8b26fa4d0238788ffc3a7d96e4169acf6fe993a28791e9e748819ac216ee85b3',
         prevTx: hexTxSigned,
-        index: i
+        index: i,
       }
     }
     const base64TxMulti: string = createTx({
       inputs: txInputs,
       outputs: [txOutput, txOutput],
       network: NetworkEnum.Mainnet,
-      rbf: false
-    })
+      rbf: false,
+    }).psbt
 
     const hexTxMultiSigned: string = signTx({
       tx: base64TxMulti,
-      privateKeys: Array(nOutputs).fill(privateKey)
+      privateKeys: Array(nOutputs).fill(privateKey),
     })
 
     expect(hexTxMultiSigned).to.equal(

--- a/test/bitcoinkeymanager-test.ts
+++ b/test/bitcoinkeymanager-test.ts
@@ -520,7 +520,7 @@ describe('bitcoin transaction creation and signing test', () => {
       ],
     }).psbt
     const hexTxSigned: string = signTx({
-      tx: base64Tx,
+      psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoin',
     })
@@ -564,7 +564,7 @@ describe('bitcoin transaction creation and signing test', () => {
     }).psbt
 
     const rawtransaction: string = signTx({
-      tx: base64Tx,
+      psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoin',
     })
@@ -592,7 +592,7 @@ describe('bitcoin transaction creation and signing test', () => {
       rbf: false,
     }).psbt
     const segwitRawTransaction: string = signTx({
-      tx: segwitTx,
+      psbt: segwitTx,
       privateKeys: Array(nOutputs).fill(privateKey),
       coin: 'bitcoin',
     })
@@ -675,7 +675,7 @@ describe('bitcoin transaction creation and signing test', () => {
     }).psbt
 
     const rawtransaction: string = signTx({
-      tx: base64Tx,
+      psbt: base64Tx,
       privateKeys: [privateKey, privateKey, privateKey],
       coin: 'bitcoin',
     })
@@ -721,7 +721,7 @@ describe('bitcoin transaction creation and signing test', () => {
     }).psbt
 
     const hexTxSigned: string = signTx({
-      tx: base64Tx,
+      psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoin',
     })
@@ -744,7 +744,7 @@ describe('bitcoin transaction creation and signing test', () => {
     }).psbt
 
     const hexTxMultiSigned: string = signTx({
-      tx: base64TxMulti,
+      psbt: base64TxMulti,
       privateKeys: Array(nOutputs).fill(privateKey),
       coin: 'bitcoin',
     })

--- a/test/bitcoinsvkeymanager-test.ts
+++ b/test/bitcoinsvkeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('bitcoin sv mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +25,7 @@ describe('bitcoin sv mnemonic to xprv test vectors as compared with iancoleman',
       path: "m/44'/236'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoinsv'
+      coin: 'bitcoinsv',
     })
     expect(resultLegacy).to.equal(
       'xprv9ydzpAw8scxgS53bvJyqSwDvfxDQZZtaJV98SYjZto3Pg7MCsPBjCcYqUtnWPRNayEXUcSYZDvXux545bHZwda7YUWvReJiRkx38VXathgK'
@@ -37,7 +38,7 @@ describe('bitcoin sv mnemonic to xprv test vectors as compared with iancoleman',
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoinsv'
+      coin: 'bitcoinsv',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +53,7 @@ describe('bitcoin sv bip32 prefix tests for the conversion from xpriv to xpub', 
         'xprv9ydzpAw8scxgS53bvJyqSwDvfxDQZZtaJV98SYjZto3Pg7MCsPBjCcYqUtnWPRNayEXUcSYZDvXux545bHZwda7YUWvReJiRkx38VXathgK',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoinsv'
+      coin: 'bitcoinsv',
     })
     expect(resultLegacy).to.equals(
       'xpub6CdMDgU2hzWyeZ852LWqp5AfDz3ty2cRfi4jEw9BT8aNYugMQvVykQsKLARZdbqKKp7yTviJdL1N9saYLmJNKD1rwVAwLTmU8r8qKeoyG4R'
@@ -65,7 +66,7 @@ describe('bitcoin sv bip32 prefix tests for the conversion from xpriv to xpub', 
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'bitcoinsv'
+      coin: 'bitcoinsv',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,25 +88,25 @@ describe('bitcoin sv xpub to address tests;  generate valid addresses by calling
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'bitcoinsv'
+      coin: 'bitcoinsv',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'bitcoinsv'
+      coin: 'bitcoinsv',
     })
     expect(p2pkhAddress).to.equals('1K6LZdwpKT5XkEZo2T2kW197aMXYbYMc4f')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: '1K6LZdwpKT5XkEZo2T2kW197aMXYbYMc4f',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'bitcoinsv'
+      coin: 'bitcoinsv',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -117,12 +118,12 @@ describe('bitcoin sv from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoinsv'
+      coin: 'bitcoinsv',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoinsv'
+      coin: 'bitcoinsv',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -134,7 +135,7 @@ describe('bitcoin sv guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: '1K6LZdwpKT5XkEZo2T2kW197aMXYbYMc4f',
       network: NetworkEnum.Mainnet,
-      coin: 'bitcoinsv'
+      coin: 'bitcoinsv',
     })
     expect(scriptPubkey).to.equal(
       '76a914c674ac8e0534044717c9ee450d5d9f25e243645088ac'

--- a/test/cashaddr-test.ts
+++ b/test/cashaddr-test.ts
@@ -12,6 +12,7 @@ import {
   AddressTypeEnum,
   NetworkEnum,
   scriptPubkeyToScriptHash,
+  ScriptTypeEnum,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('bitcoin cash address tests', () => {
@@ -23,7 +24,7 @@ describe('bitcoin cash address tests', () => {
       coin: 'bitcoin',
     }),
     network: NetworkEnum.Mainnet,
-    addressType: AddressTypeEnum.p2pkh,
+    scriptType: ScriptTypeEnum.p2pkh,
     coin: 'bitcoin',
   })
   it('pubkey hash to cashaddr', () => {
@@ -54,7 +55,7 @@ describe('bitcoin cash address tests', () => {
       coin: 'bitcoin',
     }),
     network: NetworkEnum.Mainnet,
-    addressType: AddressTypeEnum.p2sh,
+    scriptType: ScriptTypeEnum.p2sh,
     coin: 'bitcoin',
   })
 

--- a/test/cashaddr-test.ts
+++ b/test/cashaddr-test.ts
@@ -3,15 +3,15 @@ import { describe, it } from 'mocha'
 
 import {
   cashAddressToHash,
-  cashaddrPrefixEnum,
-  cashaddrTypeEnum,
-  hashToCashAddress
+  CashaddrPrefixEnum,
+  CashaddrTypeEnum,
+  hashToCashAddress,
 } from '../src/common/utxobased/keymanager/bitcoincashUtils/cashAddress'
 import {
   addressToScriptPubkey,
   AddressTypeEnum,
   NetworkEnum,
-  scriptPubkeyToScriptHash
+  scriptPubkeyToScriptHash,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('bitcoin cash address tests', () => {
@@ -20,17 +20,17 @@ describe('bitcoin cash address tests', () => {
       address: '1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     }),
     network: NetworkEnum.Mainnet,
     addressType: AddressTypeEnum.p2pkh,
-    coin: 'bitcoin'
+    coin: 'bitcoin',
   })
   it('pubkey hash to cashaddr', () => {
     const address = hashToCashAddress(
       pubkeyHash,
-      cashaddrTypeEnum.pubkeyhash,
-      cashaddrPrefixEnum.mainnet
+      CashaddrTypeEnum.pubkeyhash,
+      CashaddrPrefixEnum.mainnet
     )
     expect(address).to.equal(
       'bitcoincash:qrvcdmgpk73zyfd8pmdl9wnuld36zh9n4gms8s0u59'
@@ -51,18 +51,18 @@ describe('bitcoin cash address tests', () => {
       address: '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2sh,
-      coin: 'bitcoin'
+      coin: 'bitcoin',
     }),
     network: NetworkEnum.Mainnet,
     addressType: AddressTypeEnum.p2sh,
-    coin: 'bitcoin'
+    coin: 'bitcoin',
   })
 
   it('script hash to cashaddr', () => {
     const address = hashToCashAddress(
       scriptHash,
-      cashaddrTypeEnum.scripthash,
-      cashaddrPrefixEnum.mainnet
+      CashaddrTypeEnum.scripthash,
+      CashaddrPrefixEnum.mainnet
     )
     expect(address).to.equal(
       'bitcoincash:pqlmd62cztjhhdrfr7dy5c5gv2np5nmknvhfvqp85n'

--- a/test/checkdatasig-test.ts
+++ b/test/checkdatasig-test.ts
@@ -1,0 +1,15 @@
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+
+import { cdsScriptTemplates } from '../src/common/utxobased/keymanager/bitcoincashUtils/checkdatasig'
+
+describe('zzz bitcoin cash checkdatasig scripting tests', () => {
+  const redeemScript = cdsScriptTemplates.replayProtection(
+    '038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508'
+  )
+  it('zzz bitcoin cash checkdatasig redeem script test', () => {
+    expect(redeemScript).to.equal(
+      '4630440220256c12175e809381f97637933ed6ab97737d263eaaebca6add21bced67fd12a402205ce29ecc1369d6fc1b51977ed38faaf41119e3be1d7edfafd7cfaf0b6061bd070021038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508bb21038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508ac'
+    )
+  })
+})

--- a/test/checkdatasig-test.ts
+++ b/test/checkdatasig-test.ts
@@ -3,11 +3,11 @@ import { describe, it } from 'mocha'
 
 import { cdsScriptTemplates } from '../src/common/utxobased/keymanager/bitcoincashUtils/checkdatasig'
 
-describe('zzz bitcoin cash checkdatasig scripting tests', () => {
+describe('bitcoin cash checkdatasig scripting tests', () => {
   const redeemScript = cdsScriptTemplates.replayProtection(
     '038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508'
   )
-  it('zzz bitcoin cash checkdatasig redeem script test', () => {
+  it('bitcoin cash checkdatasig redeem script test', () => {
     expect(redeemScript).to.equal(
       '4630440220256c12175e809381f97637933ed6ab97737d263eaaebca6add21bced67fd12a402205ce29ecc1369d6fc1b51977ed38faaf41119e3be1d7edfafd7cfaf0b6061bd070021038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508bb21038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508ac'
     )

--- a/test/dashkeymanager-test.ts
+++ b/test/dashkeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('dash mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +25,7 @@ describe('dash mnemonic to xprv test vectors as compared with iancoleman', () =>
       path: "m/44'/5'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'dash'
+      coin: 'dash',
     })
     expect(resultLegacy).to.equal(
       'drkvjRAxdpDmxjUnQKX26VwVQ2mbVjXn67Tr4LZoyobdJyQpPW4ssDTnrcf1zHJui9XqpNuPYxZkHYymoZEowFHHCP6VZncvx9q9UNuerwSVDzr'
@@ -37,7 +38,7 @@ describe('dash mnemonic to xprv test vectors as compared with iancoleman', () =>
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'dash'
+      coin: 'dash',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +53,7 @@ describe('dash bip32 prefix tests for the conversion from xpriv to xpub', () => 
         'drkvjRAxdpDmxjUnQKX26VwVQ2mbVjXn67Tr4LZoyobdJyQpPW4ssDTnrcf1zHJui9XqpNuPYxZkHYymoZEowFHHCP6VZncvx9q9UNuerwSVDzr',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'dash'
+      coin: 'dash',
     })
     expect(resultLegacy).to.equals(
       'drkpRzJp5yxNJdtLq7YmV6Bfg7NtjycEopwQtnqre1mPRoie9DPWBfCu23U5gVteaKYiMF3gaFd88RnZUfowGYoBoR4sWk4RApm4jrbSAGgQUdq'
@@ -65,7 +66,7 @@ describe('dash bip32 prefix tests for the conversion from xpriv to xpub', () => 
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'dash'
+      coin: 'dash',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,25 +88,25 @@ describe('dash xpub to address tests;  generate valid addresses by calling xpubT
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'dash'
+      coin: 'dash',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'dash'
+      coin: 'dash',
     })
     expect(p2pkhAddress).to.equals('XoJA8qE3N2Y3jMLEtZ3vcN42qseZ8LvFf5')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'XoJA8qE3N2Y3jMLEtZ3vcN42qseZ8LvFf5',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'dash'
+      coin: 'dash',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -117,12 +118,12 @@ describe('dash from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'dash'
+      coin: 'dash',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'dash'
+      coin: 'dash',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -134,7 +135,7 @@ describe('dash guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'XoJA8qE3N2Y3jMLEtZ3vcN42qseZ8LvFf5',
       network: NetworkEnum.Mainnet,
-      coin: 'dash'
+      coin: 'dash',
     })
     expect(scriptPubkey).to.equal(
       '76a9148a4f58c222cd5544c527bc66925652baa70b5e8088ac'

--- a/test/decredkeymanager-test.ts
+++ b/test/decredkeymanager-test.ts
@@ -73,11 +73,6 @@ describe('decred bip32 prefix tests for the conversion from xpriv to xpub', () =
 })
 
 describe('decred xpub to address tests;  generate valid addresses by calling xpubToPubkey, pubkeyToScriptPubkey and scriptPubkeyToAddress', () => {
-  /*
-    These methods were cross verified using ian colemans bip32 website https://iancoleman.io/bip39/
-    using the same seed as in other tests (abandon, ...)
-    */
-
   it('given an xpub, generate p2pkh address and cross verify script pubkey result', () => {
     const pubkeyP2PKH = xpubToPubkey({
       xpub:

--- a/test/decredkeymanager-test.ts
+++ b/test/decredkeymanager-test.ts
@@ -7,10 +7,10 @@ import {
   BIP43PurposeTypeEnum,
   mnemonicToXPriv,
   NetworkEnum,
-  // privateKeyToWIF,
+  privateKeyToWIF,
   // pubkeyToScriptPubkey,
   // scriptPubkeyToAddress,
-  // wifToPrivateKey,
+  wifToPrivateKey,
   xprivToXPub,
   // xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
@@ -173,23 +173,38 @@ describe('decred bip32 prefix tests for the conversion from xpriv to xpub', () =
 //   })
 // })
 
-// describe('decred from WIF to private key to WIF', () => {
-//   it('take a wif private key', () => {
-//     console.log('PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W')
-//     const wifKey = 'PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W'
-//     const privateKey = wifToPrivateKey({
-//       wifKey,
-//       network: NetworkEnum.Mainnet,
-//       coin: 'decred',
-//     })
-//     const wifKeyRoundTrip = privateKeyToWIF({
-//       privateKey: privateKey,
-//       network: NetworkEnum.Mainnet,
-//       coin: 'decred',
-//     })
-//     expect(wifKey).to.be.equal(wifKeyRoundTrip)
-//   })
-// })
+describe('decred from WIF to private key to WIF', () => {
+  it('take a wif private key', () => {
+    const wifKey = 'PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W'
+    const privateKey = wifToPrivateKey({
+      wifKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'decred',
+    })
+    const wifKeyRoundTrip = privateKeyToWIF({
+      privateKey: privateKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'decred',
+    })
+    expect(wifKey).to.be.equal(wifKeyRoundTrip)
+  })
+
+  // it('take a wif private key', () => {
+  //   console.log('PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W')
+  //   const wifKey = 'PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W'
+  //   const privateKey = wifToPrivateKey({
+  //     wifKey,
+  //     network: NetworkEnum.Mainnet,
+  //     coin: 'decred',
+  //   })
+  //   const wifKeyRoundTrip = privateKeyToWIF({
+  //     privateKey: privateKey,
+  //     network: NetworkEnum.Mainnet,
+  //     coin: 'decred',
+  //   })
+  //   expect(wifKey).to.be.equal(wifKeyRoundTrip)
+  // })
+})
 
 // describe('decred guess script pubkeys from address', () => {
 //   // these tests are cross verified with bitcoin core

--- a/test/decredkeymanager-test.ts
+++ b/test/decredkeymanager-test.ts
@@ -2,17 +2,16 @@ import { expect } from 'chai'
 import { describe, it } from 'mocha'
 
 import {
-  // addressToScriptPubkey,
-  // AddressTypeEnum,
+  addressToScriptPubkey,
+  AddressTypeEnum,
   BIP43PurposeTypeEnum,
   mnemonicToXPriv,
   NetworkEnum,
-  privateKeyToWIF,
-  // pubkeyToScriptPubkey,
-  // scriptPubkeyToAddress,
-  wifToPrivateKey,
+  pubkeyToScriptPubkey,
+  scriptPubkeyToAddress,
+  ScriptTypeEnum,
   xprivToXPub,
-  // xpubToPubkey,
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('decred mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -73,170 +72,77 @@ describe('decred bip32 prefix tests for the conversion from xpriv to xpub', () =
   })
 })
 
-// describe('decred xpub to address tests;  generate valid addresses by calling xpubToPubkey, pubkeyToScriptPubkey and scriptPubkeyToAddress', () => {
-//   /*
-//     These methods were cross verified using ian colemans bip32 website https://iancoleman.io/bip39/
-//     using the same seed as in other tests (abandon, ...)
-//     */
+describe('decred xpub to address tests;  generate valid addresses by calling xpubToPubkey, pubkeyToScriptPubkey and scriptPubkeyToAddress', () => {
+  /*
+    These methods were cross verified using ian colemans bip32 website https://iancoleman.io/bip39/
+    using the same seed as in other tests (abandon, ...)
+    */
 
-//   it('given an xpub, generate p2pkh address and cross verify script pubkey result', () => {
-//     const pubkeyP2PKH = xpubToPubkey({
-//       xpub:
-//         'xpub6BwBY3LGBvGtyVy9wygN7v7yFWsK7g9jv5QwRyprquwhRQTgbXGx4HWPZHRnF5ueji94Dztce4k3RJnt2ir3xWBS7y6bDk8ryS8vKXyoYPL',
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       bip44ChangeIndex: 0,
-//       bip44AddressIndex: 0,
-//       coin: 'decred',
-//     })
-//     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
-//       pubkey: pubkeyP2PKH,
-//       addressType: AddressTypeEnum.p2pkh,
-//     }).scriptPubkey
-
-//     const p2pkhAddress = scriptPubkeyToAddress({
-//       scriptPubkey: scriptPubkeyP2PKH,
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2pkh,
-//       coin: 'decred',
-//     })
-//     expect(p2pkhAddress).to.equals('GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9')
-//     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
-//       address: 'GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9',
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2pkh,
-//       coin: 'decred',
-//     })
-//     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
-//   })
-
-//   it('given an ypub, generate p2wpkh-p2sh address and cross verify script pubkey result', () => {
-//     const pubkeyP2WPKHP2SH = xpubToPubkey({
-//       xpub:
-//         'ypub6Wu2Ax4NRoLJW1UCNBRMatwYW5Vr7vqgE4SK6FdKssNEUA2NCor8c5oSdMTUgHT3V9yj1LzMLTJpXwCh7hVenJdfhLB9M6qxmi6bcoFSdVd',
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.WrappedSegwit,
-//       bip44ChangeIndex: 0,
-//       bip44AddressIndex: 0,
-//       coin: 'decred',
-//     })
-//     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
-//       pubkey: pubkeyP2WPKHP2SH,
-//       addressType: AddressTypeEnum.p2wpkhp2sh,
-//     }).scriptPubkey
-//     const p2wpkhp2shAddress = scriptPubkeyToAddress({
-//       scriptPubkey: scriptPubkeyP2WPKHP2SH,
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2wpkhp2sh,
-//       coin: 'decred',
-//     })
-//     expect(p2wpkhp2shAddress).to.equals('AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn')
-//     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
-//       address: 'AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn',
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2wpkhp2sh,
-//       coin: 'decred',
-//     })
-//     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
-//   })
-
-//   it('given a zpub, generate p2wpkh address and cross verify script pubkey result', () => {
-//     const pubkeyP2WPKH = xpubToPubkey({
-//       xpub:
-//         'zpub6sBMnpX8349mvyqk3Y4U1mTJAeCpY4qGNgMeJejYe1sjPYyVVs6qBDrycdTNd7kHXCZBUxuTB9kojxvHKVU6kS9hsoUeekK1QRBU9nDYtx2',
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.Segwit,
-//       bip44ChangeIndex: 0,
-//       bip44AddressIndex: 0,
-//       coin: 'decred',
-//     })
-//     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
-//       pubkey: pubkeyP2WPKH,
-//       addressType: AddressTypeEnum.p2wpkh,
-//     }).scriptPubkey
-//     const p2wpkhAddress = scriptPubkeyToAddress({
-//       scriptPubkey: scriptPubkeyP2WPKH,
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2wpkh,
-//       coin: 'decred',
-//     })
-//     expect(p2wpkhAddress).to.equals(
-//       'btg1qkwnu2phwvard2spr2n0a9d84x590ahywl3yacu'
-//     )
-//     const scriptPubkeyP2WPKHRoundTrip = addressToScriptPubkey({
-//       address: 'btg1qkwnu2phwvard2spr2n0a9d84x590ahywl3yacu',
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2wpkh,
-//       coin: 'decred',
-//     })
-//     expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
-//   })
-// })
-
-describe('decred from WIF to private key to WIF', () => {
-  it('take a wif private key', () => {
-    const wifKey = 'PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W'
-    const privateKey = wifToPrivateKey({
-      wifKey,
+  it('given an xpub, generate p2pkh address and cross verify script pubkey result', () => {
+    const pubkeyP2PKH = xpubToPubkey({
+      xpub:
+        'dpubZEvuhzcFayUGWo9DFfFrKLAw46pbFNBVMGDUW1Mn5XqdFFgq8SAcmsDJTotAMMkqgQvGRtARQUzaYAvdT4zy7YwomLzYC8KLW6KdBqP9nsC',
       network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      bip44ChangeIndex: 0,
+      bip44AddressIndex: 0,
       coin: 'decred',
     })
-    const wifKeyRoundTrip = privateKeyToWIF({
-      privateKey: privateKey,
+    const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
+      pubkey: pubkeyP2PKH,
+      scriptType: ScriptTypeEnum.p2pkh,
+    }).scriptPubkey
+
+    const p2pkhAddress = scriptPubkeyToAddress({
+      scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2pkh,
       coin: 'decred',
     })
-    expect(wifKey).to.be.equal(wifKeyRoundTrip)
+    expect(p2pkhAddress).to.equals('DsmaYBuL9cgEswnx4KjeLQC2uAWUdRyVXhg')
+    const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
+      address: 'DsmaYBuL9cgEswnx4KjeLQC2uAWUdRyVXhg',
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2pkh,
+      coin: 'decred',
+    })
+    expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
-
-  // it('take a wif private key', () => {
-  //   console.log('PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W')
-  //   const wifKey = 'PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W'
-  //   const privateKey = wifToPrivateKey({
-  //     wifKey,
-  //     network: NetworkEnum.Mainnet,
-  //     coin: 'decred',
-  //   })
-  //   const wifKeyRoundTrip = privateKeyToWIF({
-  //     privateKey: privateKey,
-  //     network: NetworkEnum.Mainnet,
-  //     coin: 'decred',
-  //   })
-  //   expect(wifKey).to.be.equal(wifKeyRoundTrip)
-  // })
 })
 
-// describe('decred guess script pubkeys from address', () => {
-//   // these tests are cross verified with bitcoin core
-//   it('p2pkh address to scriptPubkey', () => {
-//     const scriptPubkey = addressToScriptPubkey({
-//       address: 'GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9',
-//       network: NetworkEnum.Mainnet,
-//       coin: 'decred',
-//     })
-//     expect(scriptPubkey).to.equal(
-//       '76a914e21fb547704ff606ba769b9d6d7985f4cca760f788ac'
-//     )
-//   })
-//   it('p2sh address to scriptPubkey', () => {
-//     const scriptPubkey = addressToScriptPubkey({
-//       address: 'AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn',
-//       network: NetworkEnum.Mainnet,
-//       coin: 'decred',
-//     })
-//     expect(scriptPubkey).to.equal(
-//       'a9142fdadae8827ecedb668946c073ebbb0482820c6387'
-//     )
-//   })
-
-//   it('p2wpkh address to scriptPubkey', () => {
-//     const scriptPubkey = addressToScriptPubkey({
-//       address: 'btg1qkwnu2phwvard2spr2n0a9d84x590ahywl3yacu',
-//       network: NetworkEnum.Mainnet,
-//       coin: 'decred',
-//     })
-//     expect(scriptPubkey).to.equal(
-//       '0014b3a7c506ee6746d5402354dfd2b4f5350afedc8e'
-//     )
-//   })
-// })
+describe('decred guess script pubkeys from address', () => {
+  it('p2pkh address to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'DsmaYBuL9cgEswnx4KjeLQC2uAWUdRyVXhg',
+      network: NetworkEnum.Mainnet,
+      coin: 'decred',
+    })
+    expect(scriptPubkey).to.equal(
+      '76a914e21fb547704ff606ba769b9d6d7985f4cca760f788ac'
+    )
+    const address = scriptPubkeyToAddress({
+      scriptPubkey: scriptPubkey,
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2pkh,
+      coin: 'decred',
+    })
+    expect(address).to.equal('DsmaYBuL9cgEswnx4KjeLQC2uAWUdRyVXhg')
+  })
+  it('p2sh address to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'DcbpczkMzqtYozqrX7vHcFQmCF5wqsW2hYW',
+      network: NetworkEnum.Mainnet,
+      coin: 'decred',
+    })
+    expect(scriptPubkey).to.equal(
+      'a9142fdadae8827ecedb668946c073ebbb0482820c6387'
+    )
+    const address = scriptPubkeyToAddress({
+      scriptPubkey: scriptPubkey,
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2sh,
+      coin: 'decred',
+    })
+    expect(address).to.equal('DcbpczkMzqtYozqrX7vHcFQmCF5wqsW2hYW')
+  })
+})

--- a/test/decredkeymanager-test.ts
+++ b/test/decredkeymanager-test.ts
@@ -1,77 +1,77 @@
-// import { expect } from 'chai'
-// import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
 
-// import {
-//   addressToScriptPubkey,
-//   AddressTypeEnum,
-//   BIP43PurposeTypeEnum,
-//   mnemonicToXPriv,
-//   NetworkEnum,
-//   privateKeyToWIF,
-//   pubkeyToScriptPubkey,
-//   scriptPubkeyToAddress,
-//   wifToPrivateKey,
-//   xprivToXPub,
-//   xpubToPubkey
-// } from '../src/common/utxobased/keymanager/keymanager'
+import {
+  // addressToScriptPubkey,
+  // AddressTypeEnum,
+  BIP43PurposeTypeEnum,
+  mnemonicToXPriv,
+  NetworkEnum,
+  // privateKeyToWIF,
+  // pubkeyToScriptPubkey,
+  // scriptPubkeyToAddress,
+  // wifToPrivateKey,
+  xprivToXPub,
+  // xpubToPubkey,
+} from '../src/common/utxobased/keymanager/keymanager'
 
-// describe('decred mnemonic to xprv test vectors as compared with iancoleman', () => {
-//   const mnemonic =
-//     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
-//   it('bip44 mnemonic to xpriv mainnet', () => {
-//     const resultLegacy = mnemonicToXPriv({
-//       mnemonic: mnemonic,
-//       path: "m/44'/156'/0'",
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'decred'
-//     })
-//     expect(resultLegacy).to.equal(
-//       'xprv9xwq8XoNMYibm1tgqx9MknBEhV2piDRtYrVLdbRFHaQiYc8Y3yxhWVBui2Pcw6GK1GjhMMsY9qnJAAFEW5QhvvQP8wCyBRMnnGCSADhBBY5'
-//     )
-//   })
+describe('decred mnemonic to xprv test vectors as compared with iancoleman', () => {
+  const mnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+  it('bip44 mnemonic to xpriv mainnet', () => {
+    const resultLegacy = mnemonicToXPriv({
+      mnemonic: mnemonic,
+      path: "m/44'/156'/0'",
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'decred',
+    })
+    expect(resultLegacy).to.equal(
+      'dprv3o8pLs3xWbQUcPFT19CVo7NgS6GKpRbR9ib9m6RR5TEzXhfCFUq1hHhHK7BUxqqpG7WP7KYuRH3rMibWqqYSnSRxeUxv57oXdV1BmJ6Qw5Y'
+    )
+  })
 
-//   it('bip44 mnemonic to xpriv testnet', () => {
-//     const resultLegacyTestnet = mnemonicToXPriv({
-//       mnemonic: mnemonic,
-//       path: "m/44'/1'/0'",
-//       network: NetworkEnum.Testnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'decred'
-//     })
-//     expect(resultLegacyTestnet).to.equal(
-//       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
-//     )
-//   })
-// })
+  it('bip44 mnemonic to xpriv testnet', () => {
+    const resultLegacyTestnet = mnemonicToXPriv({
+      mnemonic: mnemonic,
+      path: "m/44'/1'/0'",
+      network: NetworkEnum.Testnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'decred',
+    })
+    expect(resultLegacyTestnet).to.equal(
+      'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
+    )
+  })
+})
 
-// describe('decred bip32 prefix tests for the conversion from xpriv to xpub', () => {
-//   it('bip44 xpriv to xpub mainnet', () => {
-//     const resultLegacy = xprivToXPub({
-//       xpriv:
-//         'xprv9xwq8XoNMYibm1tgqx9MknBEhV2piDRtYrVLdbRFHaQiYc8Y3yxhWVBui2Pcw6GK1GjhMMsY9qnJAAFEW5QhvvQP8wCyBRMnnGCSADhBBY5',
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'decred'
-//     })
-//     expect(resultLegacy).to.equals(
-//       'xpub6BwBY3LGBvGtyVy9wygN7v7yFWsK7g9jv5QwRyprquwhRQTgbXGx4HWPZHRnF5ueji94Dztce4k3RJnt2ir3xWBS7y6bDk8ryS8vKXyoYPL'
-//     )
-//   })
+describe('decred bip32 prefix tests for the conversion from xpriv to xpub', () => {
+  it('bip44 xpriv to xpub mainnet', () => {
+    const resultLegacy = xprivToXPub({
+      xpriv:
+        'dprv3o8pLs3xWbQUcPFT19CVo7NgS6GKpRbR9ib9m6RR5TEzXhfCFUq1hHhHK7BUxqqpG7WP7KYuRH3rMibWqqYSnSRxeUxv57oXdV1BmJ6Qw5Y',
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'decred',
+    })
+    expect(resultLegacy).to.equals(
+      'dpubZEvuhzcFayUGWo9DFfFrKLAw46pbFNBVMGDUW1Mn5XqdFFgq8SAcmsDJTotAMMkqgQvGRtARQUzaYAvdT4zy7YwomLzYC8KLW6KdBqP9nsC'
+    )
+  })
 
-//   it('bip44 xpriv to xpub testnet', () => {
-//     const resultLegacyTestnet = xprivToXPub({
-//       xpriv:
-//         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
-//       network: NetworkEnum.Testnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'decred'
-//     })
-//     expect(resultLegacyTestnet).to.equals(
-//       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
-//     )
-//   })
-// })
+  it('bip44 xpriv to xpub testnet', () => {
+    const resultLegacyTestnet = xprivToXPub({
+      xpriv:
+        'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
+      network: NetworkEnum.Testnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'decred',
+    })
+    expect(resultLegacyTestnet).to.equals(
+      'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
+    )
+  })
+})
 
 // describe('decred xpub to address tests;  generate valid addresses by calling xpubToPubkey, pubkeyToScriptPubkey and scriptPubkeyToAddress', () => {
 //   /*
@@ -87,25 +87,25 @@
 //       type: BIP43PurposeTypeEnum.Legacy,
 //       bip44ChangeIndex: 0,
 //       bip44AddressIndex: 0,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
 //       pubkey: pubkeyP2PKH,
-//       addressType: AddressTypeEnum.p2pkh
+//       addressType: AddressTypeEnum.p2pkh,
 //     }).scriptPubkey
 
 //     const p2pkhAddress = scriptPubkeyToAddress({
 //       scriptPubkey: scriptPubkeyP2PKH,
 //       network: NetworkEnum.Mainnet,
 //       addressType: AddressTypeEnum.p2pkh,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     expect(p2pkhAddress).to.equals('GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9')
 //     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
 //       address: 'GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9',
 //       network: NetworkEnum.Mainnet,
 //       addressType: AddressTypeEnum.p2pkh,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
 //   })
@@ -118,24 +118,24 @@
 //       type: BIP43PurposeTypeEnum.WrappedSegwit,
 //       bip44ChangeIndex: 0,
 //       bip44AddressIndex: 0,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
 //       pubkey: pubkeyP2WPKHP2SH,
-//       addressType: AddressTypeEnum.p2wpkhp2sh
+//       addressType: AddressTypeEnum.p2wpkhp2sh,
 //     }).scriptPubkey
 //     const p2wpkhp2shAddress = scriptPubkeyToAddress({
 //       scriptPubkey: scriptPubkeyP2WPKHP2SH,
 //       network: NetworkEnum.Mainnet,
 //       addressType: AddressTypeEnum.p2wpkhp2sh,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     expect(p2wpkhp2shAddress).to.equals('AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn')
 //     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
 //       address: 'AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn',
 //       network: NetworkEnum.Mainnet,
 //       addressType: AddressTypeEnum.p2wpkhp2sh,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
 //   })
@@ -148,17 +148,17 @@
 //       type: BIP43PurposeTypeEnum.Segwit,
 //       bip44ChangeIndex: 0,
 //       bip44AddressIndex: 0,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
 //       pubkey: pubkeyP2WPKH,
-//       addressType: AddressTypeEnum.p2wpkh
+//       addressType: AddressTypeEnum.p2wpkh,
 //     }).scriptPubkey
 //     const p2wpkhAddress = scriptPubkeyToAddress({
 //       scriptPubkey: scriptPubkeyP2WPKH,
 //       network: NetworkEnum.Mainnet,
 //       addressType: AddressTypeEnum.p2wpkh,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     expect(p2wpkhAddress).to.equals(
 //       'btg1qkwnu2phwvard2spr2n0a9d84x590ahywl3yacu'
@@ -167,7 +167,7 @@
 //       address: 'btg1qkwnu2phwvard2spr2n0a9d84x590ahywl3yacu',
 //       network: NetworkEnum.Mainnet,
 //       addressType: AddressTypeEnum.p2wpkh,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
 //   })
@@ -175,16 +175,17 @@
 
 // describe('decred from WIF to private key to WIF', () => {
 //   it('take a wif private key', () => {
-//     const wifKey = 'L4gU3tKvsS3XQ5eJXDARFEnMyoCvE8vsoYBngMAJESexY5yHsdkJ'
+//     console.log('PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W')
+//     const wifKey = 'PmQhFGVRUjeRmGBPJCW2FCXFck1EoDBF6hks6auNJVQ26M4h73W9W'
 //     const privateKey = wifToPrivateKey({
 //       wifKey,
 //       network: NetworkEnum.Mainnet,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     const wifKeyRoundTrip = privateKeyToWIF({
 //       privateKey: privateKey,
 //       network: NetworkEnum.Mainnet,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     expect(wifKey).to.be.equal(wifKeyRoundTrip)
 //   })
@@ -196,7 +197,7 @@
 //     const scriptPubkey = addressToScriptPubkey({
 //       address: 'GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9',
 //       network: NetworkEnum.Mainnet,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     expect(scriptPubkey).to.equal(
 //       '76a914e21fb547704ff606ba769b9d6d7985f4cca760f788ac'
@@ -206,7 +207,7 @@
 //     const scriptPubkey = addressToScriptPubkey({
 //       address: 'AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn',
 //       network: NetworkEnum.Mainnet,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     expect(scriptPubkey).to.equal(
 //       'a9142fdadae8827ecedb668946c073ebbb0482820c6387'
@@ -217,7 +218,7 @@
 //     const scriptPubkey = addressToScriptPubkey({
 //       address: 'btg1qkwnu2phwvard2spr2n0a9d84x590ahywl3yacu',
 //       network: NetworkEnum.Mainnet,
-//       coin: 'decred'
+//       coin: 'decred',
 //     })
 //     expect(scriptPubkey).to.equal(
 //       '0014b3a7c506ee6746d5402354dfd2b4f5350afedc8e'

--- a/test/digibytekeymanager-test.ts
+++ b/test/digibytekeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('digibyte mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +25,7 @@ describe('digibyte mnemonic to xprv test vectors as compared with iancoleman', (
       path: "m/44'/20'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(resultLegacy).to.equal(
       'xprv9yjgD7qdk99UwHsGUwGeqAy1QpKrYUPuZsb2ApTfE8cv4Nuij5G7HcnCMaxPU1m4bADnR4kqHnJsvW9LHvUcoLcmKLYLzjd3FGJr1CxdxWy'
@@ -37,7 +38,7 @@ describe('digibyte mnemonic to xprv test vectors as compared with iancoleman', (
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +53,7 @@ describe('digibyte bip32 prefix tests for the conversion from xpriv to xpub', ()
         'xprv9yjgD7qdk99UwHsGUwGeqAy1QpKrYUPuZsb2ApTfE8cv4Nuij5G7HcnCMaxPU1m4bADnR4kqHnJsvW9LHvUcoLcmKLYLzjd3FGJr1CxdxWy',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(resultLegacy).to.equals(
       'xpub6Cj2cdNXaWhn9mwjaxofCJujxrALww7kw6WcyCsGnU9twBEsGcaMqR6gCtQ9b3k6awqL2egNaat2btUCVoETYzcmngU9outdn6RA2KxmNEn'
@@ -65,7 +66,7 @@ describe('digibyte bip32 prefix tests for the conversion from xpriv to xpub', ()
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,25 +88,25 @@ describe('digibyte xpub to address tests;  generate valid addresses by calling x
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(p2pkhAddress).to.equals('DG1KhhBKpsyWXTakHNezaDQ34focsXjN1i')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'DG1KhhBKpsyWXTakHNezaDQ34focsXjN1i',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -118,24 +119,24 @@ describe('digibyte xpub to address tests;  generate valid addresses by calling x
       type: BIP43PurposeTypeEnum.WrappedSegwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKHP2SH,
-      addressType: AddressTypeEnum.p2wpkhp2sh
+      scriptType: ScriptTypeEnum.p2wpkhp2sh,
     }).scriptPubkey
     const p2wpkhp2shAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKHP2SH,
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'digibyte'
+      addressType: AddressTypeEnum.p2sh,
+      coin: 'digibyte',
     })
     expect(p2wpkhp2shAddress).to.equals('SQ9EXABrHztGgefL9aH3FyeRjowdjtLfn4')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: 'SQ9EXABrHztGgefL9aH3FyeRjowdjtLfn4',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'digibyte'
+      addressType: AddressTypeEnum.p2sh,
+      coin: 'digibyte',
     })
     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
   })
@@ -148,17 +149,17 @@ describe('digibyte xpub to address tests;  generate valid addresses by calling x
       type: BIP43PurposeTypeEnum.Segwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKH,
-      addressType: AddressTypeEnum.p2wpkh
+      scriptType: ScriptTypeEnum.p2wpkh,
     }).scriptPubkey
     const p2wpkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(p2wpkhAddress).to.equals(
       'dgb1q9gmf0pv8jdymcly6lz6fl7lf6mhslsd72e2jq8'
@@ -167,7 +168,7 @@ describe('digibyte xpub to address tests;  generate valid addresses by calling x
       address: 'dgb1q9gmf0pv8jdymcly6lz6fl7lf6mhslsd72e2jq8',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
   })
@@ -179,12 +180,12 @@ describe('digibyte from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -196,7 +197,7 @@ describe('digibyte guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'DG1KhhBKpsyWXTakHNezaDQ34focsXjN1i',
       network: NetworkEnum.Mainnet,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(scriptPubkey).to.equal(
       '76a91477310b27af676f9663881f649860a327d28777be88ac'
@@ -206,7 +207,7 @@ describe('digibyte guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'SQ9EXABrHztGgefL9aH3FyeRjowdjtLfn4',
       network: NetworkEnum.Mainnet,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(scriptPubkey).to.equal(
       'a9141f3fe4a26b7d41be615d020c177c20882a2d95d287'
@@ -217,7 +218,7 @@ describe('digibyte guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'dgb1q9gmf0pv8jdymcly6lz6fl7lf6mhslsd72e2jq8',
       network: NetworkEnum.Mainnet,
-      coin: 'digibyte'
+      coin: 'digibyte',
     })
     expect(scriptPubkey).to.equal(
       '00142a369785879349bc7c9af8b49ffbe9d6ef0fc1be'

--- a/test/dogecoinkeymanager-test.ts
+++ b/test/dogecoinkeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('dogecoin mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +25,7 @@ describe('dogecoin mnemonic to xprv test vectors as compared with iancoleman', (
       path: "m/44'/3'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'dogecoin'
+      coin: 'dogecoin',
     })
     expect(resultLegacy).to.equal(
       'dgpv57bftCH9z6cEAdAY9SCDV9NfVsygaQWdi5LuCXdumz5qUPWnw1S3YBM7PdHXMvA8oSGS6Pbes1xEHMd5Zi2qHVK45y5FKKXzBXsZcTtYmX5'
@@ -37,7 +38,7 @@ describe('dogecoin mnemonic to xprv test vectors as compared with iancoleman', (
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'dogecoin'
+      coin: 'dogecoin',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +53,7 @@ describe('dogecoin bip32 prefix tests for the conversion from xpriv to xpub', ()
         'dgpv57bftCH9z6cEAdAY9SCDV9NfVsygaQWdi5LuCXdumz5qUPWnw1S3YBM7PdHXMvA8oSGS6Pbes1xEHMd5Zi2qHVK45y5FKKXzBXsZcTtYmX5',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'dogecoin'
+      coin: 'dogecoin',
     })
     expect(resultLegacy).to.equals(
       'dgub8rUhDtD3YFGZTUphBfpBbzvFxSMKQXYLzg87Me2ta78r2SdVLmypBUkkxrrn9RTnchsyiJSkHZyLWxD13ibBiXtuFWktBoDaGaZjQUBLNLs'
@@ -65,7 +66,7 @@ describe('dogecoin bip32 prefix tests for the conversion from xpriv to xpub', ()
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'dogecoin'
+      coin: 'dogecoin',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,25 +88,25 @@ describe('dogecoin xpub to address tests;  generate valid addresses by calling x
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'dogecoin'
+      coin: 'dogecoin',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'dogecoin'
+      coin: 'dogecoin',
     })
     expect(p2pkhAddress).to.equals('DBus3bamQjgJULBJtYXpEzDWQRwF5iwxgC')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'DBus3bamQjgJULBJtYXpEzDWQRwF5iwxgC',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'dogecoin'
+      coin: 'dogecoin',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -117,12 +118,12 @@ describe('dogecoin from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'dogecoin'
+      coin: 'dogecoin',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'dogecoin'
+      coin: 'dogecoin',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -134,7 +135,7 @@ describe('dogecoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'DBus3bamQjgJULBJtYXpEzDWQRwF5iwxgC',
       network: NetworkEnum.Mainnet,
-      coin: 'dogecoin'
+      coin: 'dogecoin',
     })
     expect(scriptPubkey).to.equal(
       '76a9144a483568665dcdfa68dd58a1f62893448a64333988ac'

--- a/test/eboostkeymanager-test.ts
+++ b/test/eboostkeymanager-test.ts
@@ -7,10 +7,12 @@ import {
   BIP43PurposeTypeEnum,
   mnemonicToXPriv,
   NetworkEnum,
+  privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('eboost mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -22,7 +24,7 @@ describe('eboost mnemonic to xprv test vectors as compared with iancoleman', () 
       path: "m/44'/0'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'eboost'
+      coin: 'eboost',
     })
     expect(resultLegacy).to.equal(
       'xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb'
@@ -35,7 +37,7 @@ describe('eboost mnemonic to xprv test vectors as compared with iancoleman', () 
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'eboost'
+      coin: 'eboost',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -50,7 +52,7 @@ describe('eboost bip32 prefix tests for the conversion from xpriv to xpub', () =
         'xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'eboost'
+      coin: 'eboost',
     })
     expect(resultLegacy).to.equals(
       'xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj'
@@ -63,7 +65,7 @@ describe('eboost bip32 prefix tests for the conversion from xpriv to xpub', () =
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'eboost'
+      coin: 'eboost',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -85,25 +87,25 @@ describe('eboost xpub to address tests;  generate valid addresses by calling xpu
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'eboost'
+      coin: 'eboost',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      addressType: AddressTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'eboost'
+      coin: 'eboost',
     })
     expect(p2pkhAddress).to.equals('eMvfrRkQqgc9igciD3j9tCrrmw2KzJ2yu4')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'eMvfrRkQqgc9igciD3j9tCrrmw2KzJ2yu4',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'eboost'
+      coin: 'eboost',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -115,10 +117,27 @@ describe('eboost guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'eMvfrRkQqgc9igciD3j9tCrrmw2KzJ2yu4',
       network: NetworkEnum.Mainnet,
-      coin: 'eboost'
+      coin: 'eboost',
     })
     expect(scriptPubkey).to.equal(
       '76a914d986ed01b7a22225a70edbf2ba7cfb63a15cb3aa88ac'
     )
+  })
+})
+
+describe('eboost from WIF to private key to WIF', () => {
+  it('take a wif private key', () => {
+    const wifKey = 'ZcSgeybBZAQ7y7eFUEfPk6ZDA2843QMAJBvEfFMvyQfi8HsHfgEq'
+    const privateKey = wifToPrivateKey({
+      wifKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'eboost',
+    })
+    const wifKeyRoundTrip = privateKeyToWIF({
+      privateKey: privateKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'eboost',
+    })
+    expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
 })

--- a/test/eboostkeymanager-test.ts
+++ b/test/eboostkeymanager-test.ts
@@ -10,6 +10,7 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -91,7 +92,7 @@ describe('eboost xpub to address tests;  generate valid addresses by calling xpu
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh,
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({

--- a/test/feathercoinkeymanager-test.ts
+++ b/test/feathercoinkeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('feathercoin mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +25,7 @@ describe('feathercoin mnemonic to xprv test vectors as compared with iancoleman'
       path: "m/44'/8'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(resultLegacy).to.equal(
       'xqMPAtc6rF1XptQ6QavaQ5fNyJkDgrZ3BLW4qwzMiDKmnRV4jWoDQHFdCzFMCJfXvxNtVcMW3rdD2FGVd54ygV72BVHNDMkr3k1HE3dE6NdQwc8'
@@ -37,7 +38,7 @@ describe('feathercoin mnemonic to xprv test vectors as compared with iancoleman'
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +53,7 @@ describe('feathercoin bip32 prefix tests for the conversion from xpriv to xpub',
         'xqMPAtc6rF1XptQ6QavaQ5fNyJkDgrZ3BLW4qwzMiDKmnRV4jWoDQHFdCzFMCJfXvxNtVcMW3rdD2FGVd54ygV72BVHNDMkr3k1HE3dE6NdQwc8',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(resultLegacy).to.equals(
       'xq1vow2yefS81cbgEiWByGtkSSpvaKbitriBYioqhEvBRmRnoHaozKGHmnJCkisCuwv1NebnzGWLsuPwjZZABdb8f42MtkJqekEzqo7q7hUCpvB'
@@ -65,7 +66,7 @@ describe('feathercoin bip32 prefix tests for the conversion from xpriv to xpub',
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,25 +88,25 @@ describe('feathercoin xpub to address tests;  generate valid addresses by callin
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(p2pkhAddress).to.equals('6foXhTEUMC85RAhkPS2MfoxD6oS69x4rBS')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: '6foXhTEUMC85RAhkPS2MfoxD6oS69x4rBS',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -118,24 +119,24 @@ describe('feathercoin xpub to address tests;  generate valid addresses by callin
       type: BIP43PurposeTypeEnum.WrappedSegwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKHP2SH,
-      addressType: AddressTypeEnum.p2wpkhp2sh
+      scriptType: ScriptTypeEnum.p2wpkhp2sh,
     }).scriptPubkey
     const p2wpkhp2shAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKHP2SH,
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'feathercoin'
+      addressType: AddressTypeEnum.p2sh,
+      coin: 'feathercoin',
     })
     expect(p2wpkhp2shAddress).to.equals('3643rsxfbpSKJ25TkJQo66HtAXqf2hGP3i')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: '3643rsxfbpSKJ25TkJQo66HtAXqf2hGP3i',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'feathercoin'
+      addressType: AddressTypeEnum.p2sh,
+      coin: 'feathercoin',
     })
     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
   })
@@ -148,17 +149,17 @@ describe('feathercoin xpub to address tests;  generate valid addresses by callin
       type: BIP43PurposeTypeEnum.Segwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKH,
-      addressType: AddressTypeEnum.p2wpkh
+      scriptType: ScriptTypeEnum.p2wpkh,
     }).scriptPubkey
     const p2wpkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(p2wpkhAddress).to.equals(
       'fc1qkwnu2phwvard2spr2n0a9d84x590ahywnuszd4'
@@ -167,7 +168,7 @@ describe('feathercoin xpub to address tests;  generate valid addresses by callin
       address: 'fc1qkwnu2phwvard2spr2n0a9d84x590ahywnuszd4',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
   })
@@ -179,12 +180,12 @@ describe('feathercoin from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -196,7 +197,7 @@ describe('feathercoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: '6foXhTEUMC85RAhkPS2MfoxD6oS69x4rBS',
       network: NetworkEnum.Mainnet,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(scriptPubkey).to.equal(
       '76a91416b60429ed63dedf0d83d004bc4464130ee4cefb88ac'
@@ -206,7 +207,7 @@ describe('feathercoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: '3643rsxfbpSKJ25TkJQo66HtAXqf2hGP3i',
       network: NetworkEnum.Mainnet,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(scriptPubkey).to.equal(
       'a9142fdadae8827ecedb668946c073ebbb0482820c6387'
@@ -217,7 +218,7 @@ describe('feathercoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'fc1qkwnu2phwvard2spr2n0a9d84x590ahywnuszd4',
       network: NetworkEnum.Mainnet,
-      coin: 'feathercoin'
+      coin: 'feathercoin',
     })
     expect(scriptPubkey).to.equal(
       '0014b3a7c506ee6746d5402354dfd2b4f5350afedc8e'

--- a/test/groestlcoinkeymanager-test.ts
+++ b/test/groestlcoinkeymanager-test.ts
@@ -1,226 +1,305 @@
-// import { expect } from 'chai'
-// import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
 
-// import {
-//   addressToScriptPubkey,
-//   AddressTypeEnum,
-//   BIP43PurposeTypeEnum,
-//   mnemonicToXPriv,
-//   NetworkEnum,
-//   privateKeyToWIF,
-//   pubkeyToScriptPubkey,
-//   scriptPubkeyToAddress,
-//   wifToPrivateKey,
-//   xprivToXPub,
-//   xpubToPubkey
-// } from '../src/common/utxobased/keymanager/keymanager'
+import {
+  addressToScriptPubkey,
+  AddressTypeEnum,
+  BIP43PurposeTypeEnum,
+  createTx,
+  mnemonicToXPriv,
+  NetworkEnum,
+  privateKeyToPubkey,
+  privateKeyToWIF,
+  pubkeyToScriptPubkey,
+  scriptPubkeyToAddress,
+  signTx,
+  TransactionInputTypeEnum,
+  wifToPrivateKey,
+  xprivToPrivateKey,
+  xprivToXPub,
+  xpubToPubkey,
+} from '../src/common/utxobased/keymanager/keymanager'
 
-// describe('groestlcoin mnemonic to xprv test vectors as compared with iancoleman', () => {
-//   const mnemonic =
-//     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
-//   it('bip44 mnemonic to xpriv mainnet', () => {
-//     const resultLegacy = mnemonicToXPriv({
-//       mnemonic: mnemonic,
-//       path: "m/44'/17'/0'",
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'groestlcoin'
-//     })
-//     expect(resultLegacy).to.equal(
-//       'xprv9zG5s8VhyRCaktqFMWHHkaxX1XdgDsD2GjX31daogFTCcer54yTtWroAXRAHZV6GuuiTSUfNheduV4i8rJEJ45QGcCrfKyCwmbD4zaLp9Y7'
-//     )
-//   })
+describe('groestlcoin mnemonic to xprv test vectors as compared with iancoleman', () => {
+  const mnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+  it('bip44 mnemonic to xpriv mainnet', () => {
+    const resultLegacy = mnemonicToXPriv({
+      mnemonic: mnemonic,
+      path: "m/44'/17'/0'",
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'groestlcoin',
+    })
+    expect(resultLegacy).to.equal(
+      'xprv9zG5s8VhyRCaktqFMWHHkaxX1XdgDsD2GjX31daogFTCcer54yTtWroAXRAHZV6GuuiTSUfNheduV4i8rJEJ45QGcCrfKyCwmbD4zaLp9Y7'
+    )
+  })
 
-//   it('bip44 mnemonic to xpriv testnet', () => {
-//     const resultLegacyTestnet = mnemonicToXPriv({
-//       mnemonic: mnemonic,
-//       path: "m/44'/1'/0'",
-//       network: NetworkEnum.Testnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'groestlcoin'
-//     })
-//     expect(resultLegacyTestnet).to.equal(
-//       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
-//     )
-//   })
-// })
+  it('bip44 mnemonic to xpriv testnet', () => {
+    const resultLegacyTestnet = mnemonicToXPriv({
+      mnemonic: mnemonic,
+      path: "m/44'/1'/0'",
+      network: NetworkEnum.Testnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'groestlcoin',
+    })
+    expect(resultLegacyTestnet).to.equal(
+      'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JDr5AGu'
+    )
+  })
+})
 
-// describe('groestlcoin bip32 prefix tests for the conversion from xpriv to xpub', () => {
-//   it('bip44 xpriv to xpub mainnet', () => {
-//     const resultLegacy = xprivToXPub({
-//       xpriv:
-//         'xprv9zG5s8VhyRCaktqFMWHHkaxX1XdgDsD2GjX31daogFTCcer54yTtWroAXRAHZV6GuuiTSUfNheduV4i8rJEJ45QGcCrfKyCwmbD4zaLp9Y7',
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'groestlcoin'
-//     })
-//     expect(resultLegacy).to.equals(
-//       'xpub6DFSGe2bonksyNuiTXpJ7iuFZZUAdKvsdxSdp1zREazBVTBDcWn94f7eNg5MN148WHsaUfG3Mmmqa6nBi1VCde1t7wM3NA3993CcjChk1g5'
-//     )
-//   })
+describe('groestlcoin bip32 prefix tests for the conversion from xpriv to xpub', () => {
+  it('bip44 xpriv to xpub mainnet', () => {
+    const resultLegacy = xprivToXPub({
+      xpriv:
+        'xprv9zG5s8VhyRCaktqFMWHHkaxX1XdgDsD2GjX31daogFTCcer54yTtWroAXRAHZV6GuuiTSUfNheduV4i8rJEJ45QGcCrfKyCwmbD4zaLp9Y7',
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'groestlcoin',
+    })
+    expect(resultLegacy).to.equals(
+      'xpub6DFSGe2bonksyNuiTXpJ7iuFZZUAdKvsdxSdp1zREazBVTBDcWn94f7eNg5MN148WHsaUfG3Mmmqa6nBi1VCde1t7wM3NA3993CcjChk1g5'
+    )
+  })
 
-//   it('bip44 xpriv to xpub testnet', () => {
-//     const resultLegacyTestnet = xprivToXPub({
-//       xpriv:
-//         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
-//       network: NetworkEnum.Testnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'groestlcoin'
-//     })
-//     expect(resultLegacyTestnet).to.equals(
-//       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
-//     )
-//   })
-// })
+  it('bip44 xpriv to xpub testnet', () => {
+    const resultLegacyTestnet = xprivToXPub({
+      xpriv:
+        'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JDr5AGu',
+      network: NetworkEnum.Testnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'groestlcoin',
+    })
+    expect(resultLegacyTestnet).to.equals(
+      'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCaq6qME'
+    )
+  })
+})
 
-// describe('groestlcoin xpub to address tests;  generate valid addresses by calling xpubToPubkey, pubkeyToScriptPubkey and scriptPubkeyToAddress', () => {
-//   /*
-//     These methods were cross verified using ian colemans bip32 website https://iancoleman.io/bip39/
-//     using the same seed as in other tests (abandon, ...)
-//     */
+describe('groestlcoin xpub to address tests;  generate valid addresses by calling xpubToPubkey, pubkeyToScriptPubkey and scriptPubkeyToAddress', () => {
+  /*
+    These methods were cross verified using ian colemans bip32 website https://iancoleman.io/bip39/
+    using the same seed as in other tests (abandon, ...)
+    */
 
-//   it('given an xpub, generate p2pkh address and cross verify script pubkey result', () => {
-//     const pubkeyP2PKH = xpubToPubkey({
-//       xpub:
-//         'xpub6DFSGe2bonksyNuiTXpJ7iuFZZUAdKvsdxSdp1zREazBVTBDcWn94f7eNg5MN148WHsaUfG3Mmmqa6nBi1VCde1t7wM3NA3993CcjChk1g5',
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       bip44ChangeIndex: 0,
-//       bip44AddressIndex: 0,
-//       coin: 'groestlcoin'
-//     })
-//     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
-//       pubkey: pubkeyP2PKH,
-//       addressType: AddressTypeEnum.p2pkh
-//     }).scriptPubkey
+  it('given an xpub, generate p2pkh address and cross verify script pubkey result', () => {
+    const pubkeyP2PKH = xpubToPubkey({
+      xpub:
+        'xpub6DFSGe2bonksyNuiTXpJ7iuFZZUAdKvsdxSdp1zREazBVTBDcWn94f7eNg5MN148WHsaUfG3Mmmqa6nBi1VCde1t7wM3NA3993CcjChk1g5',
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      bip44ChangeIndex: 0,
+      bip44AddressIndex: 0,
+      coin: 'groestlcoin',
+    })
+    const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
+      pubkey: pubkeyP2PKH,
+      addressType: AddressTypeEnum.p2pkh,
+    }).scriptPubkey
 
-//     const p2pkhAddress = scriptPubkeyToAddress({
-//       scriptPubkey: scriptPubkeyP2PKH,
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2pkh,
-//       coin: 'groestlcoin'
-//     })
-//     expect(p2pkhAddress).to.equals('Fpzstx4fKWhqZYbVVmuncuhbEmgecqPTgg')
-//     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
-//       address: 'Fpzstx4fKWhqZYbVVmuncuhbEmgecqPTgg',
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2pkh,
-//       coin: 'groestlcoin'
-//     })
-//     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
-//   })
+    const p2pkhAddress = scriptPubkeyToAddress({
+      scriptPubkey: scriptPubkeyP2PKH,
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2pkh,
+      coin: 'groestlcoin',
+    })
+    expect(p2pkhAddress).to.equals('Fpzstx4fKWhqZYbVVmuncuhbEmgecqPTgg')
+    const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
+      address: 'Fpzstx4fKWhqZYbVVmuncuhbEmgecqPTgg',
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2pkh,
+      coin: 'groestlcoin',
+    })
+    expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
+  })
 
-//   it('given an ypub, generate p2wpkh-p2sh address and cross verify script pubkey result', () => {
-//     const pubkeyP2WPKHP2SH = xpubToPubkey({
-//       xpub:
-//         'ypub6X46SconPpL9QhXPnMGuPLB9jYai7nrHz7ki4zq3awHb462iPSG5eV19oBWv22RWt69npsi75XGcANsevtTWE8YFgqpygrGUPnEKp6vty5v',
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.WrappedSegwit,
-//       bip44ChangeIndex: 0,
-//       bip44AddressIndex: 0,
-//       coin: 'groestlcoin'
-//     })
-//     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
-//       pubkey: pubkeyP2WPKHP2SH,
-//       addressType: AddressTypeEnum.p2wpkhp2sh
-//     }).scriptPubkey
-//     const p2wpkhp2shAddress = scriptPubkeyToAddress({
-//       scriptPubkey: scriptPubkeyP2WPKHP2SH,
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2wpkhp2sh,
-//       coin: 'groestlcoin'
-//     })
-//     expect(p2wpkhp2shAddress).to.equals('3299Qf2x9BnzLaZu4HCLvm26RbBB3ZRf4u')
-//     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
-//       address: '3299Qf2x9BnzLaZu4HCLvm26RbBB3ZRf4u',
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2wpkhp2sh,
-//       coin: 'groestlcoin'
-//     })
-//     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
-//   })
+  it('given an ypub, generate p2wpkh-p2sh address and cross verify script pubkey result', () => {
+    const pubkeyP2WPKHP2SH = xpubToPubkey({
+      xpub:
+        'ypub6X46SconPpL9QhXPnMGuPLB9jYai7nrHz7ki4zq3awHb462iPSG5eV19oBWv22RWt69npsi75XGcANsevtTWE8YFgqpygrGUPnEKp6vty5v',
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.WrappedSegwit,
+      bip44ChangeIndex: 0,
+      bip44AddressIndex: 0,
+      coin: 'groestlcoin',
+    })
+    const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
+      pubkey: pubkeyP2WPKHP2SH,
+      addressType: AddressTypeEnum.p2wpkhp2sh,
+    }).scriptPubkey
+    const p2wpkhp2shAddress = scriptPubkeyToAddress({
+      scriptPubkey: scriptPubkeyP2WPKHP2SH,
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2wpkhp2sh,
+      coin: 'groestlcoin',
+    })
+    expect(p2wpkhp2shAddress).to.equals('3299Qf2x9BnzLaZu4HCLvm26RbBB3ZRf4u')
+    const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
+      address: '3299Qf2x9BnzLaZu4HCLvm26RbBB3ZRf4u',
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2wpkhp2sh,
+      coin: 'groestlcoin',
+    })
+    expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
+  })
 
-//   it('given a zpub, generate p2wpkh address and cross verify script pubkey result', () => {
-//     const pubkeyP2WPKH = xpubToPubkey({
-//       xpub:
-//         'zpub6qdhcNVVLJ2t8kLzGLzeaiJv7EahaRBsXmu1yVPyXHvMdFmS4d7JSi5aS6mc1oz5k6DZN781Ffn3GAs3r2FJnCPSw5nti63s3c9EDg2u7MS',
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.Segwit,
-//       bip44ChangeIndex: 0,
-//       bip44AddressIndex: 0,
-//       coin: 'groestlcoin'
-//     })
-//     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
-//       pubkey: pubkeyP2WPKH,
-//       addressType: AddressTypeEnum.p2wpkh
-//     }).scriptPubkey
-//     const p2wpkhAddress = scriptPubkeyToAddress({
-//       scriptPubkey: scriptPubkeyP2WPKH,
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2wpkh,
-//       coin: 'groestlcoin'
-//     })
-//     expect(p2wpkhAddress).to.equals(
-//       'grs1qrm2uggqj846nljryvmuga56vtwfey0dtnc4z55'
-//     )
-//     const scriptPubkeyP2WPKHRoundTrip = addressToScriptPubkey({
-//       address: 'grs1qrm2uggqj846nljryvmuga56vtwfey0dtnc4z55',
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2wpkh,
-//       coin: 'groestlcoin'
-//     })
-//     expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
-//   })
-// })
+  it('given a zpub, generate p2wpkh address and cross verify script pubkey result', () => {
+    const pubkeyP2WPKH = xpubToPubkey({
+      xpub:
+        'zpub6qdhcNVVLJ2t8kLzGLzeaiJv7EahaRBsXmu1yVPyXHvMdFmS4d7JSi5aS6mc1oz5k6DZN781Ffn3GAs3r2FJnCPSw5nti63s3c9EDg2u7MS',
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Segwit,
+      bip44ChangeIndex: 0,
+      bip44AddressIndex: 0,
+      coin: 'groestlcoin',
+    })
+    const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
+      pubkey: pubkeyP2WPKH,
+      addressType: AddressTypeEnum.p2wpkh,
+    }).scriptPubkey
+    const p2wpkhAddress = scriptPubkeyToAddress({
+      scriptPubkey: scriptPubkeyP2WPKH,
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2wpkh,
+      coin: 'groestlcoin',
+    })
+    expect(p2wpkhAddress).to.equals(
+      'grs1qrm2uggqj846nljryvmuga56vtwfey0dtnc4z55'
+    )
+    const scriptPubkeyP2WPKHRoundTrip = addressToScriptPubkey({
+      address: 'grs1qrm2uggqj846nljryvmuga56vtwfey0dtnc4z55',
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2wpkh,
+      coin: 'groestlcoin',
+    })
+    expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
+  })
+})
 
-// describe('groestlcoin from WIF to private key to WIF', () => {
-//   it('take a wif private key', () => {
-//     const wifKey = 'KyeNA49yfj4JDoMEWtpQiosP6eig55att3cTv6NBXCeFNsHoNnyM'
-//     const privateKey = wifToPrivateKey({
-//       wifKey,
-//       network: NetworkEnum.Mainnet,
-//       coin: 'groestlcoin'
-//     })
-//     const wifKeyRoundTrip = privateKeyToWIF({
-//       privateKey: privateKey,
-//       network: NetworkEnum.Mainnet,
-//       coin: 'groestlcoin'
-//     })
-//     expect(wifKey).to.be.equal(wifKeyRoundTrip)
-//   })
-// })
+describe('groestlcoin from XPriv to WIF to private key to WIF', () => {
+  it('take a wif private key', () => {
+    const xpriv =
+      'xprv9zG5s8VhyRCaktqFMWHHkaxX1XdgDsD2GjX31daogFTCcer54yTtWroAXRAHZV6GuuiTSUfNheduV4i8rJEJ45QGcCrfKyCwmbD4zaLp9Y7'
+    const derivedPrivateKey = xprivToPrivateKey({
+      xpriv: xpriv,
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      bip44ChangeIndex: 0,
+      bip44AddressIndex: 0,
+      coin: 'groestlcoin',
+    })
+    const derivedWIFKey = privateKeyToWIF({
+      privateKey: derivedPrivateKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'groestlcoin',
+    })
+    const wifKey = 'KyeNA49yfj4JDoMEWtpQiosP6eig55att3cTv6NBXCeFNsHoNnyM'
+    expect(derivedWIFKey).to.equal(wifKey)
+    const privateKey = wifToPrivateKey({
+      wifKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'groestlcoin',
+    })
+    expect(derivedPrivateKey).to.equal(privateKey)
+    const wifKeyRoundTrip = privateKeyToWIF({
+      privateKey: privateKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'groestlcoin',
+    })
+    expect(wifKey).to.be.equal(wifKeyRoundTrip)
+  })
+})
 
-// describe('groestlcoin guess script pubkeys from address', () => {
-//   // these tests are cross verified with bitcoin core
-//   it('p2pkh address to scriptPubkey', () => {
-//     const scriptPubkey = addressToScriptPubkey({
-//       address: 'Fpzstx4fKWhqZYbVVmuncuhbEmgecqPTgg',
-//       network: NetworkEnum.Mainnet,
-//       coin: 'groestlcoin'
-//     })
-//     expect(scriptPubkey).to.equal(
-//       '76a91477310b27af676f9663881f649860a327d28777be88ac'
-//     )
-//   })
-//   it('p2sh address to scriptPubkey', () => {
-//     const scriptPubkey = addressToScriptPubkey({
-//       address: '3299Qf2x9BnzLaZu4HCLvm26RbBB3ZRf4u',
-//       network: NetworkEnum.Mainnet,
-//       coin: 'groestlcoin'
-//     })
-//     expect(scriptPubkey).to.equal(
-//       'a9141f3fe4a26b7d41be615d020c177c20882a2d95d287'
-//     )
-//   })
+describe('groestlcoin guess script pubkeys from address', () => {
+  // these tests are cross verified with bitcoin core
+  it('p2pkh address to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'Fpzstx4fKWhqZYbVVmuncuhbEmgecqPTgg',
+      network: NetworkEnum.Mainnet,
+      coin: 'groestlcoin',
+    })
+    expect(scriptPubkey).to.equal(
+      '76a914d9863e608009f46ce023c852c7c209a607f8542b88ac'
+    )
+  })
+  it('p2sh address to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: '3299Qf2x9BnzLaZu4HCLvm26RbBB3ZRf4u',
+      network: NetworkEnum.Mainnet,
+      coin: 'groestlcoin',
+    })
+    expect(scriptPubkey).to.equal(
+      'a91404f1101bb0f5ca39c735bf1aa9bc99be571a9f5d87'
+    )
+  })
 
-//   it('p2wpkh address to scriptPubkey', () => {
-//     const scriptPubkey = addressToScriptPubkey({
-//       address: 'grs1qrm2uggqj846nljryvmuga56vtwfey0dtnc4z55',
-//       network: NetworkEnum.Mainnet,
-//       coin: 'groestlcoin'
-//     })
-//     expect(scriptPubkey).to.equal(
-//       '00141ed5c420123d753fc86466f88ed34c5b93923dab'
-//     )
-//   })
-// })
+  it('p2wpkh address to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'grs1qrm2uggqj846nljryvmuga56vtwfey0dtnc4z55',
+      network: NetworkEnum.Mainnet,
+      coin: 'groestlcoin',
+    })
+    expect(scriptPubkey).to.equal(
+      '00141ed5c420123d753fc86466f88ed34c5b93923dab'
+    )
+  })
+})
+
+describe('groestlcoin transaction creation and signing test', () => {
+  // key with control on the unspent output and used to sign the transaction
+  const wifKey = 'KyeNA49yfj4JDoMEWtpQiosP6eig55att3cTv6NBXCeFNsHoNnyM'
+  const privateKey = wifToPrivateKey({
+    wifKey,
+    network: NetworkEnum.Mainnet,
+    coin: 'groestlcoin',
+  })
+  const segwitScriptPubkey: string = pubkeyToScriptPubkey({
+    pubkey: privateKeyToPubkey(privateKey),
+    addressType: AddressTypeEnum.p2wpkh,
+  }).scriptPubkey
+
+  it('Create transaction with one legacy input and one output', () => {
+    /*
+      This here is the rawtransaction as assembled below:
+      0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d9452e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48ca17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc5660209e761da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec631e5e1e66009ce3710ceea5b1ad13ffffffff01905f0100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000
+      The test case deconstructs the value, script pubkey and locktime values to show some deserialized values.
+      This deserialization is not required in the usual form from the caller.
+      It is enough to pass the full previous rawtransaction.
+    */
+    const base64Tx: string = createTx({
+      network: NetworkEnum.Mainnet,
+      rbf: false,
+      inputs: [
+        {
+          type: TransactionInputTypeEnum.Segwit,
+          prevTxid:
+            '7d067b4a697a09d2c3cff7d4d9506c9955e93bff41bf82d439da7d030382bc3e',
+          // prev_tx only for non segwit inputs
+          prevScriptPubkey: segwitScriptPubkey,
+          value: 80000,
+          index: 0,
+        },
+      ],
+      outputs: [
+        {
+          scriptPubkey: addressToScriptPubkey({
+            address: 'Fpzstx4fKWhqZYbVVmuncuhbEmgecqPTgg',
+            network: NetworkEnum.Mainnet,
+            addressType: AddressTypeEnum.p2pkh,
+            coin: 'groestlcoin',
+          }),
+          amount: 80000,
+        },
+      ],
+    }).psbt
+    const hexTxSigned: string = signTx({
+      tx: base64Tx,
+      privateKeys: [privateKey],
+    })
+    expect(hexTxSigned).to.equal(
+      '020000000001013ebc8203037dda39d482bf41ff3be955996c50d9d4f7cfc3d2097a694a7b067d0000000000ffffffff0180380100000000001976a914d9863e608009f46ce023c852c7c209a607f8542b88ac02483045022100aa7a1afa26c637b948f6b08986562b290fae7d5a93f7789886a323582e5ef8b0022051740e97cea1ed65d7a8e75a5a88a47f1472a10905727003ebaa1a0d550995760121030f25e157a5ddc119bf370beb688878a3600461eb5c769a5556bdfe225d9a246e00000000'
+    )
+  })
+})

--- a/test/groestlcoinkeymanager-test.ts
+++ b/test/groestlcoinkeymanager-test.ts
@@ -12,6 +12,7 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   signTx,
   TransactionInputTypeEnum,
   wifToPrivateKey,
@@ -96,7 +97,7 @@ describe('groestlcoin xpub to address tests;  generate valid addresses by callin
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh,
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
@@ -127,19 +128,19 @@ describe('groestlcoin xpub to address tests;  generate valid addresses by callin
     })
     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKHP2SH,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
+      scriptType: ScriptTypeEnum.p2wpkhp2sh,
     }).scriptPubkey
     const p2wpkhp2shAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKHP2SH,
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
+      addressType: AddressTypeEnum.p2sh,
       coin: 'groestlcoin',
     })
     expect(p2wpkhp2shAddress).to.equals('3299Qf2x9BnzLaZu4HCLvm26RbBB3ZRf4u')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: '3299Qf2x9BnzLaZu4HCLvm26RbBB3ZRf4u',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
+      addressType: AddressTypeEnum.p2sh,
       coin: 'groestlcoin',
     })
     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
@@ -157,7 +158,7 @@ describe('groestlcoin xpub to address tests;  generate valid addresses by callin
     })
     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKH,
-      addressType: AddressTypeEnum.p2wpkh,
+      scriptType: ScriptTypeEnum.p2wpkh,
     }).scriptPubkey
     const p2wpkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKH,
@@ -257,7 +258,7 @@ describe('groestlcoin transaction creation and signing test', () => {
   })
   const segwitScriptPubkey: string = pubkeyToScriptPubkey({
     pubkey: privateKeyToPubkey(privateKey),
-    addressType: AddressTypeEnum.p2wpkh,
+    scriptType: ScriptTypeEnum.p2wpkh,
   }).scriptPubkey
 
   it('Create transaction with one legacy input and one output', () => {
@@ -297,9 +298,10 @@ describe('groestlcoin transaction creation and signing test', () => {
     const hexTxSigned: string = signTx({
       tx: base64Tx,
       privateKeys: [privateKey],
+      coin: 'groestlcoin',
     })
     expect(hexTxSigned).to.equal(
-      '020000000001013ebc8203037dda39d482bf41ff3be955996c50d9d4f7cfc3d2097a694a7b067d0000000000ffffffff0180380100000000001976a914d9863e608009f46ce023c852c7c209a607f8542b88ac02483045022100aa7a1afa26c637b948f6b08986562b290fae7d5a93f7789886a323582e5ef8b0022051740e97cea1ed65d7a8e75a5a88a47f1472a10905727003ebaa1a0d550995760121030f25e157a5ddc119bf370beb688878a3600461eb5c769a5556bdfe225d9a246e00000000'
+      '020000000001013ebc8203037dda39d482bf41ff3be955996c50d9d4f7cfc3d2097a694a7b067d0000000000ffffffff0180380100000000001976a914d9863e608009f46ce023c852c7c209a607f8542b88ac024730440220558f35be4edc22260bf98fe197e39aff6bfc3717be853735be837a30bd2a0f4202207b2429dd031e851b82836e24524689c70a8c8bf4be58f9b4be23bf3e76fa577a0121030f25e157a5ddc119bf370beb688878a3600461eb5c769a5556bdfe225d9a246e00000000'
     )
   })
 })

--- a/test/groestlcoinkeymanager-test.ts
+++ b/test/groestlcoinkeymanager-test.ts
@@ -309,7 +309,7 @@ describe('groestlcoin transaction creation and signing test', () => {
       ],
     }).psbt
     const hexTxSigned: string = signTx({
-      tx: base64Tx,
+      psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'groestlcoin',
     })

--- a/test/groestlcoinkeymanager-test.ts
+++ b/test/groestlcoinkeymanager-test.ts
@@ -274,7 +274,7 @@ describe('groestlcoin transaction creation and signing test', () => {
     scriptType: ScriptTypeEnum.p2wpkh,
   }).scriptPubkey
 
-  it('Create transaction with one legacy input and one output', () => {
+  it('Create transaction with one input and one output', () => {
     /*
       This here is the rawtransaction as assembled below:
       0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d9452e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48ca17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc5660209e761da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec631e5e1e66009ce3710ceea5b1ad13ffffffff01905f0100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000

--- a/test/groestlcoinkeymanager-test.ts
+++ b/test/groestlcoinkeymanager-test.ts
@@ -196,6 +196,19 @@ describe('groestlcoin from XPriv to WIF to private key to WIF', () => {
       network: NetworkEnum.Mainnet,
       coin: 'groestlcoin',
     })
+    const wifKey2 = 'L2JewQFXAVSw4zrihJY91G6ZUTL1F8YhcCqXgJTJd1AyCTABCzMD'
+    const privateKey2 = wifToPrivateKey({
+      wifKey: wifKey2,
+      network: NetworkEnum.Mainnet,
+      coin: 'groestlcoin',
+    })
+    const wifKeyRoundTrip2 = privateKeyToWIF({
+      privateKey: privateKey2,
+      network: NetworkEnum.Mainnet,
+      coin: 'groestlcoin',
+    })
+    expect(wifKey2).to.be.equal(wifKeyRoundTrip2)
+
     const wifKey = 'KyeNA49yfj4JDoMEWtpQiosP6eig55att3cTv6NBXCeFNsHoNnyM'
     expect(derivedWIFKey).to.equal(wifKey)
     const privateKey = wifToPrivateKey({

--- a/test/litecoinkeymanager-test.ts
+++ b/test/litecoinkeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 and some generated cases to test xpub prefix bytes', () => {
@@ -24,7 +25,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
       path: "m/84'/2'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Segwit,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultSegwit).to.equal(
       'zprvAdQSgFiAHcXKb1gcktyukXyGZykTBemmPZ9brfYnxqxM2CocMdxy9aPXTbTLv7dvJgWn2Efi4vFSyPbT4QqgarYrs583WCeMXM2q3TUU8FS'
@@ -37,7 +38,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
       path: "m/84'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Segwit,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultSegwitTestnet).to.equal(
       'vprv9K7GLAaERuM58PVvbk1sMo7wzVCoPwzZpVXLRBmum93gL5pSqQCAAvZjtmz93nnnYMr9i2FwG2fqrwYLRgJmDDwFjGiamGsbRMJ5Y6siJ8H'
@@ -50,7 +51,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
       path: "m/49'/2'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultWrappedSegwit).to.equal(
       'Mtpv7RooeEQDUitupgpJcxZnfDwvq8hC24R7GAiscrqFhHHhit96vCNY7yudJgrM841dMbiRUQceC12566XAHHC8Rd1BtnBdokq9tmF7jLLvUdh'
@@ -63,7 +64,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
       path: "m/49'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultWrappedSegwitTestnet).to.equal(
       'uprv91G7gZkzehuMVxDJTYE6tLivdF8e4rvzSu1LFfKw3b2Qx1Aj8vpoFnHdfUZ3hmi9jsvPifmZ24RTN2KhwB8BfMLTVqaBReibyaFFcTP1s9n'
@@ -76,7 +77,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
       path: "m/44'/2'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultLegacy).to.equal(
       'Ltpv7735AbcbmL1gbgDWj2ezvs59rh4RM1oTN2BKTKbfe3146FCPCNFbBBSWfuV9vCJNMXD9LuHpQnqVWpn2hbMhikqPdoGqbS3ptdPoNWEvvgR'
@@ -89,7 +90,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -104,7 +105,7 @@ describe('litecoin bip32 prefix tests for the conversion from xpriv to xpub', ()
         'zprvAdQSgFiAHcXKb1gcktyukXyGZykTBemmPZ9brfYnxqxM2CocMdxy9aPXTbTLv7dvJgWn2Efi4vFSyPbT4QqgarYrs583WCeMXM2q3TUU8FS',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Segwit,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultSegwit).to.equals(
       'zpub6rPo5mF47z5coVm5rvWv7fv181awb7Vckn5Cf3xQXBVKu18kuBHDhNi1Jrb4br6vVD3ZbrnXemEsWJoR18mZwkUdzwD8TQnHDUCGxqZ6swA'
@@ -117,7 +118,7 @@ describe('litecoin bip32 prefix tests for the conversion from xpriv to xpub', ()
         'vprv9K7GLAaERuM58PVvbk1sMo7wzVCoPwzZpVXLRBmum93gL5pSqQCAAvZjtmz93nnnYMr9i2FwG2fqrwYLRgJmDDwFjGiamGsbRMJ5Y6siJ8H',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Segwit,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultSegwitTestnet).to.equals(
       'vpub5Y6cjg78GGuNLsaPhmYsiw4gYX3HoQiRBiSwDaBXKUafCt9bNwWQiitDk5VZ5BVxYnQdwoTyXSs2JHRPAgjAvtbBrf8ZhDYe2jWAqvZVnsc'
@@ -130,7 +131,7 @@ describe('litecoin bip32 prefix tests for the conversion from xpriv to xpub', ()
         'Mtpv7RooeEQDUitupgpJcxZnfDwvq8hC24R7GAiscrqFhHHhit96vCNY7yudJgrM841dMbiRUQceC12566XAHHC8Rd1BtnBdokq9tmF7jLLvUdh',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultWrappedSegwit).to.equals(
       'Mtub2rz9F1pkisRsSZX8sa4Ajon9GhPP6JymLgpuHqbYdU5JKFLBF7Qy8b1tZ3dccj2fefrAxfrPdVkpCxuWn3g72UctH2bvJRkp6iFmp8aLeRZ'
@@ -143,7 +144,7 @@ describe('litecoin bip32 prefix tests for the conversion from xpriv to xpub', ()
         'uprv91G7gZkzehuMVxDJTYE6tLivdF8e4rvzSu1LFfKw3b2Qx1Aj8vpoFnHdfUZ3hmi9jsvPifmZ24RTN2KhwB8BfMLTVqaBReibyaFFcTP1s9n',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultWrappedSegwitTestnet).to.equals(
       'upub5EFU65HtV5TeiSHmZZm7FUffBGy8UKeqp7vw43jYbvZPpoVsgU93oac7Wk3u6moKegAEWtGNF8DehrnHtv21XXEMYRUocHqguyjknFHYfgY'
@@ -156,7 +157,7 @@ describe('litecoin bip32 prefix tests for the conversion from xpriv to xpub', ()
         'Ltpv7735AbcbmL1gbgDWj2ezvs59rh4RM1oTN2BKTKbfe3146FCPCNFbBBSWfuV9vCJNMXD9LuHpQnqVWpn2hbMhikqPdoGqbS3ptdPoNWEvvgR',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultLegacy).to.equals(
       'Ltub2YDQmP391UYeDYvLye9P1SuNJFkcRGN7SYHM8JMxaDnegcPTXHJ2BnYmvHnFnGPGKu2WMuCga6iZV3SDxDMGrRyMcrYEfSPhrpS1EPkC43E'
@@ -169,7 +170,7 @@ describe('litecoin bip32 prefix tests for the conversion from xpriv to xpub', ()
         'tprv8fVU32aAEuEPeH1WYx3LhXtSFZTRaFqjbFNPaJZ9R8fCVja44tSaUPZEKGpMK6McUDkWWMvRiVfKR3Wzei6AmLoTNYHMAZ9KtvVTLZZdhvA',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDCBWBScQPGv4Xk3JSbhw6wYYpayMjb2eAYyArpbSqQTbLDpphHGAetB6VQgVeftLML8vDSUEWcC2xDi3qJJ3YCDChJDvqVzpgoYSuT52MhJ'
@@ -191,24 +192,24 @@ describe('litecoin xpub to address tests;  generate valid addresses by calling x
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(p2pkhAddress).to.equals('LUWPbpM43E2p7ZSh8cyTBEkvpHmr3cB8Ez')
     const scriptPukbeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'LUWPbpM43E2p7ZSh8cyTBEkvpHmr3cB8Ez',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(scriptPukbeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -221,24 +222,24 @@ describe('litecoin xpub to address tests;  generate valid addresses by calling x
       type: BIP43PurposeTypeEnum.WrappedSegwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKHP2SH,
-      addressType: AddressTypeEnum.p2wpkhp2sh
+      scriptType: ScriptTypeEnum.p2wpkhp2sh,
     }).scriptPubkey
     const p2wpkhp2shAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKHP2SH,
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'litecoin'
+      addressType: AddressTypeEnum.p2sh,
+      coin: 'litecoin',
     })
     expect(p2wpkhp2shAddress).to.equals('M7wtsL7wSHDBJVMWWhtQfTMSYYkyooAAXM')
     const scriptHashP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: 'M7wtsL7wSHDBJVMWWhtQfTMSYYkyooAAXM',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'litecoin'
+      addressType: AddressTypeEnum.p2sh,
+      coin: 'litecoin',
     })
     expect(scriptHashP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
   })
@@ -251,17 +252,17 @@ describe('litecoin xpub to address tests;  generate valid addresses by calling x
       type: BIP43PurposeTypeEnum.Segwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKH,
-      addressType: AddressTypeEnum.p2wpkh
+      scriptType: ScriptTypeEnum.p2wpkh,
     }).scriptPubkey
     const p2wpkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(p2wpkhAddress).to.equals(
       'ltc1qjmxnz78nmc8nq77wuxh25n2es7rzm5c2rkk4wh'
@@ -270,7 +271,7 @@ describe('litecoin xpub to address tests;  generate valid addresses by calling x
       address: 'ltc1qjmxnz78nmc8nq77wuxh25n2es7rzm5c2rkk4wh',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
   })
@@ -282,12 +283,12 @@ describe('litecoin from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -299,7 +300,7 @@ describe('litecoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'LUWPbpM43E2p7ZSh8cyTBEkvpHmr3cB8Ez',
       network: NetworkEnum.Mainnet,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(scriptPubkey).to.equal(
       '76a91465d4f0444069f3881221e24bb6a99b1d53e008cf88ac'
@@ -309,7 +310,7 @@ describe('litecoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'M7wtsL7wSHDBJVMWWhtQfTMSYYkyooAAXM',
       network: NetworkEnum.Mainnet,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(scriptPubkey).to.equal(
       'a91400846c3f4a7bb38e9b422b4129bf8b191287289e87'
@@ -320,7 +321,7 @@ describe('litecoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'ltc1qjmxnz78nmc8nq77wuxh25n2es7rzm5c2rkk4wh',
       network: NetworkEnum.Mainnet,
-      coin: 'litecoin'
+      coin: 'litecoin',
     })
     expect(scriptPubkey).to.equal(
       '001496cd3178f3de0f307bcee1aeaa4d5987862dd30a'

--- a/test/qtumkeymanager-test.ts
+++ b/test/qtumkeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('qtum mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +25,7 @@ describe('qtum mnemonic to xprv test vectors as compared with iancoleman', () =>
       path: "m/44'/2301'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'qtum'
+      coin: 'qtum',
     })
     expect(resultLegacy).to.equal(
       'xprv9yNMmQAw1VJVPvfhyQiCoDT5hpKGuddV8ciqvzDiZkpjURynLpPAsTyDArW8ZUySHdeWnTLy3mJE8RMxo6AaKywAEGVe9t84tcBFssGyVNo'
@@ -37,7 +38,7 @@ describe('qtum mnemonic to xprv test vectors as compared with iancoleman', () =>
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'qtum'
+      coin: 'qtum',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +53,7 @@ describe('qtum bip32 prefix tests for the conversion from xpriv to xpub', () => 
         'xprv9yNMmQAw1VJVPvfhyQiCoDT5hpKGuddV8ciqvzDiZkpjURynLpPAsTyDArW8ZUySHdeWnTLy3mJE8RMxo6AaKywAEGVe9t84tcBFssGyVNo',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'qtum'
+      coin: 'qtum',
     })
     expect(resultLegacy).to.equals(
       'xpub6CMiAuhpqrrncQkB5SFDAMPpFr9mK6MLVqeSjNdL86MiMEJvtMhRRGHh27KNR7zLG8BPcjSEHQ2g6MYcKVssJGVZekhuYQQJc9kGC9ofwJX'
@@ -65,7 +66,7 @@ describe('qtum bip32 prefix tests for the conversion from xpriv to xpub', () => 
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'qtum'
+      coin: 'qtum',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,25 +88,25 @@ describe('qtum xpub to address tests;  generate valid addresses by calling xpubT
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'qtum'
+      coin: 'qtum',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'qtum'
+      coin: 'qtum',
     })
     expect(p2pkhAddress).to.equals('QXykR884CoPkbYHCFZ68bNVTMRvicWAFq2')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'QXykR884CoPkbYHCFZ68bNVTMRvicWAFq2',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'qtum'
+      coin: 'qtum',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -117,12 +118,12 @@ describe('qtum from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'qtum'
+      coin: 'qtum',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'qtum'
+      coin: 'qtum',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -134,7 +135,7 @@ describe('qtum guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'QXykR884CoPkbYHCFZ68bNVTMRvicWAFq2',
       network: NetworkEnum.Mainnet,
-      coin: 'qtum'
+      coin: 'qtum',
     })
     expect(scriptPubkey).to.equal(
       '76a9147cc71ace3e2abcc05b3214d284cf7abba684758c88ac'

--- a/test/ravencoinkeymanager-test.ts
+++ b/test/ravencoinkeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('ravencoin mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +25,7 @@ describe('ravencoin mnemonic to xprv test vectors as compared with iancoleman', 
       path: "m/44'/175'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'ravencoin'
+      coin: 'ravencoin',
     })
     expect(resultLegacy).to.equal(
       'xprv9zG1qmEumfwLUb2rTjKTxJEfLRxBqMGYyYm4S6wXpJyjyqrnqWN2aYf4EEt6iv27QMeHWyzressEVbmgrRFoqJQX47F3ncu2ghzeRYPhTJc'
@@ -37,7 +38,7 @@ describe('ravencoin mnemonic to xprv test vectors as compared with iancoleman', 
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'ravencoin'
+      coin: 'ravencoin',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +53,7 @@ describe('ravencoin bip32 prefix tests for the conversion from xpriv to xpub', (
         'xprv9zG1qmEumfwLUb2rTjKTxJEfLRxBqMGYyYm4S6wXpJyjyqrnqWN2aYf4EEt6iv27QMeHWyzressEVbmgrRFoqJQX47F3ncu2ghzeRYPhTJc',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'ravencoin'
+      coin: 'ravencoin',
     })
     expect(resultLegacy).to.equals(
       'xpub6DFNFGmoc3Vdh57KZkrUKSBPtTngEozQLmgfEVM9NeWireBwP3gH8LyY5VMsVB9zCGxzsph27TuppVSrbGP5sjqcJPrWLUwsEPrXPvCVgL1'
@@ -65,7 +66,7 @@ describe('ravencoin bip32 prefix tests for the conversion from xpriv to xpub', (
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'ravencoin'
+      coin: 'ravencoin',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,25 +88,25 @@ describe('ravencoin xpub to address tests;  generate valid addresses by calling 
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'ravencoin'
+      coin: 'ravencoin',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'ravencoin'
+      coin: 'ravencoin',
     })
     expect(p2pkhAddress).to.equals('RDjNvZL1TJQ7R8L23jDutdEioQG4eTC38V')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'RDjNvZL1TJQ7R8L23jDutdEioQG4eTC38V',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'ravencoin'
+      coin: 'ravencoin',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -117,12 +118,12 @@ describe('ravencoin from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'ravencoin'
+      coin: 'ravencoin',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'ravencoin'
+      coin: 'ravencoin',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -134,7 +135,7 @@ describe('ravencoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'RDjNvZL1TJQ7R8L23jDutdEioQG4eTC38V',
       network: NetworkEnum.Mainnet,
-      coin: 'ravencoin'
+      coin: 'ravencoin',
     })
     expect(scriptPubkey).to.equal(
       '76a91430d45f1e2c0d24c8340bd0b634ce89c5b0e579b388ac'

--- a/test/smartcashkeymanager-test.ts
+++ b/test/smartcashkeymanager-test.ts
@@ -47,6 +47,7 @@ describe('smartcash mnemonic to xprv test vectors as compared with iancoleman', 
 })
 
 describe('smartcash bip32 prefix tests for the conversion from xpriv to xpub', () => {
+  // verified with old edge library tests
   it('bip44 xpriv to xpub mainnet', () => {
     const resultLegacy = xprivToXPub({
       xpriv:
@@ -101,9 +102,9 @@ describe('smartcash xpub to address tests;  generate valid addresses by calling 
       addressType: AddressTypeEnum.p2pkh,
       coin: 'smartcash',
     })
-    expect(p2pkhAddress).to.equals('SkYmjrcQQgc9XWFAfBRG61YEYRWUoFKjcJ')
+    expect(p2pkhAddress).to.equals('SkYmjrcQQgc9XWFAfBRG61YEYRWUqGEZnG')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
-      address: 'SkYmjrcQQgc9XWFAfBRG61YEYRWUoFKjcJ',
+      address: 'SkYmjrcQQgc9XWFAfBRG61YEYRWUqGEZnG',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'smartcash',
@@ -114,7 +115,7 @@ describe('smartcash xpub to address tests;  generate valid addresses by calling 
 
 describe('smartcash from WIF to private key to WIF', () => {
   it('take a wif private key', () => {
-    const wifKey = 'KxU83MzcLXP1WJtoFJXMDMcN3z5ykAa9xLdFTDY5XpV4e6Zit9BA'
+    const wifKey = 'VLqHRdvdNPgspEjPM6ee5CcLKc4CFBvafN183pevjxXKX1uZGe1m'
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
@@ -130,15 +131,14 @@ describe('smartcash from WIF to private key to WIF', () => {
 })
 
 describe('smartcash guess script pubkeys from address', () => {
-  // these tests are cross verified with bitcoin core
   it('p2pkh address to scriptPubkey', () => {
     const scriptPubkey = addressToScriptPubkey({
-      address: 'SkYmjrcQQgc9XWFAfBRG61YEYRWUoFKjcJ',
+      address: 'ScZ5enspA3DpbSkX1SYxkCLyu8gh4qzTWH',
       network: NetworkEnum.Mainnet,
       coin: 'smartcash',
     })
     expect(scriptPubkey).to.equal(
-      '76a914ff1609403946409f74cd2c07e50c4c40ec66080288ac'
+      '76a914a763fb8d08fdd6b5f6e3e3bf41ab33901b86e72088ac'
     )
   })
 })

--- a/test/smartcashkeymanager-test.ts
+++ b/test/smartcashkeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('smartcash mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +25,7 @@ describe('smartcash mnemonic to xprv test vectors as compared with iancoleman', 
       path: "m/44'/224'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'smartcash'
+      coin: 'smartcash',
     })
     expect(resultLegacy).to.equal(
       'xprv9yWirNER4qGZHR9cLGqJi8Z23wy2M9JmbCA7zkCunzneLv84Gxj4DmZkdjjkqotSverQ7pWsHnkPdFH2RqfkmSizzR6rZFHQ9cHSqjCKs3b'
@@ -37,7 +38,7 @@ describe('smartcash mnemonic to xprv test vectors as compared with iancoleman', 
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'smartcash'
+      coin: 'smartcash',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +53,7 @@ describe('smartcash bip32 prefix tests for the conversion from xpriv to xpub', (
         'xprv9yWirNER4qGZHR9cLGqJi8Z23wy2M9JmbCA7zkCunzneLv84Gxj4DmZkdjjkqotSverQ7pWsHnkPdFH2RqfkmSizzR6rZFHQ9cHSqjCKs3b',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'smartcash'
+      coin: 'smartcash',
     })
     expect(resultLegacy).to.equals(
       'xpub6CW5FsmJuCprVuE5SJNK5GVkbyoWkc2cxR5io8cXMLKdDiTCpW3JmZtEUzKML8iYKp5Fs7iGSLnW4EjGZFaRtmVo9RPW36CY2w4imVdUNjK'
@@ -65,7 +66,7 @@ describe('smartcash bip32 prefix tests for the conversion from xpriv to xpub', (
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'smartcash'
+      coin: 'smartcash',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,25 +88,25 @@ describe('smartcash xpub to address tests;  generate valid addresses by calling 
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'smartcash'
+      coin: 'smartcash',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'smartcash'
+      coin: 'smartcash',
     })
     expect(p2pkhAddress).to.equals('SkYmjrcQQgc9XWFAfBRG61YEYRWUoFKjcJ')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'SkYmjrcQQgc9XWFAfBRG61YEYRWUoFKjcJ',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'smartcash'
+      coin: 'smartcash',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -117,12 +118,12 @@ describe('smartcash from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'smartcash'
+      coin: 'smartcash',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'smartcash'
+      coin: 'smartcash',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -134,7 +135,7 @@ describe('smartcash guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'SkYmjrcQQgc9XWFAfBRG61YEYRWUoFKjcJ',
       network: NetworkEnum.Mainnet,
-      coin: 'smartcash'
+      coin: 'smartcash',
     })
     expect(scriptPubkey).to.equal(
       '76a914ff1609403946409f74cd2c07e50c4c40ec66080288ac'

--- a/test/ufokeymanager-test.ts
+++ b/test/ufokeymanager-test.ts
@@ -10,6 +10,7 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -91,7 +92,7 @@ describe('uniformfiscalobject xpub to address tests;  generate valid addresses b
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh,
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
@@ -122,19 +123,19 @@ describe('uniformfiscalobject xpub to address tests;  generate valid addresses b
     })
     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKHP2SH,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
+      scriptType: ScriptTypeEnum.p2wpkhp2sh,
     }).scriptPubkey
     const p2wpkhp2shAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKHP2SH,
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
+      addressType: AddressTypeEnum.p2sh,
       coin: 'uniformfiscalobject',
     })
     expect(p2wpkhp2shAddress).to.equals('USM3tijpLBdWpKrvHjPsdzSSpK55k9V79A')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: 'USM3tijpLBdWpKrvHjPsdzSSpK55k9V79A',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
+      addressType: AddressTypeEnum.p2sh,
       coin: 'uniformfiscalobject',
     })
     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
@@ -152,7 +153,7 @@ describe('uniformfiscalobject xpub to address tests;  generate valid addresses b
     })
     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKH,
-      addressType: AddressTypeEnum.p2wpkh,
+      scriptType: ScriptTypeEnum.p2wpkh,
     }).scriptPubkey
     const p2wpkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKH,

--- a/test/ufokeymanager-test.ts
+++ b/test/ufokeymanager-test.ts
@@ -7,10 +7,12 @@ import {
   BIP43PurposeTypeEnum,
   mnemonicToXPriv,
   NetworkEnum,
+  privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('uniformfiscalobject mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -22,7 +24,7 @@ describe('uniformfiscalobject mnemonic to xprv test vectors as compared with ian
       path: "m/44'/202'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(resultLegacy).to.equal(
       'xprv9ytsf7bk77SoYKsJAvqg3sB9gLDp54YHT8bditZW7L5Y6o914va5v6XwZcf6DAuJ4nAbJAxrtwZo8b1jA9ozd73zBz2pTT1ic533idtEwtJ'
@@ -35,7 +37,7 @@ describe('uniformfiscalobject mnemonic to xprv test vectors as compared with ian
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -50,7 +52,7 @@ describe('uniformfiscalobject bip32 prefix tests for the conversion from xpriv t
         'xprv9ytsf7bk77SoYKsJAvqg3sB9gLDp54YHT8bditZW7L5Y6o914va5v6XwZcf6DAuJ4nAbJAxrtwZo8b1jA9ozd73zBz2pTT1ic533idtEwtJ',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(resultLegacy).to.equals(
       'xpub6CtE4d8dwV16kowmGxNgR17tEN4JUXG8pMXEXGy7ffcWybU9cTtLTtrRQsDwHkMADcjoXSNeoebv5XAGJg6n7Zh9vz5TWWvUJzKTSdeUFHn'
@@ -63,7 +65,7 @@ describe('uniformfiscalobject bip32 prefix tests for the conversion from xpriv t
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -85,25 +87,25 @@ describe('uniformfiscalobject xpub to address tests;  generate valid addresses b
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      addressType: AddressTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(p2pkhAddress).to.equals('C3mUHE7dpemNsGoa4rahQoEworx5DkbnFA')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'C3mUHE7dpemNsGoa4rahQoEworx5DkbnFA',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -116,24 +118,24 @@ describe('uniformfiscalobject xpub to address tests;  generate valid addresses b
       type: BIP43PurposeTypeEnum.WrappedSegwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKHP2SH,
-      addressType: AddressTypeEnum.p2wpkhp2sh
+      addressType: AddressTypeEnum.p2wpkhp2sh,
     }).scriptPubkey
     const p2wpkhp2shAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKHP2SH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(p2wpkhp2shAddress).to.equals('USM3tijpLBdWpKrvHjPsdzSSpK55k9V79A')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: 'USM3tijpLBdWpKrvHjPsdzSSpK55k9V79A',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
   })
@@ -146,17 +148,17 @@ describe('uniformfiscalobject xpub to address tests;  generate valid addresses b
       type: BIP43PurposeTypeEnum.Segwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKH,
-      addressType: AddressTypeEnum.p2wpkh
+      addressType: AddressTypeEnum.p2wpkh,
     }).scriptPubkey
     const p2wpkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(p2wpkhAddress).to.equals(
       'uf1qkwnu2phwvard2spr2n0a9d84x590ahywqd6hp9'
@@ -165,7 +167,7 @@ describe('uniformfiscalobject xpub to address tests;  generate valid addresses b
       address: 'uf1qkwnu2phwvard2spr2n0a9d84x590ahywqd6hp9',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
   })
@@ -194,7 +196,7 @@ describe('uniformfiscalobject guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'C3mUHE7dpemNsGoa4rahQoEworx5DkbnFA',
       network: NetworkEnum.Mainnet,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(scriptPubkey).to.equal(
       '76a91474b99370640b77b9ad609c90017fea39dbda907888ac'
@@ -204,7 +206,7 @@ describe('uniformfiscalobject guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'C3mUHE7dpemNsGoa4rahQoEworx5DkbnFA',
       network: NetworkEnum.Mainnet,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(scriptPubkey).to.equal(
       '76a91474b99370640b77b9ad609c90017fea39dbda907888ac'
@@ -215,10 +217,27 @@ describe('uniformfiscalobject guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'uf1qkwnu2phwvard2spr2n0a9d84x590ahywqd6hp9',
       network: NetworkEnum.Mainnet,
-      coin: 'uniformfiscalobject'
+      coin: 'uniformfiscalobject',
     })
     expect(scriptPubkey).to.equal(
       '0014b3a7c506ee6746d5402354dfd2b4f5350afedc8e'
     )
+  })
+})
+
+describe('uniformfiscalobject from WIF to private key to WIF', () => {
+  it('take a wif private key', () => {
+    const wifKey = 'Q2paQ28ajBabp1xuCqmjP7HdeuGSK2vVNaEvrVgLiqP9qYHYFrtL'
+    const privateKey = wifToPrivateKey({
+      wifKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'uniformfiscalobject',
+    })
+    const wifKeyRoundTrip = privateKeyToWIF({
+      privateKey: privateKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'uniformfiscalobject',
+    })
+    expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
 })

--- a/test/vertcoinkeymanager-test.ts
+++ b/test/vertcoinkeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('vertcoin mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +25,7 @@ describe('vertcoin mnemonic to xprv test vectors as compared with iancoleman', (
       path: "m/44'/28'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(resultLegacy).to.equal(
       'xprv9ymzu53azAnFBpJxehxAZi18cA112AVvbeBwMMjfHBieJwrqZjaV3EBE7k5yJPf7RfYBEJzwGKvZP1Gps312YU6BJvdobsd1CmD1xobGkrR'
@@ -37,7 +38,7 @@ describe('vertcoin mnemonic to xprv test vectors as compared with iancoleman', (
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +53,7 @@ describe('vertcoin bip32 prefix tests for the conversion from xpriv to xpub', ()
         'xprv9ymzu53azAnFBpJxehxAZi18cA112AVvbeBwMMjfHBieJwrqZjaV3EBE7k5yJPf7RfYBEJzwGKvZP1Gps312YU6BJvdobsd1CmD1xobGkrR',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(resultLegacy).to.equals(
       'xpub6CmMJaaUpYLYQJPRkjVAvqwsABqVRdDmxs7Y9k9GqXFdBkBz7Gtjb2VhxzCeYKuXkEzZ23MNRFj9tqjYS5UgvewWpxYmhWuwDiLR84spHS8'
@@ -65,7 +66,7 @@ describe('vertcoin bip32 prefix tests for the conversion from xpriv to xpub', ()
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,25 +88,25 @@ describe('vertcoin xpub to address tests;  generate valid addresses by calling x
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(p2pkhAddress).to.equals('Vce16eJifb7HpuoTFEBJyKNLsBJPo7fM83')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'Vce16eJifb7HpuoTFEBJyKNLsBJPo7fM83',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -118,24 +119,24 @@ describe('vertcoin xpub to address tests;  generate valid addresses by calling x
       type: BIP43PurposeTypeEnum.WrappedSegwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     const scriptPubkeyP2WPKHP2SH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKHP2SH,
-      addressType: AddressTypeEnum.p2wpkhp2sh
+      scriptType: ScriptTypeEnum.p2wpkhp2sh,
     }).scriptPubkey
     const p2wpkhp2shAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKHP2SH,
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'vertcoin'
+      addressType: AddressTypeEnum.p2sh,
+      coin: 'vertcoin',
     })
     expect(p2wpkhp2shAddress).to.equals('3GKaSv31kZoxGwMs2Kp25ngoHRHi5pz2SP')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: '3GKaSv31kZoxGwMs2Kp25ngoHRHi5pz2SP',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.p2wpkhp2sh,
-      coin: 'vertcoin'
+      addressType: AddressTypeEnum.p2sh,
+      coin: 'vertcoin',
     })
     expect(scriptPubkeyP2WPKHP2SHRoundTrip).to.equals(scriptPubkeyP2WPKHP2SH)
   })
@@ -148,17 +149,17 @@ describe('vertcoin xpub to address tests;  generate valid addresses by calling x
       type: BIP43PurposeTypeEnum.Segwit,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     const scriptPubkeyP2WPKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2WPKH,
-      addressType: AddressTypeEnum.p2wpkh
+      scriptType: ScriptTypeEnum.p2wpkh,
     }).scriptPubkey
     const p2wpkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2WPKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(p2wpkhAddress).to.equals(
       'vtc1qfe8v6c4r39fq8xnjgcpunt5spdfcxw63zzfwru'
@@ -167,7 +168,7 @@ describe('vertcoin xpub to address tests;  generate valid addresses by calling x
       address: 'vtc1qfe8v6c4r39fq8xnjgcpunt5spdfcxw63zzfwru',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(scriptPubkeyP2WPKHRoundTrip).to.be.equal(scriptPubkeyP2WPKH)
   })
@@ -179,12 +180,12 @@ describe('vertcoin from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -196,7 +197,7 @@ describe('vertcoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'Vce16eJifb7HpuoTFEBJyKNLsBJPo7fM83',
       network: NetworkEnum.Mainnet,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(scriptPubkey).to.equal(
       '76a9141cf825a7d790c30f6eef81f397a66c156540036e88ac'
@@ -206,7 +207,7 @@ describe('vertcoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: '3GKaSv31kZoxGwMs2Kp25ngoHRHi5pz2SP',
       network: NetworkEnum.Mainnet,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(scriptPubkey).to.equal(
       'a914a07be28d5d535951b4882821e519391bf9a39f4987'
@@ -217,7 +218,7 @@ describe('vertcoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'vtc1qfe8v6c4r39fq8xnjgcpunt5spdfcxw63zzfwru',
       network: NetworkEnum.Mainnet,
-      coin: 'vertcoin'
+      coin: 'vertcoin',
     })
     expect(scriptPubkey).to.equal(
       '00144e4ecd62a38952039a724603c9ae900b53833b51'

--- a/test/zcashkeymanager-test.ts
+++ b/test/zcashkeymanager-test.ts
@@ -1,143 +1,144 @@
-// import { expect } from 'chai'
-// import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
 
-// import {
-//   addressToScriptPubkey,
-//   AddressTypeEnum,
-//   BIP43PurposeTypeEnum,
-//   mnemonicToXPriv,
-//   NetworkEnum,
-//   privateKeyToWIF,
-//   pubkeyToScriptPubkey,
-//   scriptPubkeyToAddress,
-//   wifToPrivateKey,
-//   xprivToXPub,
-//   xpubToPubkey
-// } from '../src/common/utxobased/keymanager/keymanager'
+import {
+  addressToScriptPubkey,
+  AddressTypeEnum,
+  BIP43PurposeTypeEnum,
+  mnemonicToXPriv,
+  NetworkEnum,
+  privateKeyToWIF,
+  pubkeyToScriptPubkey,
+  scriptPubkeyToAddress,
+  ScriptTypeEnum,
+  wifToPrivateKey,
+  xprivToXPub,
+  xpubToPubkey,
+} from '../src/common/utxobased/keymanager/keymanager'
 
-// describe('zcash mnemonic to xprv test vectors as compared with iancoleman', () => {
-//   const mnemonic =
-//     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
-//   it('bip44 mnemonic to xpriv mainnet', () => {
-//     const resultLegacy = mnemonicToXPriv({
-//       mnemonic: mnemonic,
-//       path: "m/44'/133'/0'",
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'zcash'
-//     })
-//     expect(resultLegacy).to.equal(
-//       'xprv9yMAh5zLARRVxiM7BXEzJ2t6WbW7dbm8G765ctzqhjYqW9GAtei2NjQyYmDsoVoWxTdfY5D1uDAm58bcTb35GHTxKRCVzpv42SfuxTfPTCm'
-//     )
-//   })
+describe('zcash mnemonic to xprv test vectors as compared with iancoleman', () => {
+  const mnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+  it('bip44 mnemonic to xpriv mainnet', () => {
+    const resultLegacy = mnemonicToXPriv({
+      mnemonic: mnemonic,
+      path: "m/44'/133'/0'",
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'zcash',
+    })
+    expect(resultLegacy).to.equal(
+      'xprv9yMAh5zLARRVxiM7BXEzJ2t6WbW7dbm8G765ctzqhjYqW9GAtei2NjQyYmDsoVoWxTdfY5D1uDAm58bcTb35GHTxKRCVzpv42SfuxTfPTCm'
+    )
+  })
 
-//   it('bip44 mnemonic to xpriv testnet', () => {
-//     const resultLegacyTestnet = mnemonicToXPriv({
-//       mnemonic: mnemonic,
-//       path: "m/44'/1'/0'",
-//       network: NetworkEnum.Testnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'zcash'
-//     })
-//     expect(resultLegacyTestnet).to.equal(
-//       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
-//     )
-//   })
-// })
+  it('bip44 mnemonic to xpriv testnet', () => {
+    const resultLegacyTestnet = mnemonicToXPriv({
+      mnemonic: mnemonic,
+      path: "m/44'/1'/0'",
+      network: NetworkEnum.Testnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'zcash',
+    })
+    expect(resultLegacyTestnet).to.equal(
+      'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
+    )
+  })
+})
 
-// describe('zcash bip32 prefix tests for the conversion from xpriv to xpub', () => {
-//   it('bip44 xpriv to xpub mainnet', () => {
-//     const resultLegacy = xprivToXPub({
-//       xpriv:
-//         'xprv9yMAh5zLARRVxiM7BXEzJ2t6WbW7dbm8G765ctzqhjYqW9GAtei2NjQyYmDsoVoWxTdfY5D1uDAm58bcTb35GHTxKRCVzpv42SfuxTfPTCm',
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'zcash'
-//     })
-//     expect(resultLegacy).to.equals(
-//       'xpub6CLX6bXDznyoBCRaHYmzfApq4dLc34UydL1gRHQTG55pNwbKSC2GvXjTQ4VS3n6P24fRd14uKz7P92xJQ3MWdRzUxGkqiftZf3riboiJLJs'
-//     )
-//   })
+describe('zcash bip32 prefix tests for the conversion from xpriv to xpub', () => {
+  it('bip44 xpriv to xpub mainnet', () => {
+    const resultLegacy = xprivToXPub({
+      xpriv:
+        'xprv9yMAh5zLARRVxiM7BXEzJ2t6WbW7dbm8G765ctzqhjYqW9GAtei2NjQyYmDsoVoWxTdfY5D1uDAm58bcTb35GHTxKRCVzpv42SfuxTfPTCm',
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'zcash',
+    })
+    expect(resultLegacy).to.equals(
+      'xpub6CLX6bXDznyoBCRaHYmzfApq4dLc34UydL1gRHQTG55pNwbKSC2GvXjTQ4VS3n6P24fRd14uKz7P92xJQ3MWdRzUxGkqiftZf3riboiJLJs'
+    )
+  })
 
-//   it('bip44 xpriv to xpub testnet', () => {
-//     const resultLegacyTestnet = xprivToXPub({
-//       xpriv:
-//         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
-//       network: NetworkEnum.Testnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       coin: 'zcash'
-//     })
-//     expect(resultLegacyTestnet).to.equals(
-//       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
-//     )
-//   })
-// })
+  it('bip44 xpriv to xpub testnet', () => {
+    const resultLegacyTestnet = xprivToXPub({
+      xpriv:
+        'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
+      network: NetworkEnum.Testnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'zcash',
+    })
+    expect(resultLegacyTestnet).to.equals(
+      'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
+    )
+  })
+})
 
-// describe('zcash xpub to address tests;  generate valid addresses by calling xpubToPubkey, pubkeyToScriptPubkey and scriptPubkeyToAddress', () => {
-//   /*
-//     These methods were cross verified using ian colemans bip32 website https://iancoleman.io/bip39/
-//     using the same seed as in other tests (abandon, ...)
-//     */
+describe('zcash xpub to address tests;  generate valid addresses by calling xpubToPubkey, pubkeyToScriptPubkey and scriptPubkeyToAddress', () => {
+  /*
+    These methods were cross verified using ian colemans bip32 website https://iancoleman.io/bip39/
+    using the same seed as in other tests (abandon, ...)
+    */
 
-//   it('given an xpub, generate p2pkh address and cross verify script pubkey result', () => {
-//     const pubkeyP2PKH = xpubToPubkey({
-//       xpub:
-//         'xpub6CLX6bXDznyoBCRaHYmzfApq4dLc34UydL1gRHQTG55pNwbKSC2GvXjTQ4VS3n6P24fRd14uKz7P92xJQ3MWdRzUxGkqiftZf3riboiJLJs',
-//       network: NetworkEnum.Mainnet,
-//       type: BIP43PurposeTypeEnum.Legacy,
-//       bip44ChangeIndex: 0,
-//       bip44AddressIndex: 0,
-//       coin: 'zcash'
-//     })
-//     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
-//       pubkey: pubkeyP2PKH,
-//       addressType: AddressTypeEnum.p2pkh
-//     }).scriptPubkey
+  it('given an xpub, generate p2pkh address and cross verify script pubkey result', () => {
+    const pubkeyP2PKH = xpubToPubkey({
+      xpub:
+        'xpub6CLX6bXDznyoBCRaHYmzfApq4dLc34UydL1gRHQTG55pNwbKSC2GvXjTQ4VS3n6P24fRd14uKz7P92xJQ3MWdRzUxGkqiftZf3riboiJLJs',
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      bip44ChangeIndex: 0,
+      bip44AddressIndex: 0,
+      coin: 'zcash',
+    })
+    const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
+      pubkey: pubkeyP2PKH,
+      scriptType: ScriptTypeEnum.p2pkh,
+    }).scriptPubkey
 
-//     const p2pkhAddress = scriptPubkeyToAddress({
-//       scriptPubkey: scriptPubkeyP2PKH,
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2pkh,
-//       coin: 'zcash'
-//     })
-//     expect(p2pkhAddress).to.equals('t1XVXWCvpMgBvUaed4XDqWtgQgJSu1Ghz7F')
-//     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
-//       address: 't1XVXWCvpMgBvUaed4XDqWtgQgJSu1Ghz7F',
-//       network: NetworkEnum.Mainnet,
-//       addressType: AddressTypeEnum.p2pkh,
-//       coin: 'zcash'
-//     })
-//     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
-//   })
-// })
+    const p2pkhAddress = scriptPubkeyToAddress({
+      scriptPubkey: scriptPubkeyP2PKH,
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2pkh,
+      coin: 'zcash',
+    })
+    expect(p2pkhAddress).to.equals('t1XVXWCvpMgBvUaed4XDqWtgQgJSu1Ghz7F')
+    const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
+      address: 't1XVXWCvpMgBvUaed4XDqWtgQgJSu1Ghz7F',
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2pkh,
+      coin: 'zcash',
+    })
+    expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
+  })
+})
 
-// describe('zcash from WIF to private key to WIF', () => {
-//   it('take a wif private key', () => {
-//     const wifKey = 'KxU83MzcLXP1WJtoFJXMDMcN3z5ykAa9xLdFTDY5XpV4e6Zit9BA'
-//     const privateKey = wifToPrivateKey({
-//       wifKey,
-//       network: NetworkEnum.Mainnet,
-//       coin: 'zcash'
-//     })
-//     const wifKeyRoundTrip = privateKeyToWIF({
-//       privateKey: privateKey,
-//       network: NetworkEnum.Mainnet,
-//       coin: 'zcash'
-//     })
-//     expect(wifKey).to.be.equal(wifKeyRoundTrip)
-//   })
-// })
+describe('zcash from WIF to private key to WIF', () => {
+  it('take a wif private key', () => {
+    const wifKey = 'KxU83MzcLXP1WJtoFJXMDMcN3z5ykAa9xLdFTDY5XpV4e6Zit9BA'
+    const privateKey = wifToPrivateKey({
+      wifKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'zcash',
+    })
+    const wifKeyRoundTrip = privateKeyToWIF({
+      privateKey: privateKey,
+      network: NetworkEnum.Mainnet,
+      coin: 'zcash',
+    })
+    expect(wifKey).to.be.equal(wifKeyRoundTrip)
+  })
+})
 
-// describe('zcash guess script pubkeys from address', () => {
-//   // these tests are cross verified with bitcoin core
-//   it('p2pkh address to scriptPubkey', () => {
-//     const scriptPubkey = addressToScriptPubkey({
-//       address: '1K6LZdwpKT5XkEZo2T2kW197aMXYbYMc4f',
-//       network: NetworkEnum.Mainnet,
-//       coin: 'zcash'
-//     })
-//     expect(scriptPubkey).to.equal(
-//       '76a914c674ac8e0534044717c9ee450d5d9f25e243645088ac'
-//     )
-//   })
-// })
+describe('zcash guess script pubkeys from address', () => {
+  // these tests are cross verified with bitcoin core
+  it('p2pkh address to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 't1XVXWCvpMgBvUaed4XDqWtgQgJSu1Ghz7F',
+      network: NetworkEnum.Mainnet,
+      coin: 'zcash',
+    })
+    expect(scriptPubkey).to.equal(
+      '76a9149564d9fed247986b15a2f57d0b3b032eeb28476c88ac'
+    )
+  })
+})

--- a/test/zcoinkeymanager-test.ts
+++ b/test/zcoinkeymanager-test.ts
@@ -10,9 +10,10 @@ import {
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
+  ScriptTypeEnum,
   wifToPrivateKey,
   xprivToXPub,
-  xpubToPubkey
+  xpubToPubkey,
 } from '../src/common/utxobased/keymanager/keymanager'
 
 describe('zcoin mnemonic to xprv test vectors as compared with iancoleman', () => {
@@ -24,7 +25,7 @@ describe('zcoin mnemonic to xprv test vectors as compared with iancoleman', () =
       path: "m/44'/136'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'zcoin'
+      coin: 'zcoin',
     })
     expect(resultLegacy).to.equal(
       'xprv9yDcvGwNLgwS8rV5AYuupanjnfAoDZksQkDdXagMv5MAfrdSaKhoxqhic4NupSGNXtg1eqoAH7UezJMFoBfNNZHL2wVHjX1hEfU1xhceu8b'
@@ -37,7 +38,7 @@ describe('zcoin mnemonic to xprv test vectors as compared with iancoleman', () =
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'zcoin'
+      coin: 'zcoin',
     })
     expect(resultLegacyTestnet).to.equal(
       'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR'
@@ -52,7 +53,7 @@ describe('zcoin bip32 prefix tests for the conversion from xpriv to xpub', () =>
         'xprv9yDcvGwNLgwS8rV5AYuupanjnfAoDZksQkDdXagMv5MAfrdSaKhoxqhic4NupSGNXtg1eqoAH7UezJMFoBfNNZHL2wVHjX1hEfU1xhceu8b',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'zcoin'
+      coin: 'zcoin',
     })
     expect(resultLegacy).to.equals(
       'xpub6CCyKnUGB4VjMLZYGaSvBijULh1Hd2Uimy9EKy5yUQt9Yexb7s24We2CTM54hWaQZYhCzSR6yEFAs5cQ8TwbaSn53S6HRrmaFkdgqczb85v'
@@ -65,7 +66,7 @@ describe('zcoin bip32 prefix tests for the conversion from xpriv to xpub', () =>
         'tprv8fPDJN9UQqg6pFsQsrVxTwHZmXLvHpfGGcsCA9rtnatUgVtBKxhtFeqiyaYKSWydunKpjhvgJf6PwTwgirwuCbFq8YKgpQiaVJf3JCrNmkR',
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
-      coin: 'zcoin'
+      coin: 'zcoin',
     })
     expect(resultLegacyTestnet).to.equals(
       'tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba'
@@ -87,25 +88,25 @@ describe('zcoin xpub to address tests;  generate valid addresses by calling xpub
       type: BIP43PurposeTypeEnum.Legacy,
       bip44ChangeIndex: 0,
       bip44AddressIndex: 0,
-      coin: 'zcoin'
+      coin: 'zcoin',
     })
     const scriptPubkeyP2PKH = pubkeyToScriptPubkey({
       pubkey: pubkeyP2PKH,
-      addressType: AddressTypeEnum.p2pkh
+      scriptType: ScriptTypeEnum.p2pkh,
     }).scriptPubkey
 
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'zcoin'
+      coin: 'zcoin',
     })
     expect(p2pkhAddress).to.equals('a1bW3sVVUsLqgKuTMXtSaAHGvpxKwugxPH')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'a1bW3sVVUsLqgKuTMXtSaAHGvpxKwugxPH',
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
-      coin: 'zcoin'
+      coin: 'zcoin',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
@@ -117,12 +118,12 @@ describe('zcoin from WIF to private key to WIF', () => {
     const privateKey = wifToPrivateKey({
       wifKey,
       network: NetworkEnum.Mainnet,
-      coin: 'zcoin'
+      coin: 'zcoin',
     })
     const wifKeyRoundTrip = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,
-      coin: 'zcoin'
+      coin: 'zcoin',
     })
     expect(wifKey).to.be.equal(wifKeyRoundTrip)
   })
@@ -134,7 +135,7 @@ describe('zcoin guess script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'a1bW3sVVUsLqgKuTMXtSaAHGvpxKwugxPH',
       network: NetworkEnum.Mainnet,
-      coin: 'zcoin'
+      coin: 'zcoin',
     })
     expect(scriptPubkey).to.equal(
       '76a91409a72463ad9977d0b81baacbf25054de672d69f088ac'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "node",
     "jsx": "react",
     "resolveJsonModule": true,
-    "target": "es2015",
+    "target": "es2017",
 
     "strict": true
   },


### PR DESCRIPTION
Part 2 of the utxo coin lib work. This mainly includes changes for altcoins with special behaviour in their serialization, hash types and transaction formats. To facilitate their usage with bitcoinjs-lib I forked the library and added some hooks to pass in special encoding, decoding and hashing functions, special sighash types and other small changes for support of large versions bytes, sighash functions and better size estimation. The patched library is found in https://github.com/TheCharlatan/bitcoinjs-lib/tree/altcoins .
Tests for the transactions of all coins are sadly not available, this would have required coins and some additional time. However address creation, encoding and decoding tests were done for all coins and cross verified with various sources and tools.
Transaction support for Decred does not exist yet, but can be worked on later. The main hurdle to take there is adding an extra field  (for the Tree and expiry value) and witness enumerators for the signatures.
This also includes the case that groestlcoin uses a special hash function for its bip32 derivation. Since this is only for the derivation and does not touch any transaction or address data, this could be skipped. However tools like iancoleman's bip39 converter use this special derivation as well, so I implemented it as a special case.