### PR TITLE
Key Manager changes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
   ],
   "rules": {
     "@typescript-eslint/promise-function-async": "off",
+    "@typescript-eslint/camelcase": "off",
     "no-var": "error",
     "simple-import-sort/sort": "error"
   }

--- a/src/common/utxobased/keymanager/bitcoincashUtils/cashAddress.ts
+++ b/src/common/utxobased/keymanager/bitcoincashUtils/cashAddress.ts
@@ -8,7 +8,8 @@ import BN from './bn'
 
 export enum CashaddrPrefixEnum {
   mainnet = 'bitcoincash',
-  testnet = 'bitcoincashtestnet',
+  testnet = 'bchtest',
+  testnetalt = 'bitcoincashtestnet',
 }
 
 export enum CashaddrTypeEnum {
@@ -235,13 +236,12 @@ export const cashAddressToHash = (address: string): BitcoinCashScriptHash => {
     }
   } else {
     const netNames = Object.values(CashaddrPrefixEnum)
-    let i = netNames.shift()
-    while (prefix === null && typeof i !== 'undefined') {
-      const p = i
-      if (validChecksum(p, payload)) {
-        prefix = p
+    let candidatePrefix = netNames.shift()
+    while (prefix === null && typeof candidatePrefix !== 'undefined') {
+      if (validChecksum(candidatePrefix, payload)) {
+        prefix = candidatePrefix
       }
-      i = netNames.shift()
+      candidatePrefix = netNames.shift()
     }
     if (prefix === null) {
       throw new Error(`InvalidArgument: ${address} has invalid checksum`)

--- a/src/common/utxobased/keymanager/bitcoincashUtils/cashAddress.ts
+++ b/src/common/utxobased/keymanager/bitcoincashUtils/cashAddress.ts
@@ -12,6 +12,12 @@ export enum CashaddrPrefixEnum {
   testnetalt = 'bitcoincashtestnet',
 }
 
+// this enumerates the network types of single coins. Can be expanded to add regtest, signet, stagenet etc.
+export enum NetworkEnum {
+  Mainnet = 'mainnet',
+  Testnet = 'testnet',
+}
+
 export enum CashaddrTypeEnum {
   pubkeyhash = 'pubkeyhash',
   scripthash = 'scripthash',
@@ -108,7 +114,7 @@ const prefixToArray = (prefix: any): number[] => {
 export const hashToCashAddress = (
   scriptHash: string,
   type: CashaddrTypeEnum,
-  prefix: CashaddrPrefixEnum
+  network: NetworkEnum
 ): string => {
   // Not any, but a BN object
   function checksumToArray(checksum: any): number[] {
@@ -155,6 +161,10 @@ export const hashToCashAddress = (
     }
   }
 
+  const prefix: CashaddrPrefixEnum =
+    NetworkEnum.Mainnet === network
+      ? CashaddrPrefixEnum.mainnet
+      : CashaddrPrefixEnum.testnet
   const hashBuffer = Buffer.from(scriptHash, 'hex')
   const eight0 = [0, 0, 0, 0, 0, 0, 0, 0]
   const prefixData = prefixToArray(prefix).concat([0])

--- a/src/common/utxobased/keymanager/coin.ts
+++ b/src/common/utxobased/keymanager/coin.ts
@@ -10,7 +10,7 @@ export interface CoinPrefixes {
   pubkeyHash: number
   scriptHash: number
   bech32?: string
-  cashAddr?: string
+  cashaddr?: string
 }
 
 export interface Coin {

--- a/src/common/utxobased/keymanager/coin.ts
+++ b/src/common/utxobased/keymanager/coin.ts
@@ -23,5 +23,7 @@ export interface Coin {
   bs58EncodeFunc?: (payload: any) => string
   wifEncodeFunc?: (prefix: any, key: any, compressed: any) => string
   mainnetConstants: CoinPrefixes
+  // by default should contain the bitcoin mainnet constants, useful for networks were multiple constants were in use.
+  legacyConstants?: CoinPrefixes
   testnetConstants: CoinPrefixes
 }

--- a/src/common/utxobased/keymanager/coin.ts
+++ b/src/common/utxobased/keymanager/coin.ts
@@ -1,3 +1,19 @@
+import { bip32 } from 'altcoin-js'
+
+interface BitcoinJSNetwork {
+  wif: number
+  bip32: Bip32
+  messagePrefix: string
+  bech32: string
+  pubKeyHash: number
+  scriptHash: number
+}
+
+interface Bip32 {
+  public: number
+  private: number
+}
+
 export interface CoinPrefixes {
   messagePrefix: string
   wif: number
@@ -22,6 +38,11 @@ export interface Coin {
   bs58DecodeFunc?: (payload: string | undefined) => Buffer
   bs58EncodeFunc?: (payload: any) => string
   wifEncodeFunc?: (prefix: any, key: any, compressed: any) => string
+  bip32FromBase58Func?: (
+    xKey: string,
+    network: BitcoinJSNetwork
+  ) => bip32.BIP32Interface
+  bip32FromSeedFunc?: (seed: Buffer) => bip32.BIP32Interface
   mainnetConstants: CoinPrefixes
   // by default should contain the bitcoin mainnet constants, useful for networks were multiple constants were in use.
   legacyConstants?: CoinPrefixes

--- a/src/common/utxobased/keymanager/coins/badcoin.ts
+++ b/src/common/utxobased/keymanager/coins/badcoin.ts
@@ -13,6 +13,15 @@ export class Badcoin implements Coin {
     scriptHash: 0x19,
   }
 
+  legacyConstants = {
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
+    wif: 0x80,
+    legacyXPriv: 0x0488ade4,
+    legacyXPub: 0x0488b21e,
+    pubkeyHash: 0x00,
+    scriptHash: 0x05,
+  }
+
   testnetConstants = {
     messagePrefix: '\x18Badcoin Signed Message:\n',
     wif: 0xef,

--- a/src/common/utxobased/keymanager/coins/bitcoincash.ts
+++ b/src/common/utxobased/keymanager/coins/bitcoincash.ts
@@ -18,6 +18,15 @@ export class BitcoinCash implements Coin {
     cashaddr: 'bitcoincash',
   }
 
+  legacyConstants = {
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
+    wif: 0x80,
+    legacyXPriv: 0x0488ade4,
+    legacyXPub: 0x0488b21e,
+    pubkeyHash: 0x00,
+    scriptHash: 0x05,
+  }
+
   testnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0xef,

--- a/src/common/utxobased/keymanager/coins/bitcoincash.ts
+++ b/src/common/utxobased/keymanager/coins/bitcoincash.ts
@@ -25,6 +25,6 @@ export class BitcoinCash implements Coin {
     legacyXPub: 0x043587cf,
     pubkeyHash: 0x6f,
     scriptHash: 0xc4,
-    cashaddr: 'bitcoincashtestnet',
+    cashaddr: 'bchtest',
   }
 }

--- a/src/common/utxobased/keymanager/coins/bitcoingold.ts
+++ b/src/common/utxobased/keymanager/coins/bitcoingold.ts
@@ -22,6 +22,20 @@ export class Bitcoingold implements Coin {
     bech32: 'btg',
   }
 
+  legacyConstants = {
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
+    wif: 0x80,
+    legacyXPriv: 0x0488ade4,
+    legacyXPub: 0x0488b21e,
+    wrappedSegwitXPriv: 0x049d7878,
+    wrappedSegwitXPub: 0x049d7cb2,
+    segwitXPriv: 0x04b2430c,
+    segwitXPub: 0x04b24746,
+    pubkeyHash: 0x00,
+    scriptHash: 0x05,
+    bech32: 'bc',
+  }
+
   testnetConstants = {
     messagePrefix: '\x18Bitcoin Gold Signed Message:\n',
     wif: 0xef,

--- a/src/common/utxobased/keymanager/coins/bitcoinsv.ts
+++ b/src/common/utxobased/keymanager/coins/bitcoinsv.ts
@@ -14,6 +14,16 @@ export class BitcoinSV implements Coin {
     scriptHash: 0x05,
   }
 
+  legacyConstants = {
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
+    wif: 0x80,
+    legacyXPriv: 0x0488ade4,
+    legacyXPub: 0x0488b21e,
+    pubkeyHash: 0x00,
+    scriptHash: 0x05,
+    cashaddr: 'bitcoincash',
+  }
+
   testnetConstants = {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     wif: 0xef,

--- a/src/common/utxobased/keymanager/coins/groestlcoin.ts
+++ b/src/common/utxobased/keymanager/coins/groestlcoin.ts
@@ -1,4 +1,5 @@
 import { crypto } from 'altcoin-js'
+import * as bip32grs from 'bip32grs'
 import * as base58grs from 'bs58grscheck'
 import * as wifgrs from 'wifgrs'
 
@@ -12,6 +13,8 @@ export class Groestlcoin implements Coin {
   bs58DecodeFunc = base58grs.decode
   bs58EncodeFunc = base58grs.encode
   wifEncodeFunc = wifgrs.encode
+  bip32FromBase58Func = bip32grs.fromBase58
+  bip32FromSeedFunc = bip32grs.fromSeed
   mainnetConstants = {
     messagePrefix: '\x1cGroestlCoin Signed Message:\n',
     wif: 0x80,

--- a/src/common/utxobased/keymanager/keymanager.ts
+++ b/src/common/utxobased/keymanager/keymanager.ts
@@ -14,7 +14,6 @@ import { cdsScriptTemplates } from './bitcoincashUtils/checkdatasig'
 import { Coin, CoinPrefixes } from './coin'
 import { getCoinFromString } from './coinmapper'
 import * as utxopicker from './utxopicker'
-import { IUTXO } from '../db/types'
 
 // this enumerates the network types of single coins. Can be expanded to add regtest, signet, stagenet etc.
 export enum NetworkEnum {
@@ -766,6 +765,7 @@ export function scriptPubkeyToElectrumScriptHash(scriptPubkey: string): string {
   ).toString('hex')
 }
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
   let sequence: number = 0xffffffff
   if (args.rbf) {
@@ -790,17 +790,17 @@ export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
       script: Buffer.from(utxo.script, 'hex'),
       scriptType: utxo.scriptType,
       sequence,
-      sighashType
+      sighashType,
     }
     if (utxo.scriptType === ScriptTypeEnum.p2pkh) {
       input.nonWitnessUtxo = input.script
     } else {
       input.witnessUtxo = {
         script: input.script,
-        value: parseInt(utxo.value)
+        value: parseInt(utxo.value),
       }
 
-      if (utxo.redeemScript) {
+      if (typeof utxo.redeemScript !== 'undefined') {
         input.redeemScript = Buffer.from(utxo.redeemScript, 'hex')
       }
     }
@@ -811,17 +811,17 @@ export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
     const script = addressToScriptPubkey({
       address: target.address,
       coin: coin.name,
-      network: args.network
+      network: args.network,
     })
     return {
       script,
-      value: target.value
+      value: target.value,
     }
   })
   const changeScript = addressToScriptPubkey({
     address: args.freshChangeAddress,
     coin: coin.name,
-    network: args.network
+    network: args.network,
   })
   const { inputs, outputs, changeUsed = false, fee } = utxopicker.accumulative(
     mappedUtxos,
@@ -958,6 +958,7 @@ export function createTx(args: CreateTxArgs): CreateTxReturn {
   return { psbt: psbt.toBase64(), vSize: txVSize }
 }
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function signTx(args: SignTxArgs): Promise<string> {
   const psbt = bitcoin.Psbt.fromBase64(args.psbt)
   const coin = getCoinFromString(args.coin)

--- a/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
@@ -473,7 +473,7 @@ describe('bitcoin transaction creation and signing test', () => {
     addressType: AddressTypeEnum.p2sh,
   })
 
-  it('Create transaction with one legacy input and one output', () => {
+  it('Create transaction with one legacy input and one output', async () => {
     /*
       This here is the rawtransaction as assembled below:
       0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d9452e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48ca17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc5660209e761da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec631e5e1e66009ce3710ceea5b1ad13ffffffff01905f0100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000
@@ -519,7 +519,7 @@ describe('bitcoin transaction creation and signing test', () => {
         },
       ],
     }).psbt
-    const hexTxSigned: string = signTx({
+    const hexTxSigned: string = await signTx({
       psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoin',
@@ -534,7 +534,7 @@ describe('bitcoin transaction creation and signing test', () => {
     )
   })
 
-  it('create a legacy tx with segwit outputs, then create another tx consuming these outputs', () => {
+  it('create a legacy tx with segwit outputs, then create another tx consuming these outputs', async () => {
     const nOutputs: number = 3
     const txInput: TxInput = {
       type: TransactionInputTypeEnum.Legacy,
@@ -563,7 +563,7 @@ describe('bitcoin transaction creation and signing test', () => {
       rbf: false,
     }).psbt
 
-    const rawtransaction: string = signTx({
+    const rawtransaction: string = await signTx({
       psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoin',
@@ -591,7 +591,7 @@ describe('bitcoin transaction creation and signing test', () => {
       network: NetworkEnum.Mainnet,
       rbf: false,
     }).psbt
-    const segwitRawTransaction: string = signTx({
+    const segwitRawTransaction: string = await signTx({
       psbt: segwitTx,
       privateKeys: Array(nOutputs).fill(privateKey),
       coin: 'bitcoin',
@@ -602,7 +602,7 @@ describe('bitcoin transaction creation and signing test', () => {
     )
   })
 
-  it(' create a mixed input and mixed output transaction', () => {
+  it(' create a mixed input and mixed output transaction', async () => {
     const txInputLegacy: TxInput = {
       type: TransactionInputTypeEnum.Legacy,
       prevTxid:
@@ -674,7 +674,7 @@ describe('bitcoin transaction creation and signing test', () => {
       rbf: false,
     }).psbt
 
-    const rawtransaction: string = signTx({
+    const rawtransaction: string = await signTx({
       psbt: base64Tx,
       privateKeys: [privateKey, privateKey, privateKey],
       coin: 'bitcoin',
@@ -684,7 +684,7 @@ describe('bitcoin transaction creation and signing test', () => {
     )
   })
 
-  it('create a legacy tx with one input and 100 outputs, then create another legacy tx with 100 inputs and two outputs', () => {
+  it('create a legacy tx with one input and 100 outputs, then create another legacy tx with 100 inputs and two outputs', async () => {
     const nOutputs: number = 100
     const txInput: TxInput = {
       type: TransactionInputTypeEnum.Legacy,
@@ -720,7 +720,7 @@ describe('bitcoin transaction creation and signing test', () => {
       rbf: false,
     }).psbt
 
-    const hexTxSigned: string = signTx({
+    const hexTxSigned: string = await signTx({
       psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoin',
@@ -743,7 +743,7 @@ describe('bitcoin transaction creation and signing test', () => {
       rbf: false,
     }).psbt
 
-    const hexTxMultiSigned: string = signTx({
+    const hexTxMultiSigned: string = await signTx({
       psbt: base64TxMulti,
       privateKeys: Array(nOutputs).fill(privateKey),
       coin: 'bitcoin',

--- a/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
@@ -6,8 +6,6 @@ import {
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
   createTx,
-  legacySeedToPrivateKey,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToPubkey,
   privateKeyToWIF,
@@ -15,11 +13,13 @@ import {
   scriptPubkeyToAddress,
   scriptPubkeyToElectrumScriptHash,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   signTx,
   TransactionInputTypeEnum,
   TxInput,
   TxOutput,
   wifToPrivateKey,
+  xprivToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
@@ -28,8 +28,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip84 mnemonic to xpriv mainnet', () => {
-    const resultSegwit = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultSegwit = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/84'/0'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Segwit,
@@ -41,8 +41,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   })
 
   it('bip84 mnemonic to xpriv testnet', () => {
-    const resultSegwitTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultSegwitTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/84'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Segwit,
@@ -54,8 +54,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   })
 
   it('bip49 mnemonic to xpriv mainnet', () => {
-    const resultWrappedSegwit = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultWrappedSegwit = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/49'/0'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
@@ -67,8 +67,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   })
 
   it('bip49 mnemonic to xpriv testnet', () => {
-    const resultWrappedSegwitTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultWrappedSegwitTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/49'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
@@ -80,8 +80,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   })
 
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/0'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -93,8 +93,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -287,11 +287,39 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
   })
 })
 
+describe('bitcoin bip32 seed, aka airbitz seed, to xpriv. Taken from official bip32 test vectors', () => {
+  it('seed to xpriv', () => {
+    const result = seedOrMnemonicToXPriv({
+      seed:
+        'fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542',
+      path: 'm/0',
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'bitcoin',
+    })
+    expect(result).to.equal(
+      'xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt'
+    )
+  })
+})
+
 describe('bitcoin from bip32 seed to private key', () => {
   it('generate a wif key from a bip32 seed', () => {
-    const seed =
-      '1dafe5a826590b3f9558dd9e1ab1d8b86fda83a4bcc3aeeb95d81f0ab95c3d62'
-    const privateKey = legacySeedToPrivateKey({ seed, index: 0 })
+    const xpriv = seedOrMnemonicToXPriv({
+      seed: '1dafe5a826590b3f9558dd9e1ab1d8b86fda83a4bcc3aeeb95d81f0ab95c3d62',
+      path: 'm/0',
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      coin: 'bitcoin',
+    })
+    const privateKey = xprivToPrivateKey({
+      xpriv,
+      network: NetworkEnum.Mainnet,
+      type: BIP43PurposeTypeEnum.Legacy,
+      bip44ChangeIndex: 0,
+      bip44AddressIndex: 0,
+      coin: 'bitcoin',
+    })
     const wifKey = privateKeyToWIF({
       privateKey: privateKey,
       network: NetworkEnum.Mainnet,

--- a/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
@@ -30,9 +30,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   it('bip84 mnemonic to xpriv mainnet', () => {
     const resultSegwit = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/84'/0'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Segwit,
+      purpose: BIP43PurposeTypeEnum.Segwit,
       coin: 'bitcoin',
     })
     expect(resultSegwit).to.equal(
@@ -43,9 +42,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   it('bip84 mnemonic to xpriv testnet', () => {
     const resultSegwitTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/84'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Segwit,
+      purpose: BIP43PurposeTypeEnum.Segwit,
       coin: 'bitcoin',
     })
     expect(resultSegwitTestnet).to.equal(
@@ -56,9 +54,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   it('bip49 mnemonic to xpriv mainnet', () => {
     const resultWrappedSegwit = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/49'/0'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.WrappedSegwit,
+      purpose: BIP43PurposeTypeEnum.WrappedSegwit,
       coin: 'bitcoin',
     })
     expect(resultWrappedSegwit).to.equal(
@@ -69,9 +66,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   it('bip49 mnemonic to xpriv testnet', () => {
     const resultWrappedSegwitTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/49'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.WrappedSegwit,
+      purpose: BIP43PurposeTypeEnum.WrappedSegwit,
       coin: 'bitcoin',
     })
     expect(resultWrappedSegwitTestnet).to.equal(
@@ -82,9 +78,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/0'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoin',
     })
     expect(resultLegacy).to.equal(
@@ -95,9 +90,8 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoin',
     })
     expect(resultLegacyTestnet).to.equal(
@@ -292,9 +286,8 @@ describe('bitcoin bip32 seed, aka airbitz seed, to xpriv. Taken from official bi
     const result = seedOrMnemonicToXPriv({
       seed:
         'fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542',
-      path: 'm/0',
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoin',
     })
     expect(result).to.equal(
@@ -307,9 +300,8 @@ describe('bitcoin from bip32 seed to private key', () => {
   it('generate a wif key from a bip32 seed', () => {
     const xpriv = seedOrMnemonicToXPriv({
       seed: '1dafe5a826590b3f9558dd9e1ab1d8b86fda83a4bcc3aeeb95d81f0ab95c3d62',
-      path: 'm/0',
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoin',
     })
     const privateKey = xprivToPrivateKey({

--- a/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
@@ -207,7 +207,7 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoin',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: '1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA',
@@ -237,7 +237,7 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2sh,
       coin: 'bitcoin',
-    })
+    }).address
     expect(p2wpkhp2shAddress).to.equals('37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf',
@@ -267,7 +267,7 @@ describe('bitcoin xpub to address tests;  generate valid addresses by calling xp
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
       coin: 'bitcoin',
-    })
+    }).address
     expect(p2wpkhAddress).to.equals(
       'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'
     )
@@ -479,19 +479,19 @@ describe('bitcoin transaction creation and signing test', () => {
     network: NetworkEnum.Mainnet,
     coin: 'bitcoin',
     addressType: AddressTypeEnum.p2pkh,
-  })
+  }).address
   const segwitAddress: string = scriptPubkeyToAddress({
     scriptPubkey: segwitScriptPubkey,
     network: NetworkEnum.Mainnet,
     coin: 'bitcoin',
     addressType: AddressTypeEnum.p2wpkh,
-  })
+  }).address
   const wrappedSegwitAddress: string = scriptPubkeyToAddress({
     scriptPubkey: wrappedSegwitScriptPubkey,
     network: NetworkEnum.Mainnet,
     coin: 'bitcoin',
     addressType: AddressTypeEnum.p2sh,
-  })
+  }).legacyAddress
 
   it('Create transaction with one legacy input and one output', async () => {
     /*

--- a/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
@@ -139,10 +139,10 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
       coin: 'bitcoincash',
     })
     expect(p2pkhAddress).to.equals(
-      'bitcoincashtestnet:qqaz6s295ncfs53m86qj0uw6sl8u2kuw0yjdsvk7h8'
+      'bchtest:qqaz6s295ncfs53m86qj0uw6sl8u2kuw0ymst35fx4'
     )
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
-      address: 'bitcoincashtestnet:qqaz6s295ncfs53m86qj0uw6sl8u2kuw0yjdsvk7h8',
+      address: 'bchtest:qqaz6s295ncfs53m86qj0uw6sl8u2kuw0ymst35fx4',
       network: NetworkEnum.Testnet,
       addressType: AddressTypeEnum.cashaddrP2PKH,
       coin: 'bitcoincash',
@@ -181,9 +181,31 @@ describe('bitcoin cash get script pubkeys from address', () => {
       '76a914ca0d36044e0dc08a22724efa6f6a07b0ec4c79aa88ac'
     )
   })
+  it('p2pkh address without prefix to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'qr9q6dsyfcxupz3zwf805mm2q7cwcnre4g60ww9wd5',
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.cashaddrP2PKH,
+      coin: 'bitcoincash',
+    })
+    expect(scriptPubkey).to.equal(
+      '76a914ca0d36044e0dc08a22724efa6f6a07b0ec4c79aa88ac'
+    )
+  })
   it('p2pkh testnet address to scriptPubkey', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bchtest:qrall9d5uddv4yvdyms4wwfw59jr5twzsvashd0fst',
+      network: NetworkEnum.Testnet,
+      addressType: AddressTypeEnum.cashaddrP2PKH,
+      coin: 'bitcoincash',
+    })
+    expect(scriptPubkey).to.equal(
+      '76a914fbff95b4e35aca918d26e157392ea1643a2dc28388ac'
+    )
+  })
+  it('p2pkh testnet address without prefix to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'qrall9d5uddv4yvdyms4wwfw59jr5twzsvashd0fst',
       network: NetworkEnum.Testnet,
       addressType: AddressTypeEnum.cashaddrP2PKH,
       coin: 'bitcoincash',
@@ -203,9 +225,31 @@ describe('bitcoin cash get script pubkeys from address', () => {
       'a914b472a266d0bd89c13706a4132ccfb16f7c3b9fcb87'
     )
   })
+  it('p2sh mainnet address without prefix to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'pz689gnx6z7cnsfhq6jpxtx0k9hhcwulev5cpumfk0',
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.cashaddrP2SH,
+      coin: 'bitcoincash',
+    })
+    expect(scriptPubkey).to.equal(
+      'a914b472a266d0bd89c13706a4132ccfb16f7c3b9fcb87'
+    )
+  })
   it('p2sh testnet address to scriptPubkey', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bchtest:pq2wfeuppegjpnrg64ws8vmv7e4fatwzwq9rvngx8x',
+      network: NetworkEnum.Testnet,
+      addressType: AddressTypeEnum.cashaddrP2SH,
+      coin: 'bitcoincash',
+    })
+    expect(scriptPubkey).to.equal(
+      'a91414e4e7810e5120cc68d55d03b36cf66a9eadc27087'
+    )
+  })
+  it('p2sh testnet address without prefix to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'pq2wfeuppegjpnrg64ws8vmv7e4fatwzwq9rvngx8x',
       network: NetworkEnum.Testnet,
       addressType: AddressTypeEnum.cashaddrP2SH,
       coin: 'bitcoincash',
@@ -228,9 +272,29 @@ describe('bitcoin cash guess script pubkeys from address', () => {
       '76a914ca0d36044e0dc08a22724efa6f6a07b0ec4c79aa88ac'
     )
   })
+  it('p2pkh address without prefix to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'qr9q6dsyfcxupz3zwf805mm2q7cwcnre4g60ww9wd5',
+      network: NetworkEnum.Mainnet,
+      coin: 'bitcoincash',
+    })
+    expect(scriptPubkey).to.equal(
+      '76a914ca0d36044e0dc08a22724efa6f6a07b0ec4c79aa88ac'
+    )
+  })
   it('p2pkh testnet address to scriptPubkey', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bchtest:qrall9d5uddv4yvdyms4wwfw59jr5twzsvashd0fst',
+      network: NetworkEnum.Testnet,
+      coin: 'bitcoincash',
+    })
+    expect(scriptPubkey).to.equal(
+      '76a914fbff95b4e35aca918d26e157392ea1643a2dc28388ac'
+    )
+  })
+  it('p2pkh testnet address without prefix to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'qrall9d5uddv4yvdyms4wwfw59jr5twzsvashd0fst',
       network: NetworkEnum.Testnet,
       coin: 'bitcoincash',
     })
@@ -248,9 +312,29 @@ describe('bitcoin cash guess script pubkeys from address', () => {
       'a914b472a266d0bd89c13706a4132ccfb16f7c3b9fcb87'
     )
   })
+  it('p2sh mainnet address without prefix to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'pz689gnx6z7cnsfhq6jpxtx0k9hhcwulev5cpumfk0',
+      network: NetworkEnum.Mainnet,
+      coin: 'bitcoincash',
+    })
+    expect(scriptPubkey).to.equal(
+      'a914b472a266d0bd89c13706a4132ccfb16f7c3b9fcb87'
+    )
+  })
   it('p2sh testnet address to scriptPubkey', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bchtest:pq2wfeuppegjpnrg64ws8vmv7e4fatwzwq9rvngx8x',
+      network: NetworkEnum.Testnet,
+      coin: 'bitcoincash',
+    })
+    expect(scriptPubkey).to.equal(
+      'a91414e4e7810e5120cc68d55d03b36cf66a9eadc27087'
+    )
+  })
+  it('p2sh testnet address without prefix to scriptPubkey', () => {
+    const scriptPubkey = addressToScriptPubkey({
+      address: 'pq2wfeuppegjpnrg64ws8vmv7e4fatwzwq9rvngx8x',
       network: NetworkEnum.Testnet,
       coin: 'bitcoincash',
     })

--- a/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
@@ -278,7 +278,7 @@ describe('bitcoincash transaction creation and signing test', () => {
     coin: 'bitcoin',
     addressType: AddressTypeEnum.p2pkh,
   })
-  it('Create transaction with one legacy input and one output', () => {
+  it('Create transaction with one legacy input and one output', async () => {
     /*
       This here is the rawtransaction as assembled below:
       0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d9452e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48ca17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc5660209e761da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec631e5e1e66009ce3710ceea5b1ad13ffffffff01905f0100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000
@@ -325,7 +325,7 @@ describe('bitcoincash transaction creation and signing test', () => {
         },
       ],
     }).psbt
-    const hexTxSigned: string = signTx({
+    const hexTxSigned: string = await signTx({
       psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoincash',
@@ -361,7 +361,7 @@ describe('bitcoincash replay protection transaction creation and signing test', 
     coin: 'bitcoin',
     addressType: AddressTypeEnum.p2pkh,
   })
-  it('Create transaction with one legacy input and one output', () => {
+  it('Create transaction with one legacy input and one output', async () => {
     /*
       This here is the rawtransaction as assembled below:
       0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d9452e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48ca17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc5660209e761da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec631e5e1e66009ce3710ceea5b1ad13ffffffff01905f0100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000
@@ -405,7 +405,7 @@ describe('bitcoincash replay protection transaction creation and signing test', 
         },
       ],
     }).psbt
-    const hexTxSigned: string = signTx({
+    const hexTxSigned: string = await signTx({
       psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoincash',

--- a/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
@@ -28,9 +28,8 @@ describe('bitcoin cash mnemonic to xprv test vectors as compared with iancoleman
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/145'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoincash',
     })
     expect(resultLegacy).to.equal(
@@ -41,9 +40,8 @@ describe('bitcoin cash mnemonic to xprv test vectors as compared with iancoleman
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoincash',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
@@ -104,8 +104,11 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
       addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoincash',
     })
-    expect(p2pkhAddress).to.equals(
+    expect(p2pkhAddress.address).to.equals(
       'bitcoincash:qqyx49mu0kkn9ftfj6hje6g2wfer34yfnq5tahq3q6'
+    )
+    expect(p2pkhAddress.legacyAddress).to.equals(
+      '1mW6fDEMjKrDHvLvoEsaeLxSCzZBf3Bfg'
     )
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'bitcoincash:qqyx49mu0kkn9ftfj6hje6g2wfer34yfnq5tahq3q6',
@@ -113,7 +116,15 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
       addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoincash',
     })
+    const scriptPubkeyP2PKHLegacyRoundTrip = addressToScriptPubkey({
+      address: '1mW6fDEMjKrDHvLvoEsaeLxSCzZBf3Bfg',
+      network: NetworkEnum.Mainnet,
+      addressType: AddressTypeEnum.p2pkh,
+      coin: 'bitcoincash',
+      legacy: true,
+    })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
+    expect(scriptPubkeyP2PKHLegacyRoundTrip).to.equals(scriptPubkeyP2PKH)
   })
 
   it('given an xpub, generate p2pkh testnet address and cross verify script pubkey result', () => {
@@ -136,7 +147,7 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
       addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoincash',
     })
-    expect(p2pkhAddress).to.equals(
+    expect(p2pkhAddress.address).to.equals(
       'bchtest:qqaz6s295ncfs53m86qj0uw6sl8u2kuw0ymst35fx4'
     )
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
@@ -359,7 +370,7 @@ describe('bitcoincash transaction creation and signing test', () => {
     network: NetworkEnum.Mainnet,
     coin: 'bitcoin',
     addressType: AddressTypeEnum.p2pkh,
-  })
+  }).address
   it('Create transaction with one legacy input and one output', async () => {
     /*
       This here is the rawtransaction as assembled below:
@@ -442,7 +453,7 @@ describe('bitcoincash replay protection transaction creation and signing test', 
     network: NetworkEnum.Mainnet,
     coin: 'bitcoin',
     addressType: AddressTypeEnum.p2pkh,
-  })
+  }).address
   it('Create transaction with one legacy input and one output', async () => {
     /*
       This here is the rawtransaction as assembled below:

--- a/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
@@ -103,7 +103,7 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.cashaddrP2PKH,
+      addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoincash',
     })
     expect(p2pkhAddress).to.equals(
@@ -112,7 +112,7 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'bitcoincash:qqyx49mu0kkn9ftfj6hje6g2wfer34yfnq5tahq3q6',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.cashaddrP2PKH,
+      addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoincash',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
@@ -135,7 +135,7 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
     const p2pkhAddress = scriptPubkeyToAddress({
       scriptPubkey: scriptPubkeyP2PKH,
       network: NetworkEnum.Testnet,
-      addressType: AddressTypeEnum.cashaddrP2PKH,
+      addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoincash',
     })
     expect(p2pkhAddress).to.equals(
@@ -144,7 +144,7 @@ describe('bitcoin cash xpub to address tests;  generate valid addresses by calli
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'bchtest:qqaz6s295ncfs53m86qj0uw6sl8u2kuw0ymst35fx4',
       network: NetworkEnum.Testnet,
-      addressType: AddressTypeEnum.cashaddrP2PKH,
+      addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoincash',
     })
     expect(scriptPubkeyP2PKHRoundTrip).to.equals(scriptPubkeyP2PKH)
@@ -174,7 +174,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bitcoincash:qr9q6dsyfcxupz3zwf805mm2q7cwcnre4g60ww9wd5',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.cashaddrP2PKH,
+      addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
@@ -185,7 +185,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'qr9q6dsyfcxupz3zwf805mm2q7cwcnre4g60ww9wd5',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.cashaddrP2PKH,
+      addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
@@ -196,7 +196,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bchtest:qrall9d5uddv4yvdyms4wwfw59jr5twzsvashd0fst',
       network: NetworkEnum.Testnet,
-      addressType: AddressTypeEnum.cashaddrP2PKH,
+      addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
@@ -207,7 +207,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'qrall9d5uddv4yvdyms4wwfw59jr5twzsvashd0fst',
       network: NetworkEnum.Testnet,
-      addressType: AddressTypeEnum.cashaddrP2PKH,
+      addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
@@ -218,7 +218,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bitcoincash:pz689gnx6z7cnsfhq6jpxtx0k9hhcwulev5cpumfk0',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.cashaddrP2SH,
+      addressType: AddressTypeEnum.p2sh,
       coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
@@ -229,7 +229,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'pz689gnx6z7cnsfhq6jpxtx0k9hhcwulev5cpumfk0',
       network: NetworkEnum.Mainnet,
-      addressType: AddressTypeEnum.cashaddrP2SH,
+      addressType: AddressTypeEnum.p2sh,
       coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
@@ -240,7 +240,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'bchtest:pq2wfeuppegjpnrg64ws8vmv7e4fatwzwq9rvngx8x',
       network: NetworkEnum.Testnet,
-      addressType: AddressTypeEnum.cashaddrP2SH,
+      addressType: AddressTypeEnum.p2sh,
       coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(
@@ -251,7 +251,7 @@ describe('bitcoin cash get script pubkeys from address', () => {
     const scriptPubkey = addressToScriptPubkey({
       address: 'pq2wfeuppegjpnrg64ws8vmv7e4fatwzwq9rvngx8x',
       network: NetworkEnum.Testnet,
-      addressType: AddressTypeEnum.cashaddrP2SH,
+      addressType: AddressTypeEnum.p2sh,
       coin: 'bitcoincash',
     })
     expect(scriptPubkey).to.equal(

--- a/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
@@ -7,7 +7,6 @@ import {
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
   createTx,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToPubkey,
   privateKeyToWIF,
@@ -15,6 +14,7 @@ import {
   scriptPubkeyToAddress,
   scriptPubkeyToP2SH,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   signTx,
   TransactionInputTypeEnum,
   wifToPrivateKey,
@@ -26,8 +26,8 @@ describe('bitcoin cash mnemonic to xprv test vectors as compared with iancoleman
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/145'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -39,8 +39,8 @@ describe('bitcoin cash mnemonic to xprv test vectors as compared with iancoleman
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/bitcoingold.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoingold.spec.ts
@@ -99,7 +99,10 @@ describe('bitcoin gold xpub to address tests;  generate valid addresses by calli
       addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoingold',
     })
-    expect(p2pkhAddress).to.equals('GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9')
+    expect(p2pkhAddress.address).to.equals('GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9')
+    expect(p2pkhAddress.legacyAddress).to.equals(
+      '1McdhUQiZ2fatmKMvVn8sc8YemYpeDum1k'
+    )
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'GeTZ7bjfXtGsyEcerSSFJNUSZwLfjtCJX9',
       network: NetworkEnum.Mainnet,
@@ -129,7 +132,12 @@ describe('bitcoin gold xpub to address tests;  generate valid addresses by calli
       addressType: AddressTypeEnum.p2sh,
       coin: 'bitcoingold',
     })
-    expect(p2wpkhp2shAddress).to.equals('AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn')
+    expect(p2wpkhp2shAddress.address).to.equals(
+      'AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn'
+    )
+    expect(p2wpkhp2shAddress.legacyAddress).to.equals(
+      '3643rsxfbpSKJ25TkJQo66HtAXqf2hGP3i'
+    )
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: 'AL8uaqKrP4n61pb2BrQXpMC3VcUdjmpAwn',
       network: NetworkEnum.Mainnet,
@@ -159,8 +167,11 @@ describe('bitcoin gold xpub to address tests;  generate valid addresses by calli
       addressType: AddressTypeEnum.p2wpkh,
       coin: 'bitcoingold',
     })
-    expect(p2wpkhAddress).to.equals(
+    expect(p2wpkhAddress.address).to.equals(
       'btg1qkwnu2phwvard2spr2n0a9d84x590ahywl3yacu'
+    )
+    expect(p2wpkhAddress.legacyAddress).to.equals(
+      'bc1qkwnu2phwvard2spr2n0a9d84x590ahywfczcd5'
     )
     const scriptPubkeyP2WPKHRoundTrip = addressToScriptPubkey({
       address: 'btg1qkwnu2phwvard2spr2n0a9d84x590ahywl3yacu',

--- a/test/common/utxobased/keymanager/coins/bitcoingold.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoingold.spec.ts
@@ -22,9 +22,8 @@ describe('bitcoin gold mnemonic to xprv test vectors as compared with iancoleman
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/156'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoingold',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('bitcoin gold mnemonic to xprv test vectors as compared with iancoleman
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoingold',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/bitcoingold.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoingold.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('bitcoin gold mnemonic to xprv test vectors as compared with iancoleman
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/156'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('bitcoin gold mnemonic to xprv test vectors as compared with iancoleman
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/bitcoinsv.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoinsv.spec.ts
@@ -99,7 +99,10 @@ describe('bitcoin sv xpub to address tests;  generate valid addresses by calling
       addressType: AddressTypeEnum.p2pkh,
       coin: 'bitcoinsv',
     })
-    expect(p2pkhAddress).to.equals('1K6LZdwpKT5XkEZo2T2kW197aMXYbYMc4f')
+    expect(p2pkhAddress.address).to.equals('1K6LZdwpKT5XkEZo2T2kW197aMXYbYMc4f')
+    expect(p2pkhAddress.legacyAddress).to.equals(
+      'bitcoincash:qrr8ftywq56qg3che8hy2r2anuj7ysmy2qwc7tfd96'
+    )
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: '1K6LZdwpKT5XkEZo2T2kW197aMXYbYMc4f',
       network: NetworkEnum.Mainnet,

--- a/test/common/utxobased/keymanager/coins/bitcoinsv.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoinsv.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('bitcoin sv mnemonic to xprv test vectors as compared with iancoleman',
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/236'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('bitcoin sv mnemonic to xprv test vectors as compared with iancoleman',
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/bitcoinsv.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoinsv.spec.ts
@@ -22,9 +22,8 @@ describe('bitcoin sv mnemonic to xprv test vectors as compared with iancoleman',
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/236'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoinsv',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('bitcoin sv mnemonic to xprv test vectors as compared with iancoleman',
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoinsv',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/cashaddr.spec.ts
+++ b/test/common/utxobased/keymanager/coins/cashaddr.spec.ts
@@ -3,7 +3,6 @@ import { describe, it } from 'mocha'
 
 import {
   cashAddressToHash,
-  CashaddrPrefixEnum,
   CashaddrTypeEnum,
   hashToCashAddress,
 } from '../../../../../src/common/utxobased/keymanager/bitcoincashUtils/cashAddress'
@@ -31,7 +30,7 @@ describe('bitcoin cash address tests', () => {
     const address = hashToCashAddress(
       pubkeyHash,
       CashaddrTypeEnum.pubkeyhash,
-      CashaddrPrefixEnum.mainnet
+      NetworkEnum.Mainnet
     )
     expect(address).to.equal(
       'bitcoincash:qrvcdmgpk73zyfd8pmdl9wnuld36zh9n4gms8s0u59'
@@ -63,7 +62,7 @@ describe('bitcoin cash address tests', () => {
     const address = hashToCashAddress(
       scriptHash,
       CashaddrTypeEnum.scripthash,
-      CashaddrPrefixEnum.mainnet
+      NetworkEnum.Mainnet
     )
     expect(address).to.equal(
       'bitcoincash:pqlmd62cztjhhdrfr7dy5c5gv2np5nmknvhfvqp85n'

--- a/test/common/utxobased/keymanager/coins/dash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/dash.spec.ts
@@ -98,7 +98,7 @@ describe('dash xpub to address tests;  generate valid addresses by calling xpubT
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'dash',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('XoJA8qE3N2Y3jMLEtZ3vcN42qseZ8LvFf5')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'XoJA8qE3N2Y3jMLEtZ3vcN42qseZ8LvFf5',

--- a/test/common/utxobased/keymanager/coins/dash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/dash.spec.ts
@@ -22,9 +22,8 @@ describe('dash mnemonic to xprv test vectors as compared with iancoleman', () =>
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/5'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'dash',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('dash mnemonic to xprv test vectors as compared with iancoleman', () =>
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'dash',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/dash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/dash.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('dash mnemonic to xprv test vectors as compared with iancoleman', () =>
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/5'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('dash mnemonic to xprv test vectors as compared with iancoleman', () =>
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/decred.spec.ts
+++ b/test/common/utxobased/keymanager/coins/decred.spec.ts
@@ -91,7 +91,7 @@ describe('decred xpub to address tests;  generate valid addresses by calling xpu
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'decred',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('DsmaYBuL9cgEswnx4KjeLQC2uAWUdRyVXhg')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'DsmaYBuL9cgEswnx4KjeLQC2uAWUdRyVXhg',
@@ -118,7 +118,7 @@ describe('decred guess script pubkeys from address', () => {
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'decred',
-    })
+    }).address
     expect(address).to.equal('DsmaYBuL9cgEswnx4KjeLQC2uAWUdRyVXhg')
   })
   it('p2sh address to scriptPubkey', () => {
@@ -135,7 +135,7 @@ describe('decred guess script pubkeys from address', () => {
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2sh,
       coin: 'decred',
-    })
+    }).address
     expect(address).to.equal('DcbpczkMzqtYozqrX7vHcFQmCF5wqsW2hYW')
   })
 })

--- a/test/common/utxobased/keymanager/coins/decred.spec.ts
+++ b/test/common/utxobased/keymanager/coins/decred.spec.ts
@@ -5,11 +5,11 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
@@ -18,8 +18,8 @@ describe('decred mnemonic to xprv test vectors as compared with iancoleman', () 
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/156'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -31,8 +31,8 @@ describe('decred mnemonic to xprv test vectors as compared with iancoleman', () 
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/decred.spec.ts
+++ b/test/common/utxobased/keymanager/coins/decred.spec.ts
@@ -20,22 +20,20 @@ describe('decred mnemonic to xprv test vectors as compared with iancoleman', () 
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/156'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'decred',
     })
     expect(resultLegacy).to.equal(
-      'dprv3o8pLs3xWbQUcPFT19CVo7NgS6GKpRbR9ib9m6RR5TEzXhfCFUq1hHhHK7BUxqqpG7WP7KYuRH3rMibWqqYSnSRxeUxv57oXdV1BmJ6Qw5Y'
+      'dprv3ogcz7QBLrY3PzbYW9U6Lr9UraTUWZAjc8A4aDRX918Qg2ka6sokXV4EdmFHR85k3tubCvKxL3DASSZBUaz3jSobBwHAVmFbymS1tYT3kRm'
     )
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'decred',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/digibyte.spec.ts
+++ b/test/common/utxobased/keymanager/coins/digibyte.spec.ts
@@ -98,7 +98,7 @@ describe('digibyte xpub to address tests;  generate valid addresses by calling x
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'digibyte',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('DG1KhhBKpsyWXTakHNezaDQ34focsXjN1i')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'DG1KhhBKpsyWXTakHNezaDQ34focsXjN1i',
@@ -128,7 +128,7 @@ describe('digibyte xpub to address tests;  generate valid addresses by calling x
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2sh,
       coin: 'digibyte',
-    })
+    }).address
     expect(p2wpkhp2shAddress).to.equals('SQ9EXABrHztGgefL9aH3FyeRjowdjtLfn4')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: 'SQ9EXABrHztGgefL9aH3FyeRjowdjtLfn4',
@@ -158,7 +158,7 @@ describe('digibyte xpub to address tests;  generate valid addresses by calling x
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
       coin: 'digibyte',
-    })
+    }).address
     expect(p2wpkhAddress).to.equals(
       'dgb1q9gmf0pv8jdymcly6lz6fl7lf6mhslsd72e2jq8'
     )

--- a/test/common/utxobased/keymanager/coins/digibyte.spec.ts
+++ b/test/common/utxobased/keymanager/coins/digibyte.spec.ts
@@ -22,9 +22,8 @@ describe('digibyte mnemonic to xprv test vectors as compared with iancoleman', (
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/20'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'digibyte',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('digibyte mnemonic to xprv test vectors as compared with iancoleman', (
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'digibyte',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/digibyte.spec.ts
+++ b/test/common/utxobased/keymanager/coins/digibyte.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('digibyte mnemonic to xprv test vectors as compared with iancoleman', (
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/20'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('digibyte mnemonic to xprv test vectors as compared with iancoleman', (
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/dogecoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/dogecoin.spec.ts
@@ -98,7 +98,7 @@ describe('dogecoin xpub to address tests;  generate valid addresses by calling x
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'dogecoin',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('DBus3bamQjgJULBJtYXpEzDWQRwF5iwxgC')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'DBus3bamQjgJULBJtYXpEzDWQRwF5iwxgC',

--- a/test/common/utxobased/keymanager/coins/dogecoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/dogecoin.spec.ts
@@ -22,9 +22,8 @@ describe('dogecoin mnemonic to xprv test vectors as compared with iancoleman', (
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/3'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'dogecoin',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('dogecoin mnemonic to xprv test vectors as compared with iancoleman', (
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'dogecoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/dogecoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/dogecoin.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('dogecoin mnemonic to xprv test vectors as compared with iancoleman', (
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/3'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('dogecoin mnemonic to xprv test vectors as compared with iancoleman', (
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/eboost.spec.ts
+++ b/test/common/utxobased/keymanager/coins/eboost.spec.ts
@@ -98,7 +98,7 @@ describe('eboost xpub to address tests;  generate valid addresses by calling xpu
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'eboost',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('eMvfrRkQqgc9igciD3j9tCrrmw2KzJ2yu4')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'eMvfrRkQqgc9igciD3j9tCrrmw2KzJ2yu4',

--- a/test/common/utxobased/keymanager/coins/eboost.spec.ts
+++ b/test/common/utxobased/keymanager/coins/eboost.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('eboost mnemonic to xprv test vectors as compared with iancoleman', () 
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/0'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('eboost mnemonic to xprv test vectors as compared with iancoleman', () 
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/eboost.spec.ts
+++ b/test/common/utxobased/keymanager/coins/eboost.spec.ts
@@ -22,22 +22,20 @@ describe('eboost mnemonic to xprv test vectors as compared with iancoleman', () 
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/0'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'eboost',
     })
     expect(resultLegacy).to.equal(
-      'xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb'
+      'xprv9zYTou2k1nf6MGqBjTJPr2sE3uZxtNs189FwEEsmm35n5jNVsv3pwVyUPpxWfeDwbhz1ByQW6eh6EFnPp34oEnDC1VZ22xapWJu3Ham3JYK'
     )
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'eboost',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/feathercoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/feathercoin.spec.ts
@@ -98,7 +98,7 @@ describe('feathercoin xpub to address tests;  generate valid addresses by callin
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'feathercoin',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('6foXhTEUMC85RAhkPS2MfoxD6oS69x4rBS')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: '6foXhTEUMC85RAhkPS2MfoxD6oS69x4rBS',
@@ -128,7 +128,7 @@ describe('feathercoin xpub to address tests;  generate valid addresses by callin
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2sh,
       coin: 'feathercoin',
-    })
+    }).address
     expect(p2wpkhp2shAddress).to.equals('3643rsxfbpSKJ25TkJQo66HtAXqf2hGP3i')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: '3643rsxfbpSKJ25TkJQo66HtAXqf2hGP3i',
@@ -158,7 +158,7 @@ describe('feathercoin xpub to address tests;  generate valid addresses by callin
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
       coin: 'feathercoin',
-    })
+    }).address
     expect(p2wpkhAddress).to.equals(
       'fc1qkwnu2phwvard2spr2n0a9d84x590ahywnuszd4'
     )

--- a/test/common/utxobased/keymanager/coins/feathercoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/feathercoin.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('feathercoin mnemonic to xprv test vectors as compared with iancoleman'
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/8'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('feathercoin mnemonic to xprv test vectors as compared with iancoleman'
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/feathercoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/feathercoin.spec.ts
@@ -22,9 +22,8 @@ describe('feathercoin mnemonic to xprv test vectors as compared with iancoleman'
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/8'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'feathercoin',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('feathercoin mnemonic to xprv test vectors as compared with iancoleman'
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'feathercoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
@@ -103,7 +103,7 @@ describe('groestlcoin xpub to address tests;  generate valid addresses by callin
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'groestlcoin',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('Fpzstx4fKWhqZYbVVmuncuhbEmgecqPTgg')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'Fpzstx4fKWhqZYbVVmuncuhbEmgecqPTgg',
@@ -133,7 +133,7 @@ describe('groestlcoin xpub to address tests;  generate valid addresses by callin
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2sh,
       coin: 'groestlcoin',
-    })
+    }).address
     expect(p2wpkhp2shAddress).to.equals('3299Qf2x9BnzLaZu4HCLvm26RbBB3ZRf4u')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: '3299Qf2x9BnzLaZu4HCLvm26RbBB3ZRf4u',
@@ -163,7 +163,7 @@ describe('groestlcoin xpub to address tests;  generate valid addresses by callin
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
       coin: 'groestlcoin',
-    })
+    }).address
     expect(p2wpkhAddress).to.equals(
       'grs1qrm2uggqj846nljryvmuga56vtwfey0dtnc4z55'
     )

--- a/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
@@ -274,7 +274,7 @@ describe('groestlcoin transaction creation and signing test', () => {
     scriptType: ScriptTypeEnum.p2wpkh,
   }).scriptPubkey
 
-  it('Create transaction with one input and one output', () => {
+  it('Create transaction with one input and one output', async () => {
     /*
       This here is the rawtransaction as assembled below:
       0200000001f9f34e95b9d5c8abcd20fc5bd4a825d1517be62f0f775e5f36da944d9452e550000000006b483045022100c86e9a111afc90f64b4904bd609e9eaed80d48ca17c162b1aca0a788ac3526f002207bb79b60d4fc6526329bf18a77135dc5660209e761da46e1c2f1152ec013215801210211755115eabf846720f5cb18f248666fec631e5e1e66009ce3710ceea5b1ad13ffffffff01905f0100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000
@@ -308,7 +308,7 @@ describe('groestlcoin transaction creation and signing test', () => {
         },
       ],
     }).psbt
-    const hexTxSigned: string = signTx({
+    const hexTxSigned: string = await signTx({
       psbt: base64Tx,
       privateKeys: [privateKey],
       coin: 'groestlcoin',

--- a/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
@@ -27,9 +27,8 @@ describe('groestlcoin mnemonic to xprv test vectors as compared with iancoleman'
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/17'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'groestlcoin',
     })
     expect(resultLegacy).to.equal(
@@ -40,9 +39,8 @@ describe('groestlcoin mnemonic to xprv test vectors as compared with iancoleman'
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'groestlcoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
@@ -6,13 +6,13 @@ import {
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
   createTx,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToPubkey,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   signTx,
   TransactionInputTypeEnum,
   wifToPrivateKey,
@@ -25,8 +25,8 @@ describe('groestlcoin mnemonic to xprv test vectors as compared with iancoleman'
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/17'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -38,8 +38,8 @@ describe('groestlcoin mnemonic to xprv test vectors as compared with iancoleman'
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/litecoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/litecoin.spec.ts
@@ -197,7 +197,7 @@ describe('litecoin xpub to address tests;  generate valid addresses by calling x
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'litecoin',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('LUWPbpM43E2p7ZSh8cyTBEkvpHmr3cB8Ez')
     const scriptPukbeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'LUWPbpM43E2p7ZSh8cyTBEkvpHmr3cB8Ez',
@@ -227,7 +227,7 @@ describe('litecoin xpub to address tests;  generate valid addresses by calling x
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2sh,
       coin: 'litecoin',
-    })
+    }).address
     expect(p2wpkhp2shAddress).to.equals('M7wtsL7wSHDBJVMWWhtQfTMSYYkyooAAXM')
     const scriptHashP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: 'M7wtsL7wSHDBJVMWWhtQfTMSYYkyooAAXM',
@@ -257,7 +257,7 @@ describe('litecoin xpub to address tests;  generate valid addresses by calling x
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
       coin: 'litecoin',
-    })
+    }).address
     expect(p2wpkhAddress).to.equals(
       'ltc1qjmxnz78nmc8nq77wuxh25n2es7rzm5c2rkk4wh'
     )

--- a/test/common/utxobased/keymanager/coins/litecoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/litecoin.spec.ts
@@ -22,9 +22,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   it('bip84 mnemonic to xpriv mainnet', () => {
     const resultSegwit = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/84'/2'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Segwit,
+      purpose: BIP43PurposeTypeEnum.Segwit,
       coin: 'litecoin',
     })
     expect(resultSegwit).to.equal(
@@ -35,9 +34,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   it('bip84 mnemonic to xpriv testnet', () => {
     const resultSegwitTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/84'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Segwit,
+      purpose: BIP43PurposeTypeEnum.Segwit,
       coin: 'litecoin',
     })
     expect(resultSegwitTestnet).to.equal(
@@ -48,9 +46,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   it('bip49 mnemonic to xpriv mainnet', () => {
     const resultWrappedSegwit = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/49'/2'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.WrappedSegwit,
+      purpose: BIP43PurposeTypeEnum.WrappedSegwit,
       coin: 'litecoin',
     })
     expect(resultWrappedSegwit).to.equal(
@@ -61,9 +58,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   it('bip49 mnemonic to xpriv testnet', () => {
     const resultWrappedSegwitTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/49'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.WrappedSegwit,
+      purpose: BIP43PurposeTypeEnum.WrappedSegwit,
       coin: 'litecoin',
     })
     expect(resultWrappedSegwitTestnet).to.equal(
@@ -74,9 +70,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/2'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'litecoin',
     })
     expect(resultLegacy).to.equal(
@@ -87,9 +82,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'litecoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/litecoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/litecoin.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip84 mnemonic to xpriv mainnet', () => {
-    const resultSegwit = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultSegwit = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/84'/2'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Segwit,
@@ -33,8 +33,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   })
 
   it('bip84 mnemonic to xpriv testnet', () => {
-    const resultSegwitTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultSegwitTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/84'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Segwit,
@@ -46,8 +46,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   })
 
   it('bip49 mnemonic to xpriv mainnet', () => {
-    const resultWrappedSegwit = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultWrappedSegwit = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/49'/2'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
@@ -59,8 +59,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   })
 
   it('bip49 mnemonic to xpriv testnet', () => {
-    const resultWrappedSegwitTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultWrappedSegwitTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/49'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.WrappedSegwit,
@@ -72,8 +72,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   })
 
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/2'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -85,8 +85,8 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/qtum.spec.ts
+++ b/test/common/utxobased/keymanager/coins/qtum.spec.ts
@@ -98,7 +98,7 @@ describe('qtum xpub to address tests;  generate valid addresses by calling xpubT
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'qtum',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('QXykR884CoPkbYHCFZ68bNVTMRvicWAFq2')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'QXykR884CoPkbYHCFZ68bNVTMRvicWAFq2',

--- a/test/common/utxobased/keymanager/coins/qtum.spec.ts
+++ b/test/common/utxobased/keymanager/coins/qtum.spec.ts
@@ -22,9 +22,8 @@ describe('qtum mnemonic to xprv test vectors as compared with iancoleman', () =>
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/2301'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'qtum',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('qtum mnemonic to xprv test vectors as compared with iancoleman', () =>
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'qtum',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/qtum.spec.ts
+++ b/test/common/utxobased/keymanager/coins/qtum.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('qtum mnemonic to xprv test vectors as compared with iancoleman', () =>
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/2301'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('qtum mnemonic to xprv test vectors as compared with iancoleman', () =>
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/ravencoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/ravencoin.spec.ts
@@ -98,7 +98,7 @@ describe('ravencoin xpub to address tests;  generate valid addresses by calling 
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'ravencoin',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('RDjNvZL1TJQ7R8L23jDutdEioQG4eTC38V')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'RDjNvZL1TJQ7R8L23jDutdEioQG4eTC38V',

--- a/test/common/utxobased/keymanager/coins/ravencoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/ravencoin.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('ravencoin mnemonic to xprv test vectors as compared with iancoleman', 
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/175'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('ravencoin mnemonic to xprv test vectors as compared with iancoleman', 
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/ravencoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/ravencoin.spec.ts
@@ -22,9 +22,8 @@ describe('ravencoin mnemonic to xprv test vectors as compared with iancoleman', 
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/175'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'ravencoin',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('ravencoin mnemonic to xprv test vectors as compared with iancoleman', 
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'ravencoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/smartcash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/smartcash.spec.ts
@@ -99,7 +99,7 @@ describe('smartcash xpub to address tests;  generate valid addresses by calling 
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'smartcash',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('SkYmjrcQQgc9XWFAfBRG61YEYRWUqGEZnG')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'SkYmjrcQQgc9XWFAfBRG61YEYRWUqGEZnG',

--- a/test/common/utxobased/keymanager/coins/smartcash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/smartcash.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('smartcash mnemonic to xprv test vectors as compared with iancoleman', 
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/224'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('smartcash mnemonic to xprv test vectors as compared with iancoleman', 
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/smartcash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/smartcash.spec.ts
@@ -22,9 +22,8 @@ describe('smartcash mnemonic to xprv test vectors as compared with iancoleman', 
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/224'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'smartcash',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('smartcash mnemonic to xprv test vectors as compared with iancoleman', 
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'smartcash',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/ufo.spec.ts
+++ b/test/common/utxobased/keymanager/coins/ufo.spec.ts
@@ -98,7 +98,7 @@ describe('uniformfiscalobject xpub to address tests;  generate valid addresses b
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'uniformfiscalobject',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('C3mUHE7dpemNsGoa4rahQoEworx5DkbnFA')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'C3mUHE7dpemNsGoa4rahQoEworx5DkbnFA',
@@ -128,7 +128,7 @@ describe('uniformfiscalobject xpub to address tests;  generate valid addresses b
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2sh,
       coin: 'uniformfiscalobject',
-    })
+    }).address
     expect(p2wpkhp2shAddress).to.equals('USM3tijpLBdWpKrvHjPsdzSSpK55k9V79A')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: 'USM3tijpLBdWpKrvHjPsdzSSpK55k9V79A',
@@ -158,7 +158,7 @@ describe('uniformfiscalobject xpub to address tests;  generate valid addresses b
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
       coin: 'uniformfiscalobject',
-    })
+    }).address
     expect(p2wpkhAddress).to.equals(
       'uf1qkwnu2phwvard2spr2n0a9d84x590ahywqd6hp9'
     )

--- a/test/common/utxobased/keymanager/coins/ufo.spec.ts
+++ b/test/common/utxobased/keymanager/coins/ufo.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('uniformfiscalobject mnemonic to xprv test vectors as compared with ian
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/202'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('uniformfiscalobject mnemonic to xprv test vectors as compared with ian
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/ufo.spec.ts
+++ b/test/common/utxobased/keymanager/coins/ufo.spec.ts
@@ -22,9 +22,8 @@ describe('uniformfiscalobject mnemonic to xprv test vectors as compared with ian
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/202'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'uniformfiscalobject',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('uniformfiscalobject mnemonic to xprv test vectors as compared with ian
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'uniformfiscalobject',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/vertcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/vertcoin.spec.ts
@@ -98,7 +98,7 @@ describe('vertcoin xpub to address tests;  generate valid addresses by calling x
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'vertcoin',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('Vce16eJifb7HpuoTFEBJyKNLsBJPo7fM83')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'Vce16eJifb7HpuoTFEBJyKNLsBJPo7fM83',
@@ -128,7 +128,7 @@ describe('vertcoin xpub to address tests;  generate valid addresses by calling x
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2sh,
       coin: 'vertcoin',
-    })
+    }).address
     expect(p2wpkhp2shAddress).to.equals('3GKaSv31kZoxGwMs2Kp25ngoHRHi5pz2SP')
     const scriptPubkeyP2WPKHP2SHRoundTrip = addressToScriptPubkey({
       address: '3GKaSv31kZoxGwMs2Kp25ngoHRHi5pz2SP',
@@ -158,7 +158,7 @@ describe('vertcoin xpub to address tests;  generate valid addresses by calling x
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2wpkh,
       coin: 'vertcoin',
-    })
+    }).address
     expect(p2wpkhAddress).to.equals(
       'vtc1qfe8v6c4r39fq8xnjgcpunt5spdfcxw63zzfwru'
     )

--- a/test/common/utxobased/keymanager/coins/vertcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/vertcoin.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('vertcoin mnemonic to xprv test vectors as compared with iancoleman', (
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/28'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('vertcoin mnemonic to xprv test vectors as compared with iancoleman', (
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/vertcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/vertcoin.spec.ts
@@ -22,9 +22,8 @@ describe('vertcoin mnemonic to xprv test vectors as compared with iancoleman', (
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/28'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'vertcoin',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('vertcoin mnemonic to xprv test vectors as compared with iancoleman', (
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'vertcoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/zcash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/zcash.spec.ts
@@ -98,7 +98,7 @@ describe('zcash xpub to address tests;  generate valid addresses by calling xpub
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'zcash',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('t1XVXWCvpMgBvUaed4XDqWtgQgJSu1Ghz7F')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 't1XVXWCvpMgBvUaed4XDqWtgQgJSu1Ghz7F',

--- a/test/common/utxobased/keymanager/coins/zcash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/zcash.spec.ts
@@ -22,9 +22,8 @@ describe('zcash mnemonic to xprv test vectors as compared with iancoleman', () =
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/133'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'zcash',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('zcash mnemonic to xprv test vectors as compared with iancoleman', () =
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'zcash',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/zcash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/zcash.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('zcash mnemonic to xprv test vectors as compared with iancoleman', () =
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/133'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('zcash mnemonic to xprv test vectors as compared with iancoleman', () =
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/zcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/zcoin.spec.ts
@@ -98,7 +98,7 @@ describe('zcoin xpub to address tests;  generate valid addresses by calling xpub
       network: NetworkEnum.Mainnet,
       addressType: AddressTypeEnum.p2pkh,
       coin: 'zcoin',
-    })
+    }).address
     expect(p2pkhAddress).to.equals('a1bW3sVVUsLqgKuTMXtSaAHGvpxKwugxPH')
     const scriptPubkeyP2PKHRoundTrip = addressToScriptPubkey({
       address: 'a1bW3sVVUsLqgKuTMXtSaAHGvpxKwugxPH',

--- a/test/common/utxobased/keymanager/coins/zcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/zcoin.spec.ts
@@ -5,12 +5,12 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  mnemonicToXPriv,
   NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
+  seedOrMnemonicToXPriv,
   wifToPrivateKey,
   xprivToXPub,
   xpubToPubkey,
@@ -20,8 +20,8 @@ describe('zcoin mnemonic to xprv test vectors as compared with iancoleman', () =
   const mnemonic =
     'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
   it('bip44 mnemonic to xpriv mainnet', () => {
-    const resultLegacy = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacy = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/136'/0'",
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
@@ -33,8 +33,8 @@ describe('zcoin mnemonic to xprv test vectors as compared with iancoleman', () =
   })
 
   it('bip44 mnemonic to xpriv testnet', () => {
-    const resultLegacyTestnet = mnemonicToXPriv({
-      mnemonic: mnemonic,
+    const resultLegacyTestnet = seedOrMnemonicToXPriv({
+      seed: mnemonic,
       path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
       type: BIP43PurposeTypeEnum.Legacy,

--- a/test/common/utxobased/keymanager/coins/zcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/zcoin.spec.ts
@@ -22,9 +22,8 @@ describe('zcoin mnemonic to xprv test vectors as compared with iancoleman', () =
   it('bip44 mnemonic to xpriv mainnet', () => {
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/136'/0'",
       network: NetworkEnum.Mainnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'zcoin',
     })
     expect(resultLegacy).to.equal(
@@ -35,9 +34,8 @@ describe('zcoin mnemonic to xprv test vectors as compared with iancoleman', () =
   it('bip44 mnemonic to xpriv testnet', () => {
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
-      path: "m/44'/1'/0'",
       network: NetworkEnum.Testnet,
-      type: BIP43PurposeTypeEnum.Legacy,
+      purpose: BIP43PurposeTypeEnum.Legacy,
       coin: 'zcoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
 
     "strict": true
   },
-  "include": ["./src/**/*"],
+  "include": ["./src/**/*", "./test/**/*"],
   "exclude": ["./node_modules/**/*", "./lib/**/*"]
 }


### PR DESCRIPTION
*Note: This does not include many changes to code calling to the keymanager yet. I was hesitant to change anything there. Please let me know, if I should completely patch calling code as well*

A host of changes to the key manager, as discussed during the meeting last Friday. The commits are all in one pull request here, each commit addresses one of the points made. Since I built them on top of each other, I will only open this single pull request for now. If required, I will split them up and open single pull requests.

The changes do not include a path check function (yet). Since the path argument is now completely eliminated from all interfaces, I'm not sure what its utility is, nor do I know what the exact required behaviour should be.

The first two commits also include some small linter and test changes that I had to include to pass linting on my system. Not sure if they are actually required and not artefacts of my environment. I can drop these if required

### Remove groestlcoin constants
    
Simplifies the code a bit by moving the bip32 specific functions of groestlcoin to its coin class.

### Add function for address verification
    
To allow the caller to learn something about an address before calling any of the functions, the verifyAddress function is added. It takes the address and coin name as an argument and returns an enum that is either 'good', for a normal address, 'legacy', for an address that is valid by legacy rules, or 'bad' for an address that is not valid for that coin.

### Add legacy address formats
    
To support legacy addresses, the coin class is expanded to handle legacy constants. ScriptPubkeyToAddress and AddressToScriptPubkey can now additionally interact with these legacy constants and return and parse respectively these legacy addresses.

### Remove path arguments
  
With the goal of abstracting derivation information away from the caller, no function should take a 'path' argument. Instead, derivations are gathered implicitly from BIP43 purpose types and BIP44 coin types. If a raw seed is passed, it is assumed to be for an airbitz account, and automatically derives from m/0. Additionally, the BIP44 coin type and account may be overridden.

### Remove cashaddress from address types

To make the calling behavior easier, the cash address types are removed from the AddressTypeEnum. The code now assumes implicit usage of the cashaddress format if cashadddr is defined in the coin class. The cashaddress prefixes are additionally now enforced by choice of the network (mainnet/testnet) and limited to 'bitcoincash' and 'bchtest'.

### Remove legacy/airbitz derivation function

The seed derivation is now handled by the same function as the mnemonic derivation. This allows the same function calling behavior for both a seed and a mnemonic.

### Keymanager: Allow cashaddresses without a prefix

Add unit tests to for the prefix-less addresses

### Lint: Explicitly add test files and switch of camelcase linter

### Await signTx and make test arrow function async
    
Additionally some minor linter fixups

