### PR TITLE
Create Private Key

### DIFF
--- a/src/common/plugin/makeCurrencyPlugin.ts
+++ b/src/common/plugin/makeCurrencyPlugin.ts
@@ -9,7 +9,7 @@ import {
 
 import { makeCurrencyTools } from './makeCurrencyTools'
 import { makeUtxoEngine } from '../utxobased/plugin/makeUtxoEngine'
-import { EngineCoinType, EngineConfig, EngineCurrencyInfo, Emitter, EmitterEvent } from './types'
+import { EngineCurrencyType, EngineConfig, EngineCurrencyInfo, Emitter, EmitterEvent } from './types'
 
 export function makeCurrencyPlugin(
   pluginOptions: EdgeCorePluginOptions,
@@ -49,8 +49,8 @@ export function makeCurrencyPlugin(
       }
 
       let engine: EdgeCurrencyEngine
-      switch (info.coinType) {
-        case EngineCoinType.UTXO:
+      switch (info.currencyType) {
+        case EngineCurrencyType.UTXO:
           engine = await makeUtxoEngine(engineConfig)
           break
       }

--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -3,12 +3,16 @@ import { EdgeCurrencyEngineOptions, EdgeWalletInfo } from 'edge-core-js/lib/type
 import { EdgeTransaction, EdgeTxidMap } from 'edge-core-js'
 import { ProcessorTransaction } from '../utxobased/db/Models/ProcessorTransaction'
 
-export enum EngineCoinType {
+type CurrencyFormats = 'bip32' | 'bip44' | 'bip49' | 'bip84'
+
+export enum EngineCurrencyType {
   UTXO
 }
 
 export interface EngineCurrencyInfo extends EdgeCurrencyInfo {
-  coinType: EngineCoinType
+  formats?: CurrencyFormats[]
+  coinType: number
+  currencyType: EngineCurrencyType
   network: string // The offical network in lower case - Needs to match the Bitcoin Lib Network Type
   gapLimit: number
   defaultFee: number

--- a/src/common/utxobased/info/bitcoin.ts
+++ b/src/common/utxobased/info/bitcoin.ts
@@ -1,8 +1,10 @@
 import { imageServerUrl } from './constants'
-import { EngineCoinType, EngineCurrencyInfo } from '../../plugin/types'
+import { EngineCurrencyType, EngineCurrencyInfo } from '../../plugin/types'
 
 export const info: EngineCurrencyInfo = {
-  coinType: EngineCoinType.UTXO,
+  currencyType: EngineCurrencyType.UTXO,
+  coinType: 0,
+  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
   network: 'bitcoin',
   currencyCode: 'BTC',
   gapLimit: 25,

--- a/src/common/utxobased/keymanager/keymanager.ts
+++ b/src/common/utxobased/keymanager/keymanager.ts
@@ -68,7 +68,7 @@ export enum VerifyAddressEnum {
 export interface SeedOrMnemonicToXPrivArgs {
   seed: string
   network: NetworkEnum
-  purpose: BIP43PurposeTypeEnum
+  type: BIP43PurposeTypeEnum
   coinType?: number // defaults to the coin type as defined in the coin class
   account?: number // defaults to account 0'
   coin: string
@@ -261,6 +261,20 @@ function bip43PurposeTypeEnumToNumber(purpose: BIP43PurposeTypeEnum): number {
   }
 }
 
+export function bip43PurposeNumberToTypeEnum(num: number): BIP43PurposeTypeEnum {
+  switch (num) {
+    case 32:
+    case 44:
+      return BIP43PurposeTypeEnum.Legacy
+    case 49:
+      return BIP43PurposeTypeEnum.WrappedSegwit
+    case 84:
+      return BIP43PurposeTypeEnum.Segwit
+    default:
+      throw new Error('InvalidPurposeNumber')
+  }
+}
+
 function bip32NetworkFromCoinPrefix(
   sigType: BIP43PurposeTypeEnum,
   coinPrefixes: CoinPrefixes,
@@ -438,10 +452,10 @@ export function seedOrMnemonicToXPriv(args: SeedOrMnemonicToXPrivArgs): string {
   const network: BitcoinJSNetwork = bip32NetworkFromCoin({
     networkType: args.network,
     coinString: args.coin,
-    sigType: args.purpose,
+    sigType: args.type,
   })
   const coin = getCoinFromString(args.coin)
-  const purpose = bip43PurposeTypeEnumToNumber(args.purpose)
+  const purpose = bip43PurposeTypeEnumToNumber(args.type)
   let coinType = args.coinType ?? coin.coinType
   const account = args.account ?? 0
   coinType = args.network === 'testnet' ? 1 : coinType

--- a/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
@@ -31,7 +31,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
     const resultSegwit = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Segwit,
+      type: BIP43PurposeTypeEnum.Segwit,
       coin: 'bitcoin',
     })
     expect(resultSegwit).to.equal(
@@ -43,7 +43,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
     const resultSegwitTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Segwit,
+      type: BIP43PurposeTypeEnum.Segwit,
       coin: 'bitcoin',
     })
     expect(resultSegwitTestnet).to.equal(
@@ -55,7 +55,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
     const resultWrappedSegwit = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.WrappedSegwit,
+      type: BIP43PurposeTypeEnum.WrappedSegwit,
       coin: 'bitcoin',
     })
     expect(resultWrappedSegwit).to.equal(
@@ -67,7 +67,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
     const resultWrappedSegwitTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.WrappedSegwit,
+      type: BIP43PurposeTypeEnum.WrappedSegwit,
       coin: 'bitcoin',
     })
     expect(resultWrappedSegwitTestnet).to.equal(
@@ -79,7 +79,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoin',
     })
     expect(resultLegacy).to.equal(
@@ -91,7 +91,7 @@ describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 a
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoin',
     })
     expect(resultLegacyTestnet).to.equal(
@@ -287,7 +287,7 @@ describe('bitcoin bip32 seed, aka airbitz seed, to xpriv. Taken from official bi
       seed:
         'fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542',
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoin',
     })
     expect(result).to.equal(
@@ -301,7 +301,7 @@ describe('bitcoin from bip32 seed to private key', () => {
     const xpriv = seedOrMnemonicToXPriv({
       seed: '1dafe5a826590b3f9558dd9e1ab1d8b86fda83a4bcc3aeeb95d81f0ab95c3d62',
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoin',
     })
     const privateKey = xprivToPrivateKey({

--- a/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
@@ -29,7 +29,7 @@ describe('bitcoin cash mnemonic to xprv test vectors as compared with iancoleman
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoincash',
     })
     expect(resultLegacy).to.equal(
@@ -41,7 +41,7 @@ describe('bitcoin cash mnemonic to xprv test vectors as compared with iancoleman
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoincash',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/bitcoingold.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoingold.spec.ts
@@ -23,7 +23,7 @@ describe('bitcoin gold mnemonic to xprv test vectors as compared with iancoleman
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoingold',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('bitcoin gold mnemonic to xprv test vectors as compared with iancoleman
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoingold',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/bitcoinsv.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoinsv.spec.ts
@@ -23,7 +23,7 @@ describe('bitcoin sv mnemonic to xprv test vectors as compared with iancoleman',
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoinsv',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('bitcoin sv mnemonic to xprv test vectors as compared with iancoleman',
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoinsv',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/dash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/dash.spec.ts
@@ -23,7 +23,7 @@ describe('dash mnemonic to xprv test vectors as compared with iancoleman', () =>
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'dash',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('dash mnemonic to xprv test vectors as compared with iancoleman', () =>
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'dash',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/decred.spec.ts
+++ b/test/common/utxobased/keymanager/coins/decred.spec.ts
@@ -21,7 +21,7 @@ describe('decred mnemonic to xprv test vectors as compared with iancoleman', () 
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'decred',
     })
     expect(resultLegacy).to.equal(
@@ -33,7 +33,7 @@ describe('decred mnemonic to xprv test vectors as compared with iancoleman', () 
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'decred',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/digibyte.spec.ts
+++ b/test/common/utxobased/keymanager/coins/digibyte.spec.ts
@@ -23,7 +23,7 @@ describe('digibyte mnemonic to xprv test vectors as compared with iancoleman', (
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'digibyte',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('digibyte mnemonic to xprv test vectors as compared with iancoleman', (
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'digibyte',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/dogecoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/dogecoin.spec.ts
@@ -23,7 +23,7 @@ describe('dogecoin mnemonic to xprv test vectors as compared with iancoleman', (
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'dogecoin',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('dogecoin mnemonic to xprv test vectors as compared with iancoleman', (
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'dogecoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/eboost.spec.ts
+++ b/test/common/utxobased/keymanager/coins/eboost.spec.ts
@@ -23,7 +23,7 @@ describe('eboost mnemonic to xprv test vectors as compared with iancoleman', () 
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'eboost',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('eboost mnemonic to xprv test vectors as compared with iancoleman', () 
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'eboost',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/feathercoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/feathercoin.spec.ts
@@ -23,7 +23,7 @@ describe('feathercoin mnemonic to xprv test vectors as compared with iancoleman'
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'feathercoin',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('feathercoin mnemonic to xprv test vectors as compared with iancoleman'
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'feathercoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
@@ -28,7 +28,7 @@ describe('groestlcoin mnemonic to xprv test vectors as compared with iancoleman'
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'groestlcoin',
     })
     expect(resultLegacy).to.equal(
@@ -40,7 +40,7 @@ describe('groestlcoin mnemonic to xprv test vectors as compared with iancoleman'
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'groestlcoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/litecoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/litecoin.spec.ts
@@ -23,7 +23,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
     const resultSegwit = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Segwit,
+      type: BIP43PurposeTypeEnum.Segwit,
       coin: 'litecoin',
     })
     expect(resultSegwit).to.equal(
@@ -35,7 +35,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
     const resultSegwitTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Segwit,
+      type: BIP43PurposeTypeEnum.Segwit,
       coin: 'litecoin',
     })
     expect(resultSegwitTestnet).to.equal(
@@ -47,7 +47,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
     const resultWrappedSegwit = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.WrappedSegwit,
+      type: BIP43PurposeTypeEnum.WrappedSegwit,
       coin: 'litecoin',
     })
     expect(resultWrappedSegwit).to.equal(
@@ -59,7 +59,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
     const resultWrappedSegwitTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.WrappedSegwit,
+      type: BIP43PurposeTypeEnum.WrappedSegwit,
       coin: 'litecoin',
     })
     expect(resultWrappedSegwitTestnet).to.equal(
@@ -71,7 +71,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'litecoin',
     })
     expect(resultLegacy).to.equal(
@@ -83,7 +83,7 @@ describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'litecoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/qtum.spec.ts
+++ b/test/common/utxobased/keymanager/coins/qtum.spec.ts
@@ -23,7 +23,7 @@ describe('qtum mnemonic to xprv test vectors as compared with iancoleman', () =>
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'qtum',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('qtum mnemonic to xprv test vectors as compared with iancoleman', () =>
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'qtum',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/ravencoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/ravencoin.spec.ts
@@ -23,7 +23,7 @@ describe('ravencoin mnemonic to xprv test vectors as compared with iancoleman', 
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'ravencoin',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('ravencoin mnemonic to xprv test vectors as compared with iancoleman', 
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'ravencoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/smartcash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/smartcash.spec.ts
@@ -23,7 +23,7 @@ describe('smartcash mnemonic to xprv test vectors as compared with iancoleman', 
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'smartcash',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('smartcash mnemonic to xprv test vectors as compared with iancoleman', 
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'smartcash',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/ufo.spec.ts
+++ b/test/common/utxobased/keymanager/coins/ufo.spec.ts
@@ -23,7 +23,7 @@ describe('uniformfiscalobject mnemonic to xprv test vectors as compared with ian
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'uniformfiscalobject',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('uniformfiscalobject mnemonic to xprv test vectors as compared with ian
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'uniformfiscalobject',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/vertcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/vertcoin.spec.ts
@@ -23,7 +23,7 @@ describe('vertcoin mnemonic to xprv test vectors as compared with iancoleman', (
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'vertcoin',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('vertcoin mnemonic to xprv test vectors as compared with iancoleman', (
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'vertcoin',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/zcash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/zcash.spec.ts
@@ -23,7 +23,7 @@ describe('zcash mnemonic to xprv test vectors as compared with iancoleman', () =
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'zcash',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('zcash mnemonic to xprv test vectors as compared with iancoleman', () =
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'zcash',
     })
     expect(resultLegacyTestnet).to.equal(

--- a/test/common/utxobased/keymanager/coins/zcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/zcoin.spec.ts
@@ -23,7 +23,7 @@ describe('zcoin mnemonic to xprv test vectors as compared with iancoleman', () =
     const resultLegacy = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Mainnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'zcoin',
     })
     expect(resultLegacy).to.equal(
@@ -35,7 +35,7 @@ describe('zcoin mnemonic to xprv test vectors as compared with iancoleman', () =
     const resultLegacyTestnet = seedOrMnemonicToXPriv({
       seed: mnemonic,
       network: NetworkEnum.Testnet,
-      purpose: BIP43PurposeTypeEnum.Legacy,
+      type: BIP43PurposeTypeEnum.Legacy,
       coin: 'zcoin',
     })
     expect(resultLegacyTestnet).to.equal(


### PR DESCRIPTION
This adds support to create a new wallet by creating a new random private key (mnemonic).

### Get data from wallet info
When creating a new private key, we want to allow an options parameter to override the default values to generate a new wallet. If no overrides are passed, we grab `foramt` and `coinType` values from the currency info data but if no values are present using default values.

### Implement Plugin Key Format
According to the specs for [Edge key formats](https://github.com/EdgeApp/edge-core-js/blob/master/docs/key-formats.md) private and public keys should be stored with specific keys.