### PR TITLE
seedOrMnemonicToXPriv to encode with base64

### DIFF
--- a/src/common/utxobased/keymanager/keymanager.ts
+++ b/src/common/utxobased/keymanager/keymanager.ts
@@ -435,7 +435,7 @@ function guessAddressTypeFromAddress(
 export function seedOrMnemonicToXPriv(args: SeedOrMnemonicToXPrivArgs): string {
   // match hexadecimal number from beginning to end of string
   const regexpHex = /^[0-9a-fA-F]+$/
-  let seed = Buffer.from(args.seed, 'hex')
+  let seed = Buffer.from(args.seed, 'base64')
   const isSeed = !!(
     args.seed.length <= 128 &&
     args.seed.length >= 32 &&

--- a/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
@@ -285,7 +285,7 @@ describe('bitcoin bip32 seed, aka airbitz seed, to xpriv. Taken from official bi
   it('seed to xpriv', () => {
     const result = seedOrMnemonicToXPriv({
       seed:
-        'fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542',
+        '//z59vPw7ern5OHe29jV0s/MycbDwL26t7SxrquopaKfnJmWk5CNioeEgX57eHVyb2xpZmNgXVpXVFFOS0hFQg==',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoin',
@@ -299,7 +299,7 @@ describe('bitcoin bip32 seed, aka airbitz seed, to xpriv. Taken from official bi
 describe('bitcoin from bip32 seed to private key', () => {
   it('generate a wif key from a bip32 seed', () => {
     const xpriv = seedOrMnemonicToXPriv({
-      seed: '1dafe5a826590b3f9558dd9e1ab1d8b86fda83a4bcc3aeeb95d81f0ab95c3d62',
+      seed: 'Ha/lqCZZCz+VWN2eGrHYuG/ag6S8w67rldgfCrlcPWI=',
       network: NetworkEnum.Mainnet,
       type: BIP43PurposeTypeEnum.Legacy,
       coin: 'bitcoin',

--- a/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoin.spec.ts
@@ -6,7 +6,6 @@ import {
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
   createTx,
-  NetworkEnum,
   privateKeyToPubkey,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
@@ -23,6 +22,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('bitcoin mnemonic to xprv test vectors as collected from BIP84, BIP49 and some generated cases to test xpub prefix bytes', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoincash.spec.ts
@@ -7,7 +7,6 @@ import {
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
   createTx,
-  NetworkEnum,
   privateKeyToPubkey,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
@@ -21,6 +20,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('bitcoin cash mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/bitcoingold.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoingold.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('bitcoin gold mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/bitcoinsv.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoinsv.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('bitcoin sv mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/cashaddr.spec.ts
+++ b/test/common/utxobased/keymanager/coins/cashaddr.spec.ts
@@ -9,10 +9,10 @@ import {
 import {
   addressToScriptPubkey,
   AddressTypeEnum,
-  NetworkEnum,
   scriptPubkeyToScriptHash,
   ScriptTypeEnum,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('bitcoin cash address tests', () => {
   const pubkeyHash = scriptPubkeyToScriptHash({

--- a/test/common/utxobased/keymanager/coins/dash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/dash.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('dash mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/decred.spec.ts
+++ b/test/common/utxobased/keymanager/coins/decred.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
   ScriptTypeEnum,
@@ -13,6 +12,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('decred mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/digibyte.spec.ts
+++ b/test/common/utxobased/keymanager/coins/digibyte.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('digibyte mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/dogecoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/dogecoin.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('dogecoin mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/eboost.spec.ts
+++ b/test/common/utxobased/keymanager/coins/eboost.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('eboost mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/feathercoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/feathercoin.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('feathercoin mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/groestlcoin.spec.ts
@@ -6,7 +6,6 @@ import {
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
   createTx,
-  NetworkEnum,
   privateKeyToPubkey,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
@@ -20,6 +19,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('groestlcoin mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/litecoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/litecoin.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('litecoin mnemonic to xprv test vectors as collected from BIP84, BIP49 and some generated cases to test xpub prefix bytes', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/qtum.spec.ts
+++ b/test/common/utxobased/keymanager/coins/qtum.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('qtum mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/ravencoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/ravencoin.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('ravencoin mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/smartcash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/smartcash.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('smartcash mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/ufo.spec.ts
+++ b/test/common/utxobased/keymanager/coins/ufo.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('uniformfiscalobject mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/vertcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/vertcoin.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('vertcoin mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/zcash.spec.ts
+++ b/test/common/utxobased/keymanager/coins/zcash.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('zcash mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =

--- a/test/common/utxobased/keymanager/coins/zcoin.spec.ts
+++ b/test/common/utxobased/keymanager/coins/zcoin.spec.ts
@@ -5,7 +5,6 @@ import {
   addressToScriptPubkey,
   AddressTypeEnum,
   BIP43PurposeTypeEnum,
-  NetworkEnum,
   privateKeyToWIF,
   pubkeyToScriptPubkey,
   scriptPubkeyToAddress,
@@ -15,6 +14,7 @@ import {
   xprivToXPub,
   xpubToPubkey,
 } from '../../../../../src/common/utxobased/keymanager/keymanager'
+import { NetworkEnum } from '../../../../../src/common/plugin/types'
 
 describe('zcoin mnemonic to xprv test vectors as compared with iancoleman', () => {
   const mnemonic =


### PR DESCRIPTION
When a seed or mnemonic is passed in to the keymanager, it should be using the `base64` encoding when casting to a `Buffer`