### PR TITLE
Block book notification tests

### DIFF
--- a/src/common/utxobased/db/Models/baselet.ts
+++ b/src/common/utxobased/db/Models/baselet.ts
@@ -30,6 +30,13 @@ export const addressPathByMRUConfig: BaseletConfig<BaseType.CountBase> = {
   bucketSize: 100
 }
 
+export type TxIdsByConfirmations = string[]
+export const txIdsByConfirmationsConfig: BaseletConfig<BaseType.CountBase> = {
+  dbName: 'txIdByConfirmations',
+  type: BaseType.CountBase,
+  bucketSize: 1
+}
+
 export type ScriptPubKeysByBalance = {
   [RANGE_ID_KEY]: string
   [RANGE_KEY]: string

--- a/src/common/utxobased/network/Socket.ts
+++ b/src/common/utxobased/network/Socket.ts
@@ -9,7 +9,7 @@ export enum ReadyState {
 
 // cb?: (ev: MessageEvent) => any
 export interface Socket extends InnerSocket {
-  connect(): void
+  connect: () => Promise<void>
 }
 
 interface InnerSocket {
@@ -40,10 +40,10 @@ export function makeSocket(uri: string, config?: SocketConfig): Socket {
       return socket?.readyState ?? ReadyState.CLOSED
     },
 
-    connect() {
+    async connect() {
       socket?.disconnect()
 
-      return new Promise((resolve) => {
+      return await new Promise(resolve => {
         const callbacks: InnerSocketCallbacks = {
           ...config?.callbacks,
           onOpen() {

--- a/test/common/utxobased/db/Processor.spec.ts
+++ b/test/common/utxobased/db/Processor.spec.ts
@@ -9,6 +9,7 @@ import {
   makeUtxoWalletTools
 } from '../../../../src/common/utxobased/engine/makeUtxoWalletTools'
 import { EventEmitter } from 'events'
+import { expect } from 'chai'
 
 chai.should()
 chai.use(chaiAsPromised)
@@ -33,5 +34,21 @@ describe('Processor', function() {
 
   before(async () => {
     processor = await makeProcessor({ disklet, emitter })
+  })
+
+  it('insert tx id by confirmation', async function () {
+    const noEntry = await processor.fetchTxIdsByConfirmations(0)
+    expect(noEntry).to.equal(undefined)
+    await processor.insertTxIdByConfirmations(0, 'this')
+    await processor.insertTxIdByConfirmations(0, 'that')
+    await processor.insertTxIdByConfirmations(1, 'this')
+    let zeroConf = await processor.fetchTxIdsByConfirmations(0)
+    const oneConf = await processor.fetchTxIdsByConfirmations(1)
+    expect(zeroConf[0]).to.equal('this')
+    expect(zeroConf[1]).to.equal('that')
+    expect(oneConf[0]).to.equal('this')
+    await processor.removeTxIdByConfirmations(0, 'this')
+    zeroConf = await processor.fetchTxIdsByConfirmations(0)
+    expect(zeroConf[0]).to.equal('that')
   })
 })

--- a/test/common/utxobased/network/BlockBook.spec.ts
+++ b/test/common/utxobased/network/BlockBook.spec.ts
@@ -1,9 +1,82 @@
 import * as chai from 'chai'
 import { EventEmitter } from 'events'
+import WS from 'ws'
+
 
 import { BlockBook, BlockHeightEmitter, makeBlockBook } from '../../../../src/common/utxobased/network/BlockBook'
 
 chai.should()
+
+describe('BlockBook notifications tests with dummy server', function() {
+  let websocketServer: WS.Server
+  let blockBook: BlockBook
+  let websocketClient: WebSocket
+
+  beforeEach(async () => {
+    websocketServer = new WS.Server({ port: 8080 })
+    websocketServer.on('connection', (ws: WebSocket) => {
+      websocketClient = ws
+      websocketClient.onmessage = event => {
+        const data = JSON.parse(event.data)
+        switch (data.method) {
+          case 'ping':
+            websocketClient.send(
+              JSON.stringify({
+                id: data.id,
+                data: {}
+              })
+            )
+            break
+          case 'subscribeAddress':
+          case 'subscribeNewBlock':
+            websocketClient.send(
+              JSON.stringify({
+                id: data.id,
+                data: { subscribed: true }
+              })
+            )
+            break
+        }
+      }
+    })
+    websocketServer.on('error', error => {
+      console.log(error)
+    })
+    const emitter: BlockHeightEmitter = new EventEmitter() as any
+    blockBook = makeBlockBook({ emitter, wsAddress: "ws://localhost:8080" })
+    await blockBook.connect()
+    blockBook.isConnected.should.be.true
+  })
+
+  afterEach(async () => {
+    await blockBook.disconnect()
+    blockBook.isConnected.should.be.false
+    websocketServer.close()
+  })
+
+  it('Test BlockBook watch address and watch block events', async () => {
+    let test = false
+    test.should.be.false
+    const cb = (): void => {
+      test = true
+    }
+    blockBook.watchBlocks(cb)
+    websocketClient.send(
+      '{"id":"WATCH_NEW_BLOCK_EVENT_ID","data":{"height":1916453,"hash":"0000000000000e0444fa7c1540a96e5658898a59733311d08f01292e114e8d5b"}}'
+    )
+    await new Promise(resolve => setTimeout(resolve, 100))
+    test.should.be.true
+
+    test = false
+    test.should.be.false
+    blockBook.watchAddresses(['tb1q8uc93239etekcywh2l0t7aklxwywhaw0xlexld'], cb)
+    websocketClient.send(
+      '{"id":"WATCH_ADDRESS_TX_EVENT_ID","data":{"address":"tb1q8uc93239etekcywh2l0t7aklxwywhaw0xlexld","tx":{"txid":"cfd4c31709bd48026c6c1027c47cef305c47947d73248129fee3f4b63ca1af43","version":1,"vin":[{"txid":"e0965d6df36a4ba811fb29819beeae0203fe68e48143344908146a58c5333996","vout":1,"sequence":4294967295,"n":0,"addresses":["tb1qrps90para9l48lydp2xga0p5yyckuj5l7vsu6t"],"isAddress":true,"value":"81581580"}],"vout":[{"value":"100000","n":0,"hex":"00143f3058aa25caf36c11d757debf76df3388ebf5cf","addresses":["tb1q8uc93239etekcywh2l0t7aklxwywhaw0xlexld"],"isAddress":true},{"value":"81463900","n":1,"hex":"0014be4df3d4535bd56f4d35dc1ffdb58408b084ebaa","addresses":["tb1qhexl84znt02k7nf4ms0lmdvypzcgf6a2c9zduk"],"isAddress":true}],"blockHeight":0,"confirmations":0,"blockTime":1612198107,"value":"81563900","valueIn":"81581580","fees":"17680","hex":"01000000000101963933c5586a140849344381e468fe0302aeee9b8129fb11a84b6af36d5d96e00100000000ffffffff02a0860100000000001600143f3058aa25caf36c11d757debf76df3388ebf5cf5c0adb0400000000160014be4df3d4535bd56f4d35dc1ffdb58408b084ebaa0247304402201e7f25a03517d932b2df5d099da597132047f5b7bb5cff43252ba0113fc161d2022003b80682bf7f32e685b21a6f28abc494dcc73c34bc62233f918b54afbbaca36c0121029eea7dac242382a543f6288023ac5a62064bea27349d25fc93180b14d5dd117400000000"}}}'
+    )
+    await new Promise(resolve => setTimeout(resolve, 100))
+    test.should.be.true
+  })
+})
 
 describe('BlockBook', function() {
   this.timeout(10000)


### PR DESCRIPTION
To facilitate the tracking of an unconfirmed transaction an additional CountBase is created to keep track of the unconfirmed transactions. A count base was chosen to enable extension of its functionality into tracking non-matured transactions. In such a scenario each coin would have a defined maturity limit. This would also make it easier to detect and track transaction re-orgs.

If a new transaction is saved to the Transaction base with a block height of 0, its txid is added to count base at index 0.

Upon each incoming block notification all txids in the unconfirmed transaction count base are fetched. For each of them, their transaction data is re-fetched from Blockbook and compared with their existing saved transaction. If its block height is changed, the new transaction updates the old one and its txid is removed from the count base.

Blockbook does not expose an endpoint for block headers, so it's not possible to simply check for txid inclusion in them. Instead, the entire block can be fetched from Blockbook. It does not seem worth the extra bandwidth, especially compared to fetching just a couple of transactions. It might be interesting to eventually fetch the entire block when reaching a threshold of unconfirmed transactions.