### PR TITLE
Address Database Refactor

### DIFF
--- a/src/common/utxobased/db/Models/baselet.ts
+++ b/src/common/utxobased/db/Models/baselet.ts
@@ -9,18 +9,18 @@ export const RANGE_KEY = 'rangeKey'
 export const addressPathToPrefix = (path: Omit<AddressPath, 'addressIndex'>) =>
   `${path.format}_${path.changeIndex}`
 
-export type AddressByPath = IAddress | null
-export const addressByPathConfig: BaseletConfig<BaseType.CountBase> = {
-  dbName: 'addressByPath',
+export type ScriptPubKeyByPath = string | undefined
+export const scriptPubKeyByPathConfig: BaseletConfig<BaseType.CountBase> = {
+  dbName: 'scriptPubKeyByPath',
   type: BaseType.CountBase,
   bucketSize: 50
 }
 
-export type AddressPathByScriptPubKey = AddressPath
-export const addressPathByScriptPubKeyConfig: BaseletConfig<BaseType.HashBase> = {
-  dbName: 'addressPathByScriptPubKey',
+export type AddressByScriptPubKey = IAddress | undefined
+export const addressByScriptPubKeyConfig: BaseletConfig<BaseType.HashBase> = {
+  dbName: 'addressByScriptPubKey',
   type: BaseType.HashBase,
-  bucketSize: 6
+  bucketSize: 8
 }
 
 export type AddressPathByMRU = string

--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -280,7 +280,7 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
     )
   }
 
-  async function innerUpdateAddress(scriptPubKey: string, data: Partial<IAddress>): Promise<IAddress> {
+  async function innerUpdateAddressByScriptPubKey(scriptPubKey: string, data: Partial<IAddress>): Promise<IAddress> {
     const [ address ] = await addressByScriptPubKey.query('', [ scriptPubKey ])
     if (!address) {
       throw new Error('Cannot update address that does not exist')
@@ -332,18 +332,6 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
     return address
   }
 
-  async function innerUpdateAddressByScriptPubKey(
-    scriptPubKey: string,
-    data: Partial<IAddress>
-  ) {
-    const path = await fns.fetchAddressPathBySPubKey(scriptPubKey)
-    if (!path) {
-      throw new Error(`Cannot update address by scriptPubKey that does not exist: ${scriptPubKey}`)
-    }
-
-    await innerUpdateAddress(path, data)
-  }
-
   async function innerSaveTransaction(tx: ProcessorTransaction): Promise<void> {
     const existingTx = await fns.fetchTransaction(tx.txid)
     if (!existingTx) {
@@ -367,7 +355,7 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
             tx.ourOuts = Object.keys(txs[tx.txid].outs)
           }
 
-          await fns.updateAddressByScriptPubKey(scriptPubKey, {
+          await innerUpdateAddressByScriptPubKey(scriptPubKey, {
             lastTouched: tx.date,
             used: true
           })

--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -5,16 +5,7 @@ import { RangeBase } from 'baselet/src/RangeBase'
 import * as bs from 'biggystring'
 import { Disklet } from 'disklet'
 
-import {
-  Baselet,
-  BaseletConfig,
-  IAddress,
-  IAddressOptional,
-  IAddressPartial,
-  IAddressRequired,
-  IProcessorTransaction,
-  IUTXO
-} from './types'
+import { Baselet, BaseletConfig, IAddress, IProcessorTransaction, IUTXO } from './types'
 import { ProcessorTransaction } from './Models/ProcessorTransaction'
 import { makeQueue } from './makeQueue'
 import { AddressPath, EmitterEvent } from '../../plugin/types'
@@ -63,7 +54,7 @@ export interface Processor {
 
   fetchScriptPubKeysByBalance(): Promise<Array<ScriptPubKeysByBalance>>
 
-  saveAddress(data: IAddressRequired & IAddressOptional, onComplete?: () => void): void
+  saveAddress(data: IAddress, onComplete?: () => void): void
 
   updateAddress(path: AddressPath, data: Partial<IAddress>): void
 
@@ -150,7 +141,7 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
   async function processAndSaveAddress(data: IAddress) {
     try {
       await Promise.all([
-        addressByPath.insert(addressPathToPrefix(data.path), data.path.addressIndex, data),
+        addressByPath.insert(addressPathToPrefix(data.path!), data.path!.addressIndex, data),
 
         scriptPubKeysByBalance.insert('', {
           [RANGE_ID_KEY]: data.scriptPubKey,
@@ -264,17 +255,9 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
   }
 
   async function innerSaveAddress(
-    data: IAddressPartial
+    data: IAddress
   ) {
-    const values: IAddress = {
-      lastQuery: 0,
-      lastTouched: 0,
-      used: false,
-      balance: '0',
-      ...data
-    }
-
-    await processAndSaveAddress(values)
+    await processAndSaveAddress(data)
   }
 
   async function innerUpdateAddress(path: AddressPath, data: Partial<IAddress>): Promise<IAddress> {
@@ -471,7 +454,7 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
         if (address) {
           const addressPath: AddressPath = {
             ...path,
-            addressIndex: address.path.addressIndex
+            addressIndex: address.path!.addressIndex
           }
           queue.add(() => innerUpdateAddress(addressPath, { ...address, lastQuery: now }))
         }
@@ -491,7 +474,7 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
     },
 
     saveAddress(
-      data: IAddressPartial,
+      data: IAddress,
       onComplete?: () => void
     ): void {
       queue.add(async () => {

--- a/src/common/utxobased/db/types.ts
+++ b/src/common/utxobased/db/types.ts
@@ -5,22 +5,14 @@ import { RangeBase } from 'baselet/src/RangeBase'
 import { ScriptTypeEnum } from '../keymanager/keymanager'
 import { AddressPath } from '../../plugin/types'
 
-export type IAddress = Required<IAddressPartial>
-
-export interface IAddressPartial extends IAddressRequired, IAddressOptional {
-}
-
-export interface IAddressRequired {
+export type IAddress = {
   scriptPubKey: string
   networkQueryVal: number
-  path: AddressPath
-}
-
-export interface IAddressOptional {
-  lastQuery?: number
-  lastTouched?: number
-  used?: boolean
-  balance?: string
+  path?: AddressPath
+  lastQuery: number
+  lastTouched: number
+  used: boolean
+  balance: string
 }
 
 export interface IUTXO {

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -173,13 +173,8 @@ export async function makeUtxoEngine(config: EngineConfig): Promise<EdgeCurrency
     // @ts-ignore
     async isAddressUsed(address: string): Promise<boolean> {
       const scriptPubKey = walletTools.addressToScriptPubkey(address)
-      const path = await processor.fetchAddressPathBySPubKey(scriptPubKey)
-      if (path) {
-        const address = await processor.fetchAddress(path)
-        return address?.used ?? false
-      }
-
-      return false
+      const addressData = await processor.fetchAddressByScriptPubKey(scriptPubKey)
+      return !!addressData?.used
     },
 
     async makeSpend(edgeSpendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
@@ -260,10 +255,10 @@ export async function makeUtxoEngine(config: EngineConfig): Promise<EdgeCurrency
         const utxo = await processor.fetchUtxo(`${txid}_${index}`)
         if (!utxo) throw new Error('Invalid UTXO')
 
-        const path = await processor.fetchAddressPathBySPubKey(utxo.scriptPubKey)
-        if (!path) throw new Error('Invalid script pubkey')
+        const address = await processor.fetchAddressByScriptPubKey(utxo.scriptPubKey)
+        if (!address?.path) throw new Error('Invalid script pubkey')
 
-        return walletTools.getPrivateKey(path)
+        return walletTools.getPrivateKey(address.path)
       }))
       transaction.signedTx = await signTx({
         psbt,


### PR DESCRIPTION
### Baselet Database Restructure
Due to the realization of needing to store the address data by the script pubkey, the database structure has been slightly modified. 
* Script pubkeys are the only thing stored by an address' path
* Address data is now stored by the script pubkey
* Fetch/update functions have been fixed appropriately 