### PR TITLE
Resync blockchain

### DIFF
--- a/src/common/plugin/utils.ts
+++ b/src/common/plugin/utils.ts
@@ -18,6 +18,13 @@ export const fetchMetadata = async (disklet: Disklet): Promise<LocalWalletMetada
   }
 }
 
+export const clearMetadata = async (
+  disklet: Disklet
+): Promise<LocalWalletMetadata> => {
+  await disklet.delete(metadataPath)
+  return await fetchMetadata(disklet)
+}
+
 export const setMetadata = (disklet: Disklet, data: LocalWalletMetadata): Promise<void> =>
   disklet.setText(metadataPath, JSON.stringify(data)).then()
 


### PR DESCRIPTION
This pull request builds largely on @passabilities original work, adding functionality to the current makeUtxoEngine `resyncBlockchain` function stub. All data in the baselets is now retained in an additional top-level disklet that is itself subdir'ed from the original passed in disklet. This should ensure that only the data of the resyncing blockchain is deleted.

To test its functionality, an address is added to the baselets and then removed with the new clearAll function.