### PR TITLE
Calculate Transaction Amount Without Queue

### DIFF
--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -194,8 +194,8 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
           used: true
         })
 
+        txData.ourAmount = await calculateTransactionAmount(txData)
         await innerUpdateTransaction(txId, txData, true)
-        queue.add(() => calculateTransactionAmount(txId))
       }
     }
   }
@@ -250,24 +250,18 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
     return txs
   }
 
-  async function calculateTransactionAmount(txId: string) {
-    const tx = await fns.fetchTransaction(txId)
-    if (!tx) {
-      throw new Error(`Cannot calculate amount for non-existent transaction: ${txId}`)
-    }
-
-    let total = '0'
+  async function calculateTransactionAmount(tx: IProcessorTransaction): Promise<string> {
+    let ourAmount = '0'
     for (const i of tx.ourIns) {
       const { amount } = tx.inputs[parseInt(i)]
-      total = bs.sub(total, amount)
+      ourAmount = bs.sub(ourAmount, amount)
     }
     for (const i of tx.ourOuts) {
       const { amount } = tx.outputs[parseInt(i)]
-      total = bs.add(total, amount)
+      ourAmount = bs.add(ourAmount, amount)
     }
-    tx.ourAmount = total
 
-    await innerUpdateTransaction(tx.txid, tx, true)
+    return ourAmount
   }
 
   async function innerSaveScriptPubkeyByPath(scriptPubkey: string, path: AddressPath): Promise<void> {
@@ -361,8 +355,8 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
       }
     }
 
+    tx.ourAmount = await calculateTransactionAmount(tx)
     await txById.insert('', tx.txid, tx)
-    queue.add(() => calculateTransactionAmount(tx.txid))
   }
 
   async function innerUpdateTransaction(


### PR DESCRIPTION
It will calculate a transaction amount using data that is already in memory instead of adding a task to the queue to update the transaction after calculating the amount.