### PR TITLE
Update Processor Address API

### DIFF
--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -54,9 +54,9 @@ export interface Processor {
 
   fetchScriptPubkeysByBalance(): Promise<ScriptPubkeysByBalance[]>
 
-  saveAddress(data: IAddress, onComplete?: () => void): void
+  saveAddress(data: IAddress): Promise<void>
 
-  updateAddressByScriptPubkey(scriptPubkey: string, data: Partial<IAddress>): void
+  updateAddressByScriptPubkey(scriptPubkey: string, data: Partial<IAddress>): Promise<void>
 
   fetchTransaction(txId: string): Promise<TxById>
 
@@ -472,21 +472,15 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
       return scriptPubkeysByBalance.query('', 0, max)
     },
 
-    saveAddress(
-      data: IAddress,
-      onComplete?: () => void
-    ): void {
-      queue.add(async () => {
-        await processAndSaveAddress(data)
-        onComplete?.()
-      })
+    async saveAddress(data: IAddress): Promise<void> {
+      await processAndSaveAddress(data)
     },
 
-    updateAddressByScriptPubkey(
+    async updateAddressByScriptPubkey(
       scriptPubkey: string,
       data: Partial<IAddress>
-    ): void {
-      queue.add(() => innerUpdateAddressByScriptPubkey(scriptPubkey, data))
+    ): Promise<void> {
+      await innerUpdateAddressByScriptPubkey(scriptPubkey, data)
     },
 
     async fetchTransaction(txId: string): Promise<TxById> {

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -120,9 +120,8 @@ export function makeUtxoEngineState(config: UtxoEngineStateConfig): UtxoEngineSt
           balance: '0'
         }
       await calculateAddressBalance(address)
-      processor.saveAddress(address, () => {
-        processAddress(address)
-      })
+      await processor.saveAddress(address)
+      await processAddress(address)
 
       gap = address.used ? 0 : gap + 1
       path = {
@@ -155,7 +154,7 @@ export function makeUtxoEngineState(config: UtxoEngineStateConfig): UtxoEngineSt
 
     address.networkQueryVal = metadata.lastSeenBlockHeight + 1
 
-    processor.updateAddressByScriptPubkey(address.scriptPubkey, address)
+    await processor.updateAddressByScriptPubkey(address.scriptPubkey, address)
   }
 
   function updateFreshIndex(path: AddressPath): void {
@@ -343,7 +342,7 @@ export function makeUtxoEngineState(config: UtxoEngineStateConfig): UtxoEngineSt
       }
 
       updateFreshIndex(address.path)
-      processor.updateAddressByScriptPubkey(scriptPubkey, {
+      await processor.updateAddressByScriptPubkey(scriptPubkey, {
         used: true
       })
     }


### PR DESCRIPTION
It changes the processor api for saving/updating an address by returning promises and not adding anything to the queue.