### PR TITLE
Engine: Add json payment protocol options

### DIFF
--- a/src/common/utxobased/engine/paymentRequest.ts
+++ b/src/common/utxobased/engine/paymentRequest.ts
@@ -1,0 +1,88 @@
+import { EdgePaymentProtocolInfo, EdgeSpendTarget } from 'edge-core-js'
+import parse from 'url-parse'
+
+interface BitPayOutput {
+  amount: number
+  address: string
+}
+
+interface getSpendTargetsReturn {
+  nativeAmount: number
+  spendTargets: EdgeSpendTarget[]
+}
+
+export function getSpendTargets(
+  outputs: BitPayOutput[]
+): getSpendTargetsReturn {
+  let nativeAmount = 0
+  const spendTargets: EdgeSpendTarget[] = []
+  for (const output of outputs) {
+    nativeAmount += output.amount
+    spendTargets.push({
+      publicAddress: output.address,
+      nativeAmount: `${output.amount}`
+    })
+  }
+  return { nativeAmount, spendTargets }
+}
+
+export async function getPaymentDetails(
+  paymentProtocolURL: string,
+  network: string,
+  currencyCode: string,
+  fetch: any
+): Promise<EdgePaymentProtocolInfo> {
+  const headers = {
+    Accept: 'application/payment-request',
+    'x-currency': currencyCode
+  }
+  const result = await fetch(paymentProtocolURL, { headers })
+  if (parseInt(result.status) !== 200) {
+    const error = await result.text()
+    throw new Error(error)
+  }
+  const paymentRequest = await result.json()
+  const {
+    outputs,
+    memo,
+    paymentUrl,
+    paymentId,
+    requiredFeeRate
+  } = paymentRequest
+
+  const { nativeAmount, spendTargets } = getSpendTargets(outputs)
+  const domain = parse(paymentUrl, {}).hostname
+
+  const edgePaymentProtocolInfo: EdgePaymentProtocolInfo = {
+    nativeAmount: `${nativeAmount}`,
+    merchant: `{ ${paymentId}, ${requiredFeeRate} }`,
+    memo,
+    domain,
+    spendTargets
+  }
+
+  return edgePaymentProtocolInfo
+}
+
+export function createPayment(tx: string, currencyCode: string): any {
+  return { currency: currencyCode, transactions: [tx] }
+}
+
+export async function sendPayment(
+  fetch: any,
+  paymentUrl: string,
+  payment: any
+): Promise<any> {
+  const headers = { 'Content-Type': 'application/payment' }
+  const result = await fetch(paymentUrl, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payment)
+  })
+  if (parseInt(result.status) !== 200) {
+    const error = await result.text()
+    throw new Error(error)
+  }
+  const paymentACK = await result.json()
+  return paymentACK
+}

--- a/test/common/utxobased/engine/PaymentRequest.spec.ts
+++ b/test/common/utxobased/engine/PaymentRequest.spec.ts
@@ -1,0 +1,29 @@
+import * as chai from 'chai'
+import { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+
+import { getSpendTargets } from '../../../../src/common/utxobased/engine/paymentRequest'
+
+chai.should()
+chai.use(chaiAsPromised)
+
+describe('PaymentRequest', function () {
+  it('calculate spend target', async function () {
+    const outputs = [
+      {
+        amount: 239200,
+        address: 'n3YaQSkTXrpbQyAns1kQQRxsECMn9ifx5n'
+      }
+    ]
+    const result = getSpendTargets(outputs)
+    expect(result).to.eql({
+      nativeAmount: 239200,
+      spendTargets: [
+        {
+          publicAddress: 'n3YaQSkTXrpbQyAns1kQQRxsECMn9ifx5n',
+          nativeAmount: '239200'
+        }
+      ]
+    })
+  })
+})


### PR DESCRIPTION
This is a port of the old plugin behavior to the new plugin. The old plugin had additional address sanity checks and converted addresses to legacy format. These additional steps are dropped. Some redundant arguments in create payment were also dropped.