### PR TITLE
Fetch Transactions Fix

### DIFF
--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -19,10 +19,10 @@ import {
   scriptPubkeyByPathConfig,
   ScriptPubkeysByBalance,
   scriptPubkeysByBalanceConfig,
-  TxIdsByBlockHeight,
-  txIdsByBlockHeightConfig,
   TxById,
   txByIdConfig,
+  txIdsByBlockHeightConfig,
+  TxsByDate,
   txsByDateConfig,
   TxsByScriptPubkey,
   txsByScriptPubkeyConfig,
@@ -53,13 +53,15 @@ export interface Processor {
 
   fetchAddressesByPath(path: Omit<AddressPath, 'addressIndex'>): Promise<AddressByScriptPubkey[]>
 
-  fetchAddressCountFromPathPartition(path: Omit<AddressPath, 'addressIndex'>): number
+  getNumAddressesFromPathPartition(path: Omit<AddressPath, 'addressIndex'>): number
 
   fetchScriptPubkeysByBalance(): Promise<ScriptPubkeysByBalance[]>
 
   saveAddress(data: IAddress): Promise<void>
 
   updateAddressByScriptPubkey(scriptPubkey: string, data: Partial<IAddress>): Promise<void>
+
+  getNumTransactions(): number
 
   fetchTxIdsByBlockHeight(blockHeightMin: number, blockHeightMax?: number): Promise<string[]>
 
@@ -181,7 +183,7 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
         scriptPubkeysByBalance.insert('', {
           [RANGE_ID_KEY]: data.scriptPubkey,
           [RANGE_KEY]: parseInt(data.balance)
-        }),
+        })
 
         // TODO: change to rangebase
         // addressByMRU.insert('', index, data)
@@ -193,7 +195,7 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
       await Promise.all([
         scriptPubkeysByBalance.delete('', parseInt(data.balance), data.scriptPubkey),
 
-        addressByScriptPubkey.delete('', [ data.scriptPubkey ]),
+        addressByScriptPubkey.delete('', [ data.scriptPubkey ])
 
         // TODO:
         // addressByMRU.delete()
@@ -521,7 +523,7 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
       return innerFetchAddressesByScriptPubkeys(scriptPubkeys)
     },
 
-    fetchAddressCountFromPathPartition(path: Omit<AddressPath, 'addressIndex'>): number {
+    getNumAddressesFromPathPartition(path: Omit<AddressPath, 'addressIndex'>): number {
       return scriptPubkeyByPath.length(addressPathToPrefix(path))
     },
 
@@ -542,6 +544,10 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
       await innerUpdateAddressByScriptPubkey(scriptPubkey, data)
     },
 
+    getNumTransactions(): number {
+      return txsByDate.size('')
+    },
+
     async fetchTransaction(txId: string): Promise<TxById> {
       const [ data ] = await txById.query('', [ txId ])
       return data
@@ -556,14 +562,24 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
 
     async fetchTransactions(opts: EdgeGetTransactionsOptions): Promise<IProcessorTransaction[]> {
       const {
-        startEntries = 10,
-        startIndex = 0
+        startEntries,
+        startIndex,
+        startDate,
+        endDate
       } = opts
-      const txData = await txsByDate.queryByCount('', startEntries, startIndex)
-      const txPromises = txData.map(async ({ [RANGE_ID_KEY]: txId }) => {
-        const [ tx ] = await txById.query('', [ txId ])
-        return tx
-      })
+
+      let txData: TxsByDate = []
+      if (startEntries && startIndex) {
+        txData = await txsByDate.queryByCount('', startEntries, startIndex)
+      } else if (startDate) {
+        txData = await txsByDate.query('', startDate.getTime(), endDate?.getTime())
+      } else {
+        txData = await txsByDate.query('', 0, Date.now())
+      }
+
+      const txPromises = txData.map(({ [RANGE_ID_KEY]: txId }) =>
+        txById.query('', [ txId ]).then(([ tx ]) => tx)
+      )
       return Promise.all(txPromises)
     },
 

--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -564,17 +564,15 @@ export async function makeProcessor(config: ProcessorConfig): Promise<Processor>
       const {
         startEntries,
         startIndex,
-        startDate,
-        endDate
+        startDate = new Date(0),
+        endDate = new Date()
       } = opts
 
       let txData: TxsByDate = []
-      if (startEntries && startIndex) {
+      if (startEntries != null && startIndex != null) {
         txData = await txsByDate.queryByCount('', startEntries, startIndex)
-      } else if (startDate) {
-        txData = await txsByDate.query('', startDate.getTime(), endDate?.getTime())
       } else {
-        txData = await txsByDate.query('', 0, Date.now())
+        txData = await txsByDate.query('', startDate.getTime(), endDate.getTime())
       }
 
       const txPromises = txData.map(({ [RANGE_ID_KEY]: txId }) =>

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -184,7 +184,7 @@ export async function makeUtxoEngine(config: EngineConfig): Promise<EdgeCurrency
     },
 
     getNumTransactions(_opts: EdgeCurrencyCodeOptions): number {
-      return 0
+      return processor.getNumTransactions()
     },
 
     async getPaymentProtocolInfo(paymentProtocolUrl: string): Promise<EdgePaymentProtocolInfo> {

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -69,10 +69,15 @@ export async function makeUtxoEngine(config: EngineConfig): Promise<EdgeCurrency
     metadata
   })
 
-  emitter.on(EmitterEvent.PROCESSOR_TRANSACTION_CHANGED, (tx: IProcessorTransaction) => {
-    emitter.emit(EmitterEvent.TRANSACTIONS_CHANGED, ([
-      toEdgeTransaction(tx, currencyInfo.currencyCode)
-    ]))
+  emitter.on(EmitterEvent.PROCESSOR_TRANSACTION_CHANGED, async (tx: IProcessorTransaction) => {
+    emitter.emit(EmitterEvent.TRANSACTIONS_CHANGED, [
+      await toEdgeTransaction({
+        tx,
+        currencyCode: currencyInfo.currencyCode,
+        walletTools,
+        processor
+      })
+    ])
   })
 
   emitter.on(EmitterEvent.BALANCE_CHANGED, async (currencyCode: string, nativeBalance: string) => {
@@ -202,7 +207,14 @@ export async function makeUtxoEngine(config: EngineConfig): Promise<EdgeCurrency
 
     async getTransactions(opts: EdgeGetTransactionsOptions): Promise<EdgeTransaction[]> {
       const txs = await processor.fetchTransactions(opts)
-      return txs.map((tx) => toEdgeTransaction(tx, currencyInfo.currencyCode))
+      return await Promise.all(txs.map((tx: IProcessorTransaction) =>
+        toEdgeTransaction({
+          tx,
+          currencyCode: currencyInfo.currencyCode,
+          walletTools,
+          processor
+        })
+      ))
     },
 
     // @ts-ignore

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -202,7 +202,7 @@ const setLookAhead = async (args: SetLookAheadArgs) => {
       }
 
       const getLastUsed = () => findLastUsedIndex({ ...args, ...partialPath })
-      const getAddressCount = () => processor.fetchAddressCountFromPathPartition(partialPath)
+      const getAddressCount = () => processor.getNumAddressesFromPathPartition(partialPath)
 
       while (await getLastUsed() + currencyInfo.gapLimit > getAddressCount()) {
         const path: AddressPath = {
@@ -307,7 +307,7 @@ const getFormatAddressCount = async (args: GetFormatAddressCountArgs): Promise<n
 
   const branches = getFormatSupportedBranches(format)
   for (const branch of branches) {
-    let branchCount = await processor.fetchAddressCountFromPathPartition({ format, changeIndex: branch })
+    let branchCount = await processor.getNumAddressesFromPathPartition({ format, changeIndex: branch })
     if (branchCount < currencyInfo.gapLimit) branchCount = currencyInfo.gapLimit
     count += branchCount
   }
@@ -338,7 +338,7 @@ const findLastUsedIndex = async (args: FindLastUsedIndexArgs): Promise<number> =
     changeIndex,
     addressIndex: 0 // tmp
   }
-  const addressCount = await processor.fetchAddressCountFromPathPartition(path)
+  const addressCount = await processor.getNumAddressesFromPathPartition(path)
   // Get the assumed last used index
   path.addressIndex = Math.max(addressCount - currencyInfo.gapLimit - 1, 0)
 
@@ -427,7 +427,7 @@ const processPathAddresses = async (args: ProcessPathAddressesArgs) => {
     changeIndex
   } = args
 
-  const addressCount = await processor.fetchAddressCountFromPathPartition({ format, changeIndex })
+  const addressCount = await processor.getNumAddressesFromPathPartition({ format, changeIndex })
   for (let i = 0; i < addressCount; i++) {
     const path: AddressPath = {
       format,


### PR DESCRIPTION
### Correctly Fetching Transaction Data
The function `fetchTransactions` did not properly fetch data from the database. If no params from the function arguments match, return all transaction in the db. Also because an `EdgeTransaction` has a parameter `ourReceiveAddresses` I remap the values stored in the db for `ourOuts` to get the `scriptPubkey` from the db and convert it to the addresses expected.