### PR TITLE
Sweep private key

### DIFF
--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -9,7 +9,7 @@ import {
   EdgeWalletInfo
 } from 'edge-core-js/lib/types/types'
 
-import { IProcessorTransaction } from '../utxobased/db/types'
+import { IProcessorTransaction, IUTXO } from '../utxobased/db/types'
 
 // this enumerates the network types of single coins. Can be expanded to add regtest, signet, stagenet etc.
 export enum NetworkEnum {
@@ -27,6 +27,11 @@ export interface AddressPath {
 
 export enum EngineCurrencyType {
   UTXO
+}
+
+export interface TxOptions {
+  utxos?: IUTXO[]
+  subtractFee?: boolean
 }
 
 export interface EngineCurrencyInfo extends EdgeCurrencyInfo {

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -252,7 +252,10 @@ export async function makeUtxoEngine(
       return !!addressData?.used
     },
 
-    async makeSpend(edgeSpendInfo: EdgeSpendInfo, options?: TxOptions): Promise<EdgeTransaction> {
+    async makeSpend(
+      edgeSpendInfo: EdgeSpendInfo,
+      options?: TxOptions
+    ): Promise<EdgeTransaction> {
       const targets: MakeTxTarget[] = []
       const ourReceiveAddresses: string[] = []
       for (const target of edgeSpendInfo.spendTargets) {
@@ -449,7 +452,8 @@ export async function makeUtxoEngine(
           spendInfo.spendTargets = [
             { publicAddress: publicAddress.publicAddress, nativeAmount }
           ]
-
+          // TODO: TheCharlatan - add option to makeSpend declaration in edge-core-js
+          // @ts-expect-error
           this.makeSpend(spendInfo, options)
             .then(tx => success(tx))
             .catch(e => failure(e))

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -438,8 +438,6 @@ export async function makeUtxoEngine(
         if (ratio === 1) {
           await engineState.stop()
           await blockBook.disconnect()
-          config.options.emitter = emitter
-          config.currencyInfo.gapLimit = currencyInfo.gapLimit
 
           const utxos = await processor.fetchAllUtxos()
           if (utxos === null || utxos.length < 1) {
@@ -458,11 +456,17 @@ export async function makeUtxoEngine(
         }
       })
 
-      config.options.emitter = tmpEmitter
-      // hack to not overflow the wallet tools private key array
-      config.currencyInfo.gapLimit = privateKeys.length + 1
       const engineState = makeUtxoEngineState({
         ...config,
+        options: {
+          ...config.options,
+          emitter: tmpEmitter
+        },
+        currencyInfo: {
+          ...config.currencyInfo,
+          // hack to not overflow the wallet tools private key array
+          gapLimit: privateKeys.length + 1
+        },
         walletTools: tmpWalletTools,
         processor: tmpProcessor,
         blockBook,

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -13,8 +13,9 @@ import {
   EdgeTxidMap,
   JsonObject
 } from 'edge-core-js'
+import { EventEmitter } from 'events'
 
-import { EmitterEvent, EngineConfig } from '../../plugin/types'
+import { EmitterEvent, EngineConfig, TxOptions } from '../../plugin/types'
 import { clearMetadata, fetchMetadata, setMetadata } from '../../plugin/utils'
 import { makeProcessor } from '../db/makeProcessor'
 import {
@@ -251,7 +252,7 @@ export async function makeUtxoEngine(
       return !!addressData?.used
     },
 
-    async makeSpend(edgeSpendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
+    async makeSpend(edgeSpendInfo: EdgeSpendInfo, options?: TxOptions): Promise<EdgeTransaction> {
       const targets: MakeTxTarget[] = []
       const ourReceiveAddresses: string[] = []
       for (const target of edgeSpendInfo.spendTargets) {
@@ -273,9 +274,12 @@ export async function makeUtxoEngine(
       }
 
       const freshAddress = await state.getFreshAddress(1)
-      const freshChangeAddress =
-        freshAddress.segwitAddress ?? freshAddress.publicAddress
-      const utxos = await processor.fetchAllUtxos()
+      const freshChangeAddress = freshAddress.segwitAddress ?? freshAddress.publicAddress
+      const utxos = options?.utxos ?? (await processor.fetchAllUtxos())
+      let subtractFee = false
+      if (options != null) {
+        subtractFee = options.subtractFee ?? false
+      }
       const feeRate = parseInt(calculateFeeRate(currencyInfo, edgeSpendInfo))
       const tx = await makeTx({
         utxos,
@@ -284,7 +288,8 @@ export async function makeUtxoEngine(
         coin: currencyInfo.network,
         network,
         rbf: false,
-        freshChangeAddress
+        freshChangeAddress,
+        subtractFee
       })
       if (tx.changeUsed) {
         ourReceiveAddresses.push(freshChangeAddress)
@@ -388,11 +393,83 @@ export async function makeUtxoEngine(
       return transaction
     },
 
-    async sweepPrivateKeys(
-      _spendInfo: EdgeSpendInfo
-    ): Promise<EdgeTransaction> {
-      // @ts-expect-error
-      return await Promise.resolve(undefined)
+    async sweepPrivateKeys(spendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
+      const privateKeys = spendInfo.privateKeys ?? []
+      if (privateKeys.length < 1) throw new Error('No private keys given')
+      let success: (
+        value: EdgeTransaction | PromiseLike<EdgeTransaction>
+      ) => void
+      let failure: (reason?: any) => void
+      const end: Promise<EdgeTransaction> = new Promise((resolve, reject) => {
+        success = resolve
+        failure = reject
+      })
+      const tmpDisklet = walletLocalDisklet
+      const tmpMetadata = await fetchMetadata(tmpDisklet)
+
+      const tmpEmitter = new EventEmitter() as any
+      tmpEmitter.on(
+        EmitterEvent.BALANCE_CHANGED,
+        async (currencyCode: string, nativeBalance: string) => {
+          metadata.balance = nativeBalance
+          await setMetadata(tmpDisklet, tmpMetadata)
+        }
+      )
+      tmpEmitter.on(
+        EmitterEvent.BLOCK_HEIGHT_CHANGED,
+        async (height: number) => {
+          metadata.lastSeenBlockHeight = height
+          await setMetadata(tmpDisklet, tmpMetadata)
+        }
+      )
+
+      const tmpProcessor = await makeProcessor({
+        disklet: tmpDisklet,
+        emitter: tmpEmitter
+      })
+      const blockBook = makeBlockBook({ emitter: tmpEmitter })
+      const tmpWalletTools = makeUtxoWalletTools({
+        keys: { wifKeys: privateKeys },
+        coin: currencyInfo.network,
+        network
+      })
+
+      tmpEmitter.on(EmitterEvent.ADDRESSES_CHECKED, async (ratio: number) => {
+        if (ratio === 1) {
+          await engineState.stop()
+          await blockBook.disconnect()
+          config.options.emitter = emitter
+          config.currencyInfo.gapLimit = currencyInfo.gapLimit
+
+          const utxos = await processor.fetchAllUtxos()
+          if (utxos === null || utxos.length < 1) {
+            throw new Error('Private key has no funds')
+          }
+          const publicAddress = await this.getFreshAddress({})
+          const nativeAmount = tmpMetadata.balance
+          const options: TxOptions = { utxos, subtractFee: true }
+          spendInfo.spendTargets = [
+            { publicAddress: publicAddress.publicAddress, nativeAmount }
+          ]
+
+          this.makeSpend(spendInfo, options)
+            .then(tx => success(tx))
+            .catch(e => failure(e))
+        }
+      })
+
+      config.options.emitter = tmpEmitter
+      // hack to not overflow the wallet tools private key array
+      config.currencyInfo.gapLimit = privateKeys.length + 1
+      const engineState = makeUtxoEngineState({
+        ...config,
+        walletTools: tmpWalletTools,
+        processor: tmpProcessor,
+        blockBook,
+        metadata: tmpMetadata
+      })
+      await engineState.start()
+      return end
     }
   }
 

--- a/src/common/utxobased/keymanager/keymanager.ts
+++ b/src/common/utxobased/keymanager/keymanager.ts
@@ -204,6 +204,7 @@ export interface MakeTxArgs {
   rbf: boolean
   coin: string
   freshChangeAddress: string
+  subtractFee?: boolean
 }
 
 export interface MakeTxTarget {
@@ -927,12 +928,11 @@ export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
     coin: coin.name,
     network: args.network
   })
-  const result = utxopicker.accumulative(
-    mappedUtxos,
-    targets,
-    args.feeRate,
-    changeScript
-  )
+  const subtractFee = args.subtractFee ?? false
+  const utxopicking = subtractFee
+    ? utxopicker.subtractFee
+    : utxopicker.accumulative
+  const result = utxopicking(mappedUtxos, targets, args.feeRate, changeScript)
   if (!result.inputs || !result.outputs) {
     throw new Error('Make spend failed.')
   }

--- a/src/common/utxobased/keymanager/utxopicker.ts
+++ b/src/common/utxobased/keymanager/utxopicker.ts
@@ -1,2 +1,3 @@
 export * from './utxopicker/types'
 export * from './utxopicker/accumulative'
+export * from './utxopicker/subtractFee'

--- a/src/common/utxobased/keymanager/utxopicker/subtractFee.ts
+++ b/src/common/utxobased/keymanager/utxopicker/subtractFee.ts
@@ -15,5 +15,5 @@ export function subtractFee(
   const fee = feeRate * utils.transactionBytes(utxos, outputs)
   targets[0].value -= fee
   outputs[0].value -= fee
-  return { inputs: utxos, outputs, fee }
+  return { inputs: utxos, outputs, fee, changeUsed: false }
 }

--- a/src/common/utxobased/keymanager/utxopicker/subtractFee.ts
+++ b/src/common/utxobased/keymanager/utxopicker/subtractFee.ts
@@ -1,0 +1,19 @@
+import { Output, Result, Target, UTXO } from './types'
+import * as utils from './utils'
+
+export function subtractFee(
+  utxos: UTXO[],
+  targets: Target[],
+  feeRate: number,
+  _changeScript: string
+): Result {
+  const outputs: Output[] = targets.map(target => ({
+    ...target,
+    script: Buffer.from(target.script, 'hex')
+  }))
+
+  const fee = feeRate * utils.transactionBytes(utxos, outputs)
+  targets[0].value -= fee
+  outputs[0].value -= fee
+  return { inputs: utxos, outputs, fee }
+}


### PR DESCRIPTION
Based on #73 and #74.

Sweep private key is implemented in the UtxoEngine's sweepPrivateKey function. To facilitate fetching the to be spent utxos, a temporary engine state is created. The UtxoEngineState emitter is in turn used as a callback to notify when all addresses have been scanned. The callback then resolves the Promise of the sweepPrivateKey function. On success, it returns an unsigned EdgeTransaction.

To support sweepPrivateKey, additional changes were done in the wallet tools to support wif keys and the keymanager to support creating transactions with pre-selected UTXOs.