### PR TITLE
Network refactor

### DIFF
--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -86,7 +86,10 @@ export interface Emitter {
     ) => this) &
     ((event: EmitterEvent.BLOCK_HEIGHT_CHANGED, blockHeight: number) => this) &
     ((event: EmitterEvent.ADDRESSES_CHECKED, progressRatio: number) => this) &
-    ((event: EmitterEvent.TXIDS_CHANGED, txids: EdgeTxidMap) => this)
+    ((event: EmitterEvent.TXIDS_CHANGED, txids: EdgeTxidMap) => this) &
+    ((event: EmitterEvent.CONNECTION_OPEN) => void) &
+    ((event: EmitterEvent.CONNECTION_CLOSE, error?: Error) => this) &
+    ((event: EmitterEvent.CONNECTION_TIMER, queryTime: number) => this)
 
   on: ((
     event: EmitterEvent.TRANSACTIONS_CHANGED,
@@ -114,6 +117,15 @@ export interface Emitter {
     ((
       event: EmitterEvent.TXIDS_CHANGED,
       listener: (txids: EdgeTxidMap) => void | Promise<void>
+    ) => this) &
+    ((event: EmitterEvent.CONNECTION_OPEN, listener: () => void) => this) &
+    ((
+      event: EmitterEvent.CONNECTION_CLOSE,
+      listener: (error?: Error) => void
+    ) => this) &
+    ((
+      event: EmitterEvent.CONNECTION_TIMER,
+      listener: (queryTime: number) => void
     ) => this)
 }
 
@@ -122,6 +134,9 @@ export enum EmitterEvent {
   PROCESSOR_TRANSACTION_CHANGED = 'processor:transactions:changed',
   BALANCE_CHANGED = 'balance:changed',
   BLOCK_HEIGHT_CHANGED = 'block:height:changed',
+  CONNECTION_OPEN = 'connection:open',
+  CONNECTION_CLOSE = 'connection:close',
+  CONNECTION_TIMER = 'connection:timer',
   ADDRESSES_CHECKED = 'addresses:checked',
   TXIDS_CHANGED = 'txids:changed'
 }

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -81,7 +81,7 @@ export async function makeUtxoEngine(
     network
   })
 
-  const blockBook = makeBlockBook({ emitter })
+  const blockBook = makeBlockBook({ emitter, log: io.console })
   let metadata = await fetchMetadata(walletLocalDisklet)
   const processor = await makeProcessor({
     disklet: walletLocalDisklet,
@@ -446,7 +446,7 @@ export async function makeUtxoEngine(
         disklet: tmpDisklet,
         emitter: tmpEmitter
       })
-      const blockBook = makeBlockBook({ emitter: tmpEmitter })
+      const blockBook = makeBlockBook({ emitter: tmpEmitter, log: io.console })
       const tmpWalletTools = makeUtxoWalletTools({
         keys: { wifKeys: privateKeys },
         coin: currencyInfo.network,

--- a/src/common/utxobased/network/BlockBook.ts
+++ b/src/common/utxobased/network/BlockBook.ts
@@ -1,4 +1,4 @@
-import { EdgeTransaction } from 'edge-core-js'
+import { EdgeConsole, EdgeTransaction } from 'edge-core-js'
 
 import { Emitter, EmitterEvent } from '../../plugin/types'
 import { makeSocket, potentialWsTask, WsTask } from './Socket'
@@ -148,12 +148,13 @@ export interface BlockHeightEmitter {
 interface BlockBookConfig {
   emitter: Emitter
   wsAddress?: string
+  log: EdgeConsole
 }
 
 const baseUri = 'btc1.trezor.io'
 
 export function makeBlockBook(config: BlockBookConfig): BlockBook {
-  const emitter = config.emitter
+  const { emitter, log } = config
   const baseWSAddress = config.wsAddress ?? `wss://${baseUri}/websocket`
 
   const instance: BlockBook = {
@@ -183,6 +184,7 @@ export function makeBlockBook(config: BlockBookConfig): BlockBook {
   const socket = makeSocket(baseWSAddress, {
     healthCheck: ping,
     onQueueSpace,
+    log,
     emitter
   })
 

--- a/src/common/utxobased/network/BlockBook.ts
+++ b/src/common/utxobased/network/BlockBook.ts
@@ -1,26 +1,16 @@
 import { EdgeTransaction } from 'edge-core-js'
 
-import { EmitterEvent } from '../../plugin/types'
-import { makeSocket } from './Socket'
+import { Emitter, EmitterEvent } from '../../plugin/types'
+import { makeSocket, potentialWsTask, WsTask } from './Socket'
 
 export interface INewTransactionResponse {
   address: string
   tx: ITransaction
 }
 
-interface IWsPendingMessages {
-  [id: string]: Function
-}
-
-interface IWsMessage {
-  id: string
-  method: string
-  params?: object
-}
-
-interface IWsResponse {
-  id: string
-  data: any
+export interface INewBlockResponse {
+  height: number
+  hash: string
 }
 
 export interface IAccountDetailsBasic {
@@ -139,7 +129,7 @@ export interface BlockBook {
 
   watchAddresses: (
     addresses: string[],
-    cb?: (response: INewTransactionResponse) => Promise<void>
+    cb: (response: INewTransactionResponse) => Promise<void>
   ) => void
 
   watchBlocks: (cb: () => void | Promise<void>) => void
@@ -156,12 +146,11 @@ export interface BlockHeightEmitter {
 }
 
 interface BlockBookConfig {
-  emitter: BlockHeightEmitter
+  emitter: Emitter
   wsAddress?: string
 }
 
 const baseUri = 'btc1.trezor.io'
-const PING_TIMEOUT = 30000
 
 export function makeBlockBook(config: BlockBookConfig): BlockBook {
   const emitter = config.emitter
@@ -179,81 +168,35 @@ export function makeBlockBook(config: BlockBookConfig): BlockBook {
     fetchTransaction,
     broadcastTx
   }
-  let wsIdCounter = 0
-  const wsPendingMessages: IWsPendingMessages = {}
-  let pingTimeout!: NodeJS.Timeout
-  let addressesToWatch: string[] = []
-  let addressWatcherCallback:
-    | undefined
-    | ((response: INewTransactionResponse) => void)
-  let blockWatcherCallback: Callback = () => {}
-  const PING_ID = 'ping'
-  const WATCH_NEW_BLOCK_EVENT_ID = 'WATCH_NEW_BLOCK_EVENT_ID'
-  const WATCH_ADDRESS_TX_EVENT_ID = 'WATCH_ADDRESS_TX_EVENT_ID'
+
+  emitter.on(EmitterEvent.CONNECTION_OPEN, () => {})
+  emitter.on(EmitterEvent.CONNECTION_CLOSE, (error?: Error) => {
+    if (error != null) {
+      throw new Error(`connection closing due to ${error.message}`)
+    }
+  })
+  emitter.on(EmitterEvent.CONNECTION_TIMER, (queryTime: number) => {})
+  const onQueueSpace = (): potentialWsTask => {
+    return {}
+  }
 
   const socket = makeSocket(baseWSAddress, {
-    callbacks: {
-      onMessage(message: string) {
-        if (!instance.isConnected) return
-        const response: IWsResponse = JSON.parse(message)
-
-        switch (response.id) {
-          case PING_ID:
-            console.log('ping')
-            pingTimeout = setTimeout(ping, PING_TIMEOUT)
-            break
-          case WATCH_NEW_BLOCK_EVENT_ID:
-            // Don't notify on successful subscribe
-            if (response.data?.subscribed === true) {
-              return
-            }
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            blockWatcherCallback()
-            emitter.emit(
-              EmitterEvent.BLOCK_HEIGHT_CHANGED,
-              response.data.height
-            )
-            break
-          case WATCH_ADDRESS_TX_EVENT_ID:
-            // Don't notify on successful subscribe
-            if (response.data?.subscribed === true) {
-              return
-            }
-            break
-        }
-
-        const fn = wsPendingMessages[response.id]
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-        delete wsPendingMessages[response.id]
-        if ('error' in response.data) {
-          throw response.data.error
-        } else {
-          fn?.(response.data)
-        }
-      }
-    }
+    healthCheck: ping,
+    onQueueSpace,
+    emitter
   })
 
   async function connect(): Promise<void> {
     if (instance.isConnected) return
 
     await socket.connect()
-
-    instance.isConnected = true
-    // Ping the server for a pong response and start a timeout
-    ping()
-    watchAddresses(addressesToWatch, addressWatcherCallback)
-    sendWsMessage({
-      id: WATCH_NEW_BLOCK_EVENT_ID,
-      method: 'subscribeNewBlock'
-    })
+    instance.isConnected = socket.isConnected()
   }
 
   async function disconnect(): Promise<void> {
     if (!instance.isConnected) return
 
     socket.disconnect()
-    clearTimeout(pingTimeout)
     instance.isConnected = false
   }
 
@@ -261,26 +204,17 @@ export function makeBlockBook(config: BlockBookConfig): BlockBook {
     method: string,
     params?: object
   ): Promise<T> {
-    return await new Promise(resolve => {
-      const id = wsIdCounter++
-      sendWsMessage({ id: id.toString(), method, params }, resolve)
+    return await new Promise((resolve, reject) => {
+      sendWsMessage({ method, params, resolve, reject })
     })
   }
 
-  function sendWsMessage(message: IWsMessage, cb?: Function): void {
-    if (!instance.isConnected) {
-      throw new Error('BlockBook websocket not connected')
-    }
-
-    if (cb != null) wsPendingMessages[message.id] = cb
-    socket.send(JSON.stringify(message))
+  function sendWsMessage(task: WsTask): void {
+    socket.submitTask(task)
   }
 
-  function ping(): void {
-    sendWsMessage({
-      id: PING_ID,
-      method: PING_ID
-    })
+  async function ping(): Promise<object> {
+    return await promisifyWsMessage('ping')
   }
 
   async function fetchInfo(): Promise<IServerInfo> {
@@ -307,28 +241,28 @@ export function makeBlockBook(config: BlockBookConfig): BlockBook {
     })
   }
 
-  function watchBlocks(cb: Callback): void {
-    blockWatcherCallback = cb
+  async function watchBlocks(cb: Callback): Promise<void> {
+    const socketCb = async (value: INewBlockResponse): Promise<void> => {
+      // eslint-disable-next-line no-void
+      await cb()
+      emitter.emit(EmitterEvent.BLOCK_HEIGHT_CHANGED, value.height)
+    }
+    socket.subscribe({
+      method: 'subscribeNewBlock',
+      params: {},
+      cb: socketCb
+    })
   }
 
   function watchAddresses(
     addresses: string[],
-    cb?: (response: INewTransactionResponse) => void
+    cb: (response: INewTransactionResponse) => Promise<void>
   ): void {
-    addressesToWatch = addresses
-    addressWatcherCallback = cb
-    sendWsMessage(
-      {
-        id: WATCH_ADDRESS_TX_EVENT_ID,
-        method: 'subscribeAddresses',
-        params: { addresses }
-      },
-      async (response: INewTransactionResponse) => {
-        // Need to resubscribe to addresses
-        await watchAddresses(addressesToWatch, cb)
-        cb?.(response)
-      }
-    )
+    socket.subscribe({
+      method: 'subscribeAddresses',
+      params: { addresses },
+      cb
+    })
   }
 
   async function fetchAddressUtxos(account: string): Promise<IAccountUTXO[]> {

--- a/src/common/utxobased/network/Socket.ts
+++ b/src/common/utxobased/network/Socket.ts
@@ -1,40 +1,271 @@
-import WS from 'ws'
+import { Emitter, EmitterEvent } from '../../plugin/types'
+import { setupWS } from './nodejsWS'
+import { pushUpdate, removeIdFromQueue } from './socketQueue'
+import { InnerSocket, InnerSocketCallbacks, ReadyState } from './types'
+import { setupBrowser } from './windowWS'
 
-export enum ReadyState {
-  CONNECTING,
-  OPEN,
-  CLOSING,
-  CLOSED
+const TIMER_SLACK = 500
+const KEEP_ALIVE_MS = 60000
+
+export type OnFailHandler = (error: Error) => void
+
+export interface potentialWsTask {
+  task?: WsTask
 }
 
-// cb?: (ev: MessageEvent) => any
-export interface Socket extends InnerSocket {
-  connect: () => Promise<void>
+export interface WsTask {
+  method: string
+  params: object | undefined
+  resolve: (value: any) => void
+  reject: (reason?: any) => void
 }
 
-interface InnerSocket {
+export interface WsSubscription {
+  method: string
+  params: object | undefined
+  cb: (value: any) => void
+}
+
+export interface Socket {
   readyState: ReadyState
+  connect: () => Promise<void>
   disconnect: () => void
-  send: (data: string) => void
+  submitTask: (task: WsTask) => void
+  subscribe: (subscription: WsSubscription) => void
+  isConnected: () => boolean
 }
 
 interface SocketConfig {
-  callbacks?: SocketCallbacks
+  queueSize?: number
+  timeout?: number
+  walletId?: string
+  emitter: Emitter
+  onQueueSpace: () => potentialWsTask
+  healthCheck: () => Promise<object> // function for heartbeat, should submit task itself
 }
 
-export interface SocketCallbacks {
-  onError?: (error?: Error) => void
-  onMessage?: (message: string) => void
+interface WsMessage {
+  task: WsTask
+  startTime: number
 }
 
-export interface InnerSocketCallbacks extends SocketCallbacks {
-  onOpen: () => void
-}
-
-export function makeSocket(uri: string, config?: SocketConfig): Socket {
+export function makeSocket(uri: string, config: SocketConfig): Socket {
   let socket: InnerSocket | null
+  const { emitter, onQueueSpace, queueSize = 5, walletId = '' } = config
+  const version = ''
+  const subscriptions: Map<string, WsSubscription> = new Map()
+  let pendingMessages: Map<string, WsMessage> = new Map()
+  let nextId = 0
+  let lastKeepAlive = 0
+  let connected = false
+  let cancelConnect = false
+  const timeout: number = 1000 * (config.timeout ?? 30)
+  let error: Error | undefined
+  let timer: NodeJS.Timeout
 
-  // return socket
+  const handleError = (e: Error): void => {
+    if (error == null) error = e
+    if (connected && socket != null && socket.readyState === ReadyState.OPEN)
+      disconnect()
+    else cancelConnect = true
+    console.log('handled error!', e)
+  }
+
+  const logError = (e: Error): void => {
+    // TODO: change this to edge log
+    console.error(`${e.message}`)
+  }
+
+  const disconnect = (): void => {
+    clearTimeout(timer)
+    connected = false
+    if (socket != null) socket.disconnect()
+    removeIdFromQueue(uri)
+  }
+
+  const onSocketClose = (): void => {
+    const err = error ?? new Error('Socket close')
+    clearTimeout(timer)
+    connected = false
+    socket = null
+    cancelConnect = false
+    pendingMessages.forEach((message, _id) => {
+      try {
+        message.task.reject(err)
+      } catch (e) {
+        logError(e)
+      }
+    })
+    pendingMessages = new Map()
+    try {
+      emitter.emit(EmitterEvent.CONNECTION_CLOSE, err)
+    } catch (e) {
+      logError(e)
+    }
+  }
+
+  const onSocketConnect = (): void => {
+    if (cancelConnect) {
+      if (socket != null) socket.disconnect()
+      return
+    }
+    connected = true
+    lastKeepAlive = Date.now()
+    try {
+      emitter.emit(EmitterEvent.CONNECTION_OPEN)
+    } catch (e) {
+      handleError(e)
+    }
+    pendingMessages.forEach((message, id) => {
+      transmitMessage(id, message)
+    })
+
+    wakeUp()
+    cancelConnect = false
+  }
+
+  const wakeUp = (): void => {
+    pushUpdate({
+      id: walletId + '==' + uri,
+      updateFunc: () => {
+        doWakeUp()
+      }
+    })
+  }
+
+  const doWakeUp = (): void => {
+    if (connected && version != null) {
+      while (pendingMessages.size < queueSize) {
+        const task = onQueueSpace()
+        if (task.task == null) break
+        submitTask(task.task)
+      }
+    }
+  }
+
+  const subscribe = (subscription: WsSubscription): void => {
+    if (socket != null && socket.readyState === ReadyState.OPEN && connected) {
+      const id = subscription.method
+      const message = {
+        id,
+        method: subscription.method,
+        params: subscription.params ?? {}
+      }
+      subscriptions.set(id, subscription)
+      socket.send(JSON.stringify(message))
+    }
+  }
+
+  const submitTask = (task: WsTask): void => {
+    const id = (nextId++).toString()
+    const message = { task, startTime: Date.now() }
+    pendingMessages.set(id.toString(), message)
+    transmitMessage(id, message)
+  }
+
+  const transmitMessage = (id: string, pending: WsMessage): void => {
+    const now = Date.now()
+    if (
+      socket != null &&
+      socket.readyState === ReadyState.OPEN &&
+      connected &&
+      !cancelConnect
+    ) {
+      pending.startTime = now
+      const message = {
+        id,
+        method: pending.task.method,
+        params: pending.task.params ?? {}
+      }
+      socket.send(JSON.stringify(message))
+    }
+  }
+
+  const onTimer = (): void => {
+    const now = Date.now() - TIMER_SLACK
+    if (lastKeepAlive + KEEP_ALIVE_MS < now) {
+      lastKeepAlive = now
+      // eslint-disable-next-line no-void
+      void config
+        .healthCheck()
+        .catch((e: Error) => handleError(e))
+        .then(() => {
+          emitter.emit(EmitterEvent.CONNECTION_TIMER, now)
+        })
+    }
+
+    pendingMessages.forEach((message, id) => {
+      if (message.startTime + timeout < now) {
+        try {
+          message.task.reject(new Error('Timeout'))
+        } catch (e) {
+          logError(e)
+        }
+        pendingMessages.delete(id)
+      }
+    })
+    setupTimer()
+  }
+
+  const setupTimer = (): void => {
+    let nextWakeUp = lastKeepAlive + KEEP_ALIVE_MS
+    pendingMessages.forEach((message, _id) => {
+      const to = message.startTime + timeout
+      if (to < nextWakeUp) nextWakeUp = to
+    })
+
+    const now = Date.now() - TIMER_SLACK
+    const delay = nextWakeUp < now ? 0 : nextWakeUp - now
+    timer = setTimeout(() => onTimer(), delay)
+  }
+
+  const onMessage = (messageJson: string): void => {
+    try {
+      const json = JSON.parse(messageJson)
+      if (json.id != null) {
+        const id: string = json.id.toString()
+        for (const cId of subscriptions.keys()) {
+          if (id === cId) {
+            const subscription = subscriptions.get(id)
+            if (subscription == null) {
+              throw new Error(`cannot find subscription for ${id}`)
+            }
+            if (json.data?.subscribed != null) {
+              // dropping subscription accepted message
+              return
+            }
+            subscription.cb(json.data)
+            return
+          }
+        }
+        const message = pendingMessages.get(id)
+        if (message == null) {
+          throw new Error(`Bad response id in ${messageJson}`)
+        }
+        pendingMessages.delete(id)
+        const { error } = json
+        try {
+          if (error != null) {
+            const errorMessage =
+              error.message != null
+                ? error.message.split('\n')[0]
+                : error.connected
+            throw new Error(errorMessage)
+          }
+          message.task.resolve(json.data)
+        } catch (e) {
+          message.task.reject(e)
+        }
+      }
+    } catch (e) {
+      handleError(e)
+    }
+    wakeUp()
+  }
+
+  setupTimer()
+
+  // return a Socket
   return {
     get readyState(): ReadyState {
       return socket?.readyState ?? ReadyState.CLOSED
@@ -44,17 +275,22 @@ export function makeSocket(uri: string, config?: SocketConfig): Socket {
       socket?.disconnect()
 
       return await new Promise<void>(resolve => {
-        const callbacks: InnerSocketCallbacks = {
-          ...config?.callbacks,
-          onOpen() {
+        const cbs: InnerSocketCallbacks = {
+          onOpen: () => {
+            onSocketConnect()
             resolve()
-          }
+          },
+          onMessage: onMessage,
+          onError: event => {
+            error = new Error(JSON.stringify(event))
+          },
+          onClose: onSocketClose
         }
 
         try {
-          socket = setupBrowser(uri, callbacks)
+          socket = setupBrowser(uri, cbs)
         } catch {
-          socket = setupWS(uri, callbacks)
+          socket = setupWS(uri, cbs)
         }
       })
     },
@@ -62,108 +298,19 @@ export function makeSocket(uri: string, config?: SocketConfig): Socket {
     disconnect() {
       socket?.disconnect()
       socket = null
+      disconnect()
     },
 
-    send(data: string): void {
-      socket?.send?.(data)
-    }
-  }
-}
-
-function setupBrowser(
-  uri: string,
-  callbacks?: InnerSocketCallbacks
-): InnerSocket {
-  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-  if (!window?.WebSocket)
-    throw Error('Native browser WebSocket does not exists')
-
-  const socket = new window.WebSocket(uri)
-  socket.onopen = () => {
-    callbacks?.onOpen?.()
-  }
-  socket.onmessage = (message: MessageEvent) => {
-    callbacks?.onMessage?.(message.data.toString())
-  }
-  socket.onerror = () => {
-    callbacks?.onError?.()
-  }
-
-  return {
-    get readyState(): ReadyState {
-      switch (socket?.readyState) {
-        case WebSocket.CONNECTING:
-          return ReadyState.CONNECTING
-        case WebSocket.OPEN:
-          return ReadyState.OPEN
-        case WebSocket.CLOSING:
-          return ReadyState.CLOSING
-        case WebSocket.CLOSED:
-        default:
-          return ReadyState.CLOSED
-      }
+    isConnected(): boolean {
+      return socket?.readyState === ReadyState.OPEN
     },
 
-    disconnect() {
-      if (
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        !socket ||
-        socket.readyState === WebSocket.CLOSING ||
-        socket.readyState === WebSocket.CLOSED
-      )
-        return
-
-      socket.close()
+    submitTask(task: WsTask): void {
+      submitTask(task)
     },
 
-    send(data: string) {
-      socket?.send(data)
-    }
-  }
-}
-
-function setupWS(uri: string, callbacks?: InnerSocketCallbacks): InnerSocket {
-  const ws = new WS(uri)
-
-  ws.on('open', () => {
-    callbacks?.onOpen?.()
-  })
-
-  ws.on('message', (data: WS.Data) => {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    callbacks?.onMessage?.(data.toString())
-  })
-
-  ws.on('error', error => {
-    callbacks?.onError?.(error)
-  })
-
-  return {
-    get readyState(): ReadyState {
-      switch (ws.readyState) {
-        case WS.CONNECTING:
-          return ReadyState.CONNECTING
-        case WS.OPEN:
-          return ReadyState.OPEN
-        case WS.CLOSING:
-          return ReadyState.CLOSING
-        case WS.CLOSED:
-        default:
-          return ReadyState.CLOSED
-      }
-    },
-
-    disconnect(): void {
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-      if (!ws || ws.readyState === WS.CLOSING || ws.readyState === WS.CLOSED)
-        return
-
-      ws.removeAllListeners()
-      ws.terminate()
-    },
-
-    send(data: string): void {
-      ws.send(data)
+    subscribe(subscription: WsSubscription): void {
+      subscribe(subscription)
     }
   }
 }

--- a/src/common/utxobased/network/nodejsWS.ts
+++ b/src/common/utxobased/network/nodejsWS.ts
@@ -1,0 +1,55 @@
+import WS from 'ws'
+
+import { InnerSocket, InnerSocketCallbacks, ReadyState } from './types'
+
+export function setupWS(
+  uri: string,
+  callbacks: InnerSocketCallbacks
+): InnerSocket {
+  const ws = new WS(uri)
+
+  ws.on('open', () => {
+    callbacks.onOpen()
+  })
+  ws.on('message', (data: WS.Data) => {
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+    callbacks.onMessage(data.toString())
+  })
+  ws.on('error', error => {
+    callbacks.onError(error)
+  })
+  ws.on('close', event => {
+    callbacks.onClose()
+  })
+
+  return {
+    get readyState(): ReadyState {
+      switch (ws.readyState) {
+        case WS.CONNECTING:
+          return ReadyState.CONNECTING
+        case WS.OPEN:
+          return ReadyState.OPEN
+        case WS.CLOSING:
+          return ReadyState.CLOSING
+        case WS.CLOSED:
+        default:
+          return ReadyState.CLOSED
+      }
+    },
+
+    disconnect(): void {
+      if (
+        ws == null ||
+        ws.readyState === WS.CLOSING ||
+        ws.readyState === WS.CLOSED
+      )
+        return
+      ws.removeAllListeners()
+      ws.close()
+    },
+
+    send(data: string): void {
+      ws.send(data)
+    }
+  }
+}

--- a/src/common/utxobased/network/socketQueue.ts
+++ b/src/common/utxobased/network/socketQueue.ts
@@ -1,0 +1,59 @@
+const QUEUE_JOBS_PER_RUN = 3
+const QUEUE_RUN_DELAY = 200
+
+interface UpdateQueue {
+  id: string
+  action?: string
+  updateFunc: Function
+}
+
+const updateQueue: UpdateQueue[] = []
+let timeOut: NodeJS.Timeout
+
+export function pushUpdate(update: UpdateQueue): void {
+  if (updateQueue.length === 0) {
+    startQueue()
+  }
+  let didUpdate = false
+  for (const u of updateQueue) {
+    if (u.id === update.id && u.action === update.action) {
+      u.updateFunc = update.updateFunc
+      didUpdate = true
+      break
+    }
+  }
+  if (!didUpdate) {
+    updateQueue.push(update)
+  }
+}
+
+export function removeIdFromQueue(id: string): void {
+  for (let i = 0; i < updateQueue.length; i++) {
+    const update = updateQueue[i]
+    if (id === update.id) {
+      updateQueue.splice(i, 1)
+      break
+    }
+  }
+  if (updateQueue.length === 0) {
+    clearTimeout(timeOut)
+  }
+}
+
+function startQueue(): void {
+  timeOut = setTimeout(() => {
+    const numJobs =
+      QUEUE_JOBS_PER_RUN < updateQueue.length
+        ? QUEUE_JOBS_PER_RUN
+        : updateQueue.length
+    for (let i = 0; i < numJobs; i++) {
+      if (updateQueue.length > 0) {
+        const u = updateQueue.shift()
+        u?.updateFunc()
+      }
+    }
+    if (updateQueue.length > 0) {
+      startQueue()
+    }
+  }, QUEUE_RUN_DELAY)
+}

--- a/src/common/utxobased/network/types.ts
+++ b/src/common/utxobased/network/types.ts
@@ -1,0 +1,19 @@
+export interface InnerSocketCallbacks {
+  onError: (error?: Error) => void
+  onMessage: (message: string) => void
+  onClose: (error?: Error) => void
+  onOpen: () => void
+}
+
+export enum ReadyState {
+  CONNECTING,
+  OPEN,
+  CLOSING,
+  CLOSED
+}
+
+export interface InnerSocket {
+  readyState: ReadyState
+  disconnect: () => void
+  send: (message: string) => void
+}

--- a/src/common/utxobased/network/windowWS.ts
+++ b/src/common/utxobased/network/windowWS.ts
@@ -1,0 +1,54 @@
+import { InnerSocket, InnerSocketCallbacks, ReadyState } from './types'
+
+export function setupBrowser(
+  uri: string,
+  callbacks: InnerSocketCallbacks
+): InnerSocket {
+  if (window.WebSocket == null)
+    throw Error('Native browser WebSocket does not exists')
+
+  const socket = new window.WebSocket(uri)
+  socket.onopen = () => {
+    callbacks.onOpen()
+  }
+  socket.onmessage = (message: MessageEvent) => {
+    callbacks.onMessage(message.data.toString())
+  }
+  socket.onerror = () => {
+    callbacks.onError()
+  }
+  socket.onclose = () => {
+    callbacks.onClose()
+  }
+
+  return {
+    get readyState(): ReadyState {
+      switch (socket.readyState) {
+        case WebSocket.CONNECTING:
+          return ReadyState.CONNECTING
+        case WebSocket.OPEN:
+          return ReadyState.OPEN
+        case WebSocket.CLOSING:
+          return ReadyState.CLOSING
+        case WebSocket.CLOSED:
+        default:
+          return ReadyState.CLOSED
+      }
+    },
+
+    disconnect() {
+      if (
+        socket == null ||
+        socket.readyState === WebSocket.CLOSING ||
+        socket.readyState === WebSocket.CLOSED
+      )
+        return
+
+      socket.close()
+    },
+
+    send(data: string) {
+      socket.send(data)
+    }
+  }
+}

--- a/test/common/utxobased/network/BlockBook.spec.ts
+++ b/test/common/utxobased/network/BlockBook.spec.ts
@@ -5,7 +5,7 @@ import WS from 'ws'
 
 import {
   BlockBook,
-  BlockHeightEmitter,
+  INewTransactionResponse,
   makeBlockBook
 } from '../../../../src/common/utxobased/network/BlockBook'
 
@@ -46,7 +46,7 @@ describe('BlockBook notifications tests with dummy server', function () {
     websocketServer.on('error', error => {
       console.log(error)
     })
-    const emitter: BlockHeightEmitter = new EventEmitter() as any
+    const emitter = new EventEmitter() as any
     blockBook = makeBlockBook({ emitter, wsAddress: 'ws://localhost:8080' })
     await blockBook.connect()
     blockBook.isConnected.should.be.true
@@ -61,27 +61,41 @@ describe('BlockBook notifications tests with dummy server', function () {
   it('Test BlockBook watch address and watch block events', async () => {
     let test = false
     test.should.be.false
-    const cb = (): void => {
+    const blockCB = (): void => {
       test = true
     }
-    blockBook.watchBlocks(cb)
+    blockBook.watchBlocks(blockCB)
     websocketClient.send(
-      '{"id":"WATCH_NEW_BLOCK_EVENT_ID","data":{"height":1916453,"hash":"0000000000000e0444fa7c1540a96e5658898a59733311d08f01292e114e8d5b"}}'
+      '{"id":"subscribeNewBlock","data":{"height":1916453,"hash":"0000000000000e0444fa7c1540a96e5658898a59733311d08f01292e114e8d5b"}}'
     )
     await new Promise(resolve => setTimeout(resolve, 100))
     test.should.be.true
 
-    const cbA = async (): Promise<void> => {
-      await cb()
-    }
     test = false
+    websocketClient.send(
+      '{"id":"subscribeNewBlock","data":{"height":1916453,"hash":"0000000000000e0444fa7c1540a96e5658898a59733311d08f01292e114e8d5b"}}'
+    )
+    await new Promise(resolve => setTimeout(resolve, 100))
+    test.should.be.true
+    test = false
+
+    const addressCB = (response: INewTransactionResponse): void => {
+      response.tx.blockHeight.should.be.equal(0)
+      test = true
+    }
     test.should.be.false
     blockBook.watchAddresses(
       ['tb1q8uc93239etekcywh2l0t7aklxwywhaw0xlexld'],
-      cbA
+      addressCB
     )
     websocketClient.send(
-      '{"id":"WATCH_ADDRESS_TX_EVENT_ID","data":{"address":"tb1q8uc93239etekcywh2l0t7aklxwywhaw0xlexld","tx":{"txid":"cfd4c31709bd48026c6c1027c47cef305c47947d73248129fee3f4b63ca1af43","version":1,"vin":[{"txid":"e0965d6df36a4ba811fb29819beeae0203fe68e48143344908146a58c5333996","vout":1,"sequence":4294967295,"n":0,"addresses":["tb1qrps90para9l48lydp2xga0p5yyckuj5l7vsu6t"],"isAddress":true,"value":"81581580"}],"vout":[{"value":"100000","n":0,"hex":"00143f3058aa25caf36c11d757debf76df3388ebf5cf","addresses":["tb1q8uc93239etekcywh2l0t7aklxwywhaw0xlexld"],"isAddress":true},{"value":"81463900","n":1,"hex":"0014be4df3d4535bd56f4d35dc1ffdb58408b084ebaa","addresses":["tb1qhexl84znt02k7nf4ms0lmdvypzcgf6a2c9zduk"],"isAddress":true}],"blockHeight":0,"confirmations":0,"blockTime":1612198107,"value":"81563900","valueIn":"81581580","fees":"17680","hex":"01000000000101963933c5586a140849344381e468fe0302aeee9b8129fb11a84b6af36d5d96e00100000000ffffffff02a0860100000000001600143f3058aa25caf36c11d757debf76df3388ebf5cf5c0adb0400000000160014be4df3d4535bd56f4d35dc1ffdb58408b084ebaa0247304402201e7f25a03517d932b2df5d099da597132047f5b7bb5cff43252ba0113fc161d2022003b80682bf7f32e685b21a6f28abc494dcc73c34bc62233f918b54afbbaca36c0121029eea7dac242382a543f6288023ac5a62064bea27349d25fc93180b14d5dd117400000000"}}}'
+      '{"id":"subscribeAddresses","data":{"address":"tb1q8uc93239etekcywh2l0t7aklxwywhaw0xlexld","tx":{"txid":"cfd4c31709bd48026c6c1027c47cef305c47947d73248129fee3f4b63ca1af43","version":1,"vin":[{"txid":"e0965d6df36a4ba811fb29819beeae0203fe68e48143344908146a58c5333996","vout":1,"sequence":4294967295,"n":0,"addresses":["tb1qrps90para9l48lydp2xga0p5yyckuj5l7vsu6t"],"isAddress":true,"value":"81581580"}],"vout":[{"value":"100000","n":0,"hex":"00143f3058aa25caf36c11d757debf76df3388ebf5cf","addresses":["tb1q8uc93239etekcywh2l0t7aklxwywhaw0xlexld"],"isAddress":true},{"value":"81463900","n":1,"hex":"0014be4df3d4535bd56f4d35dc1ffdb58408b084ebaa","addresses":["tb1qhexl84znt02k7nf4ms0lmdvypzcgf6a2c9zduk"],"isAddress":true}],"blockHeight":0,"confirmations":0,"blockTime":1612198107,"value":"81563900","valueIn":"81581580","fees":"17680","hex":"01000000000101963933c5586a140849344381e468fe0302aeee9b8129fb11a84b6af36d5d96e00100000000ffffffff02a0860100000000001600143f3058aa25caf36c11d757debf76df3388ebf5cf5c0adb0400000000160014be4df3d4535bd56f4d35dc1ffdb58408b084ebaa0247304402201e7f25a03517d932b2df5d099da597132047f5b7bb5cff43252ba0113fc161d2022003b80682bf7f32e685b21a6f28abc494dcc73c34bc62233f918b54afbbaca36c0121029eea7dac242382a543f6288023ac5a62064bea27349d25fc93180b14d5dd117400000000"}}}'
+    )
+    await new Promise(resolve => setTimeout(resolve, 100))
+    test.should.be.true
+    test = false
+    websocketClient.send(
+      '{"id":"subscribeAddresses","data":{"address":"tb1q8uc93239etekcywh2l0t7aklxwywhaw0xlexld","tx":{"txid":"cfd4c31709bd48026c6c1027c47cef305c47947d73248129fee3f4b63ca1af43","version":1,"vin":[{"txid":"e0965d6df36a4ba811fb29819beeae0203fe68e48143344908146a58c5333996","vout":1,"sequence":4294967295,"n":0,"addresses":["tb1qrps90para9l48lydp2xga0p5yyckuj5l7vsu6t"],"isAddress":true,"value":"81581580"}],"vout":[{"value":"100000","n":0,"hex":"00143f3058aa25caf36c11d757debf76df3388ebf5cf","addresses":["tb1q8uc93239etekcywh2l0t7aklxwywhaw0xlexld"],"isAddress":true},{"value":"81463900","n":1,"hex":"0014be4df3d4535bd56f4d35dc1ffdb58408b084ebaa","addresses":["tb1qhexl84znt02k7nf4ms0lmdvypzcgf6a2c9zduk"],"isAddress":true}],"blockHeight":0,"confirmations":0,"blockTime":1612198107,"value":"81563900","valueIn":"81581580","fees":"17680","hex":"01000000000101963933c5586a140849344381e468fe0302aeee9b8129fb11a84b6af36d5d96e00100000000ffffffff02a0860100000000001600143f3058aa25caf36c11d757debf76df3388ebf5cf5c0adb0400000000160014be4df3d4535bd56f4d35dc1ffdb58408b084ebaa0247304402201e7f25a03517d932b2df5d099da597132047f5b7bb5cff43252ba0113fc161d2022003b80682bf7f32e685b21a6f28abc494dcc73c34bc62233f918b54afbbaca36c0121029eea7dac242382a543f6288023ac5a62064bea27349d25fc93180b14d5dd117400000000"}}}'
     )
     await new Promise(resolve => setTimeout(resolve, 100))
     test.should.be.true
@@ -92,7 +106,7 @@ describe('BlockBook', function () {
   this.timeout(10000)
 
   const satoshiAddress = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
-  const emitter: BlockHeightEmitter = new EventEmitter() as any
+  const emitter = new EventEmitter() as any
   let blockBook: BlockBook
 
   beforeEach(async () => {
@@ -120,6 +134,7 @@ describe('BlockBook', function () {
 
   describe('fetchInfo', function () {
     it('should fetch the BlockBook server info', async function () {
+      blockBook.isConnected.should.be.true
       const info = await blockBook.fetchInfo()
       info.should.have.keys(
         'name',

--- a/test/common/utxobased/network/BlockBook.spec.ts
+++ b/test/common/utxobased/network/BlockBook.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import * as chai from 'chai'
+import { makeFakeIo } from 'edge-core-js'
 import { EventEmitter } from 'events'
 import WS from 'ws'
 
@@ -47,7 +48,12 @@ describe('BlockBook notifications tests with dummy server', function () {
       console.log(error)
     })
     const emitter = new EventEmitter() as any
-    blockBook = makeBlockBook({ emitter, wsAddress: 'ws://localhost:8080' })
+    const io = makeFakeIo()
+    blockBook = makeBlockBook({
+      emitter,
+      log: io.console,
+      wsAddress: 'ws://localhost:8080'
+    })
     await blockBook.connect()
     blockBook.isConnected.should.be.true
   })
@@ -79,7 +85,9 @@ describe('BlockBook notifications tests with dummy server', function () {
     test.should.be.true
     test = false
 
-    const addressCB = (response: INewTransactionResponse): void => {
+    const addressCB = async (
+      response: INewTransactionResponse
+    ): Promise<void> => {
       response.tx.blockHeight.should.be.equal(0)
       test = true
     }
@@ -107,10 +115,11 @@ describe('BlockBook', function () {
 
   const satoshiAddress = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
   const emitter = new EventEmitter() as any
+  const io = makeFakeIo()
   let blockBook: BlockBook
 
   beforeEach(async () => {
-    blockBook = makeBlockBook({ emitter })
+    blockBook = makeBlockBook({ emitter, log: io.console })
     await blockBook.connect()
   })
 


### PR DESCRIPTION
Based on #73 

Refactors the Socket and Blockbook functions to be more like the networking code of the old, battle-tested edge-currency-bitcoin plugin.
 
This commit is meant as pre-cursor work to lay the foundation for a task queue and multiple sockets.

The new networking code is designed to use fewer callbacks and more promises and events, favors maps over objects with dynamic keys, has a more robust keep alive / heartbeat system that takes existing queries into account, has a cleaner subscription interface and allows for the potential usage of a task queue and multiple sockets.

Further, some more error handling is introduced, though this will need further improvement.

Some more test cases in the block book tests are added to test these new capabilities. Note that this work does not change the interface of the blockbook functions though.