### PR TITLE
Fix Pending Tx Showing Dropped

### DIFF
--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -391,7 +391,8 @@ const processRawTx = (args: ProcessRawTxArgs): IProcessorTransaction => {
   return {
     txid: tx.txid,
     hex: tx.hex,
-    blockHeight: tx.blockHeight,
+    // Blockbook can return a blockHeight of -1 when the tx is pending in the mempool
+    blockHeight: tx.blockHeight > 0 ? tx.blockHeight : 0,
     date: tx.blockTime,
     fees: tx.fees,
     inputs: tx.vin.map((input) => ({


### PR DESCRIPTION
### Tx Block Height
Transaction data returned from BlockBook can have the `blockHeight` value of `-1`. Because in Edge, `-1` means dropped and `0` means pending, a new pending transaction shows as being dropped rather than pending.

When processing raw tx data from BlockBook, checking if the `blockHeight < 0` and then setting it to `0`