### PR TITLE
Signed Transaction Id

### DIFF
--- a/src/common/utxobased/db/Models/ProcessorTransaction.ts
+++ b/src/common/utxobased/db/Models/ProcessorTransaction.ts
@@ -1,9 +1,10 @@
-import { EdgeTransaction } from 'edge-core-js/lib/types'
+import { EdgeTransaction } from 'edge-core-js'
+
 import { IProcessorTransaction } from '../types'
 
 export const fromEdgeTransaction = (tx: EdgeTransaction): IProcessorTransaction => ({
   txid: tx.txid,
-  hex: tx.otherParams?.hex,
+  hex: tx.signedTx,
   blockHeight: tx.blockHeight,
   date: tx.date,
   fees: tx.networkFee,
@@ -21,10 +22,9 @@ export const toEdgeTransaction = (tx: IProcessorTransaction, currencyCode: strin
   date: tx.date,
   nativeAmount: tx.ourAmount,
   networkFee: tx.fees,
-  signedTx: '',
+  signedTx: tx.hex,
   ourReceiveAddresses: [],
   otherParams: {
-    hex: tx.hex,
     inputs: tx.inputs,
     outputs: tx.outputs,
     ourIns: tx.ourIns,

--- a/src/common/utxobased/engine/types.ts
+++ b/src/common/utxobased/engine/types.ts
@@ -1,0 +1,11 @@
+import { EdgeSpendInfo } from 'edge-core-js'
+
+import { Input } from '../keymanager/utxopicker/types'
+
+export interface UTXOTxOtherParams {
+  psbt: {
+    base64: string
+    inputs: Input[]
+  }
+  edgeSpendInfo: EdgeSpendInfo
+}

--- a/src/common/utxobased/keymanager/utxopicker/accumulative.ts
+++ b/src/common/utxobased/keymanager/utxopicker/accumulative.ts
@@ -45,5 +45,5 @@ export function accumulative(utxos: UTXO[], targets: Target[], feeRate: number, 
     return utils.finalize(inputs, outputs, feeRate, changeScript)
   }
 
-  return { fee: feeRate * utils.transactionBytes(inputs, outputs) }
+  return { changeUsed: false, fee: feeRate * utils.transactionBytes(inputs, outputs) }
 }

--- a/src/common/utxobased/keymanager/utxopicker/types.ts
+++ b/src/common/utxobased/keymanager/utxopicker/types.ts
@@ -23,8 +23,8 @@ export interface Target {
 }
 
 export interface Result {
-  inputs?: UTXO[]
+  inputs?: Input[]
   outputs?: Output[]
-  changeUsed?: boolean
+  changeUsed: boolean
   fee: number
 }

--- a/test/common/utxobased/keymanager/coins/bitcoincashtransactiontest.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoincashtransactiontest.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
+import * as bitcoin from 'altcoin-js'
 
 import { NetworkEnum } from '../../../../../src/common/plugin/types'
 import { cdsScriptTemplates } from '../../../../../src/common/utxobased/keymanager/bitcoincashUtils/checkdatasig'
@@ -82,12 +83,12 @@ describe('bitcoincash transaction creation and signing test', () => {
         }
       ]
     }).psbt
-    const hexTxSigned: string = await signTx({
-      psbt: base64Tx,
+    const signedTx = await signTx({
+      psbtBase64: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoincash'
     })
-    expect(hexTxSigned).to.equal(
+    expect(signedTx.hex).to.equal(
       '02000000013ebc8203037dda39d482bf41ff3be955996c50d9d4f7cfc3d2097a694a7b067d000000006a473044022041e30e01f06523646374a356a61238da09f67cfbb5017ff7df47be7c5d1fc1bf0220788ed258f1b6d9c2b28d49c10909cd2cf48f49139c1bb9fe6bfd102f9bf4e44141210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f455ffffffff0180380100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000'
     )
   })
@@ -162,12 +163,12 @@ describe('bitcoincash replay protection transaction creation and signing test', 
         }
       ]
     }).psbt
-    const hexTxSigned: string = await signTx({
-      psbt: base64Tx,
+    const signedTx = await signTx({
+      psbtBase64: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoincash'
     })
-    expect(hexTxSigned).to.equal(
+    expect(signedTx.hex).to.equal(
       '02000000010c95c06e793d969af6d1b253d71da18bbc3e549a9d9816214c2a21bb1eed9be600000000fa4730440220398da49dabcb8bde7b004d62b7a4f50e0c8b74e5f0f99ebb86ce2932ba3df05e02200ba98a43fa4f67f6252b04f586660ed934ee1ef2c3de6cca3ec3b407c93b095c41210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f4554c8e4630440220256c12175e809381f97637933ed6ab97737d263eaaebca6add21bced67fd12a402205ce29ecc1369d6fc1b51977ed38faaf41119e3be1d7edfafd7cfaf0b6061bd070021038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508bb210365db9da3f8a260078a7e8f8b708a1161468fb2323ffda5ec16b261ec1056f455acffffffff0180380100000000001976a9148bbc95d2709c71607c60ee3f097c1217482f518d88ac00000000'
     )
   })

--- a/test/common/utxobased/keymanager/coins/bitcointransactiontest.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcointransactiontest.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
+import * as bitcoin from 'altcoin-js'
 
 import { NetworkEnum } from '../../../../../src/common/plugin/types'
 import {
@@ -219,12 +220,12 @@ describe('bitcoin transaction creation and signing test', () => {
         }
       ]
     }).psbt
-    const hexTxSigned: string = await signTx({
-      psbt: base64Tx,
+    const signedTx = await signTx({
+      psbtBase64: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoin'
     })
-    expect(hexTxSigned).to.equal(
+    expect(signedTx.hex).to.equal(
       '02000000013ebc8203037dda39d482bf41ff3be955996c50d9d4f7cfc3d2097a694a7' +
         'b067d000000006b483045022100931b6db94aed25d5486884d83fc37160f37f3368c0' +
         'd7f48c757112abefec983802205fda64cff98c849577026eb2ce916a50ea70626a766' +
@@ -263,8 +264,8 @@ describe('bitcoin transaction creation and signing test', () => {
       rbf: false
     }).psbt
 
-    const rawtransaction: string = await signTx({
-      psbt: base64Tx,
+    const { hex: rawtransaction } = await signTx({
+      psbtBase64: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoin'
     })
@@ -291,8 +292,8 @@ describe('bitcoin transaction creation and signing test', () => {
       network: NetworkEnum.Mainnet,
       rbf: false
     }).psbt
-    const segwitRawTransaction: string = await signTx({
-      psbt: segwitTx,
+    const { hex: segwitRawTransaction } = await signTx({
+      psbtBase64: segwitTx,
       privateKeys: Array(nOutputs).fill(privateKey),
       coin: 'bitcoin'
     })
@@ -374,8 +375,8 @@ describe('bitcoin transaction creation and signing test', () => {
       rbf: false
     }).psbt
 
-    const rawtransaction: string = await signTx({
-      psbt: base64Tx,
+    const { hex: rawtransaction } = await signTx({
+      psbtBase64: base64Tx,
       privateKeys: [privateKey, privateKey, privateKey],
       coin: 'bitcoin'
     })
@@ -420,8 +421,8 @@ describe('bitcoin transaction creation and signing test', () => {
       rbf: false
     }).psbt
 
-    const hexTxSigned: string = await signTx({
-      psbt: base64Tx,
+    const signedTx = await signTx({
+      psbtBase64: base64Tx,
       privateKeys: [privateKey],
       coin: 'bitcoin'
     })
@@ -432,7 +433,7 @@ describe('bitcoin transaction creation and signing test', () => {
         type: TransactionInputTypeEnum.Legacy,
         prevTxid:
           '8b26fa4d0238788ffc3a7d96e4169acf6fe993a28791e9e748819ac216ee85b3',
-        prevTx: hexTxSigned,
+        prevTx: signedTx.hex,
         index: i
       }
     }
@@ -443,8 +444,8 @@ describe('bitcoin transaction creation and signing test', () => {
       rbf: false
     }).psbt
 
-    const hexTxMultiSigned: string = await signTx({
-      psbt: base64TxMulti,
+    const { hex: hexTxMultiSigned } = await signTx({
+      psbtBase64: base64TxMulti,
       privateKeys: Array(nOutputs).fill(privateKey),
       coin: 'bitcoin'
     })

--- a/test/common/utxobased/keymanager/coins/groestlcointransactiontest.spec.ts
+++ b/test/common/utxobased/keymanager/coins/groestlcointransactiontest.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
+import * as bitcoin from 'altcoin-js'
 
 import { NetworkEnum } from '../../../../../src/common/plugin/types'
 import {
@@ -61,8 +62,8 @@ describe('groestlcoin transaction creation and signing test', () => {
         }
       ]
     }).psbt
-    const hexTxSigned: string = await signTx({
-      psbt: base64Tx,
+    const { hex: hexTxSigned } = await signTx({
+      psbtBase64: base64Tx,
       privateKeys: [privateKey],
       coin: 'groestlcoin'
     })


### PR DESCRIPTION
### Signed Transaction Id
After signing a transaction, we return the transaction which is in turn passed to `engine.saveTransaction()`. Previously, the `txid` was not being set. Since in order to calculate the txid, the full transaction needs to be signed, we should set the id when we set the `signedTx` value on the `EdgeTransaction` as well.

Also going from an `EdgeTransaction` to `ProcessorTransaction` was not preserving the `signedTx` or `hex` value. 