### PR TITLE
Fixing SignTx Payment Protocol Info

### DIFF
--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -85,27 +85,30 @@ export interface Emitter {
 
   on: ((
     event: EmitterEvent.TRANSACTIONS_CHANGED,
-    listener: (transactions: EdgeTransaction[]) => void
+    listener: (transactions: EdgeTransaction[]) => void | Promise<void>
   ) => this) &
     ((
       event: EmitterEvent.PROCESSOR_TRANSACTION_CHANGED,
-      listener: (transaction: IProcessorTransaction) => void
+      listener: (transaction: IProcessorTransaction) => void | Promise<void>
     ) => this) &
     ((
       event: EmitterEvent.BALANCE_CHANGED,
-      listener: (currencyCode: string, nativeBalance: string) => void
+      listener: (
+        currencyCode: string,
+        nativeBalance: string
+      ) => void | Promise<void>
     ) => this) &
     ((
       event: EmitterEvent.BLOCK_HEIGHT_CHANGED,
-      listener: (blockHeight: number) => void
+      listener: (blockHeight: number) => void | Promise<void>
     ) => this) &
     ((
       event: EmitterEvent.ADDRESSES_CHECKED,
-      listener: (progressRatio: number) => void
+      listener: (progressRatio: number) => void | Promise<void>
     ) => this) &
     ((
       event: EmitterEvent.TXIDS_CHANGED,
-      listener: (txids: EdgeTxidMap) => void
+      listener: (txids: EdgeTxidMap) => void | Promise<void>
     ) => this)
 }
 

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -1,4 +1,3 @@
-import * as bitcoin from 'altcoin-js'
 import * as bs from 'biggystring'
 import {
   EdgeCurrencyCodeOptions,
@@ -10,7 +9,6 @@ import {
   EdgeSpendInfo,
   EdgeTokenInfo,
   EdgeTransaction,
-  EdgeTxidMap,
   JsonObject
 } from 'edge-core-js'
 
@@ -248,14 +246,14 @@ export async function makeUtxoEngine(
       const addressData = await processor.fetchAddressByScriptPubkey(
         scriptPubkey
       )
-      return !!addressData?.used
+      return addressData?.used === true
     },
 
     async makeSpend(edgeSpendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
       const targets: MakeTxTarget[] = []
       const ourReceiveAddresses: string[] = []
       for (const target of edgeSpendInfo.spendTargets) {
-        if (!target.publicAddress || !target.nativeAmount) {
+        if (target.publicAddress == null || target.nativeAmount == null) {
           throw new Error('Invalid spend target')
         }
 
@@ -342,7 +340,8 @@ export async function makeUtxoEngine(
     async signTx(transaction: EdgeTransaction): Promise<EdgeTransaction> {
       const { psbt, edgeSpendInfo }: Partial<UTXOTxOtherParams> =
         transaction.otherParams ?? {}
-      if (!psbt || !edgeSpendInfo) throw new Error('Invalid transaction data')
+      if (psbt == null || edgeSpendInfo == null)
+        throw new Error('Invalid transaction data')
 
       const privateKeys = await Promise.all(
         psbt.inputs.map(async ({ hash, index }) => {
@@ -351,12 +350,12 @@ export async function makeUtxoEngine(
             : hash
 
           const utxo = await processor.fetchUtxo(`${txid}_${index}`)
-          if (!utxo) throw new Error('Invalid UTXO')
+          if (utxo == null) throw new Error('Invalid UTXO')
 
           const address = await processor.fetchAddressByScriptPubkey(
             utxo.scriptPubkey
           )
-          if (!address?.path) throw new Error('Invalid script pubkey')
+          if (address?.path == null) throw new Error('Invalid script pubkey')
 
           return walletTools.getPrivateKey(address.path)
         })

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -376,11 +376,7 @@ export async function makeUtxoEngine(
           transaction.currencyCode
         )
         Object.assign(transaction.otherParams, {
-          paymentProtocolInfo: {
-            // @ts-expect-error
-            ...edgeSpendInfo.otherParams.paymentProtocolInfo,
-            payment
-          }
+          paymentProtocolInfo: { ...paymentProtocolInfo, payment }
         })
       }
 


### PR DESCRIPTION
Fixes types in `signTx` that defaults the `paymentProtocolInfo` to an empty object.