### PR TITLE
Make Metatdata

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "disklet": "^0.4.5",
     "edge-core-js": "^0.17.27-alpha.1",
     "lodash": "^4.17.20",
+    "memlet": "^0.0.4",
     "uri-js": "^4.4.0",
     "url-parse": "^1.4.7",
     "wif-smart": "^2.0.0",

--- a/src/common/plugin/makeCurrencyPlugin.ts
+++ b/src/common/plugin/makeCurrencyPlugin.ts
@@ -36,7 +36,7 @@ export function makeCurrencyPlugin(
         engineOptions.callbacks.onTransactionsChanged
       )
       emitter.on(
-        EngineEvent.BALANCE_CHANGED,
+        EngineEvent.WALLET_BALANCE_CHANGED,
         engineOptions.callbacks.onBalanceChanged
       )
       emitter.on(

--- a/src/common/plugin/makeEngineEmitter.ts
+++ b/src/common/plugin/makeEngineEmitter.ts
@@ -13,7 +13,12 @@ export declare interface EngineEmitter {
       transaction: IProcessorTransaction
     ) => boolean) &
     ((
-      event: EngineEvent.BALANCE_CHANGED,
+      event: EngineEvent.ADDRESS_BALANCE_CHANGED,
+      currencyCode: string,
+      nativeDiff: string
+    ) => boolean) &
+    ((
+      event: EngineEvent.WALLET_BALANCE_CHANGED,
       currencyCode: string,
       nativeBalance: string
     ) => boolean) &
@@ -36,10 +41,17 @@ export declare interface EngineEmitter {
       listener: (transaction: IProcessorTransaction) => Promise<void> | void
     ) => this) &
     ((
-      event: EngineEvent.BALANCE_CHANGED,
+      event: EngineEvent.ADDRESS_BALANCE_CHANGED,
       listener: (
         currencyCode: string,
-        balanceDiff: string
+        nativeDiff: string
+      ) => Promise<void> | void
+    ) => this) &
+    ((
+      event: EngineEvent.WALLET_BALANCE_CHANGED,
+      listener: (
+        currencyCode: string,
+        nativeBalance: string
       ) => Promise<void> | void
     ) => this) &
     ((
@@ -69,7 +81,8 @@ export class EngineEmitter extends EventEmitter {}
 export enum EngineEvent {
   TRANSACTIONS_CHANGED = 'transactions:changed',
   PROCESSOR_TRANSACTION_CHANGED = 'processor:transactions:changed',
-  BALANCE_CHANGED = 'balance:changed',
+  WALLET_BALANCE_CHANGED = 'wallet:balance:changed',
+  ADDRESS_BALANCE_CHANGED = 'address:balance:changed',
   BLOCK_HEIGHT_CHANGED = 'block:height:changed',
   ADDRESSES_CHECKED = 'addresses:checked',
   TXIDS_CHANGED = 'txids:changed',

--- a/src/common/plugin/makeMetadata.ts
+++ b/src/common/plugin/makeMetadata.ts
@@ -1,0 +1,85 @@
+import { Mutex } from 'async-mutex'
+import * as bs from 'biggystring'
+import { Disklet } from 'disklet'
+
+import { EngineEmitter, EngineEvent } from './makeEngineEmitter'
+import { LocalWalletMetadata } from './types'
+
+const metadataPath = `metadata.json`
+
+interface MetadataConfig {
+  disklet: Disklet
+  emitter: EngineEmitter
+}
+
+interface Metadata extends LocalWalletMetadata {
+  clear: () => Promise<void>
+}
+
+export const makeMetadata = async (
+  config: MetadataConfig
+): Promise<Metadata> => {
+  const { disklet, emitter } = config
+
+  const mutex = new Mutex()
+
+  let cache: LocalWalletMetadata = await fetchMetadata(disklet)
+
+  emitter.on(
+    EngineEvent.ADDRESS_BALANCE_CHANGED,
+    (currencyCode: string, balanceDiff: string) => {
+      void mutex.runExclusive(async () => {
+        cache.balance = bs.add(cache.balance, balanceDiff)
+        emitter.emit(
+          EngineEvent.WALLET_BALANCE_CHANGED,
+          currencyCode,
+          cache.balance
+        )
+        await setMetadata(disklet, cache)
+      })
+    }
+  )
+
+  emitter.on(EngineEvent.BLOCK_HEIGHT_CHANGED, (height: number) => {
+    void mutex.runExclusive(async () => {
+      cache.lastSeenBlockHeight = height
+      await setMetadata(disklet, cache)
+    })
+  })
+
+  return {
+    get balance() {
+      return cache.balance
+    },
+    get lastSeenBlockHeight() {
+      return cache.lastSeenBlockHeight
+    },
+    clear: async () => {
+      await disklet.delete(metadataPath)
+      cache = await fetchMetadata(disklet)
+    }
+  }
+}
+
+const fetchMetadata = async (
+  disklet: Disklet
+): Promise<LocalWalletMetadata> => {
+  try {
+    const dataStr = await disklet.getText(metadataPath)
+    return JSON.parse(dataStr)
+  } catch {
+    const data: LocalWalletMetadata = {
+      balance: '0',
+      lastSeenBlockHeight: 0
+    }
+    await setMetadata(disklet, data)
+    return data
+  }
+}
+
+const setMetadata = async (
+  disklet: Disklet,
+  data: LocalWalletMetadata
+): Promise<void> => {
+  await disklet.setText(metadataPath, JSON.stringify(data))
+}

--- a/src/common/plugin/utils.ts
+++ b/src/common/plugin/utils.ts
@@ -1,38 +1,3 @@
-import { Disklet } from 'disklet'
-
-import { LocalWalletMetadata } from './types'
-
-const metadataPath = `metadata.json`
-
-export const fetchMetadata = async (
-  disklet: Disklet
-): Promise<LocalWalletMetadata> => {
-  try {
-    const dataStr = await disklet.getText(metadataPath)
-    return JSON.parse(dataStr)
-  } catch {
-    const data: LocalWalletMetadata = {
-      balance: '0',
-      lastSeenBlockHeight: 0
-    }
-    await setMetadata(disklet, data)
-    return data
-  }
-}
-
-export const clearMetadata = async (
-  disklet: Disklet
-): Promise<LocalWalletMetadata> => {
-  await disklet.delete(metadataPath)
-  return await fetchMetadata(disklet)
-}
-
-export const setMetadata = async (
-  disklet: Disklet,
-  data: LocalWalletMetadata
-): Promise<void> =>
-  await disklet.setText(metadataPath, JSON.stringify(data)).then()
-
 export const getMnemonicKey = ({ coin }: { coin: string }): string =>
   `${coin}Key`
 

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -13,13 +13,9 @@ import {
 } from 'edge-core-js'
 
 import { EngineEmitter, EngineEvent } from '../../plugin/makeEngineEmitter'
+import { makeMetadata } from '../../plugin/makeMetadata'
 import { EngineConfig, TxOptions } from '../../plugin/types'
-import {
-  clearMetadata,
-  fetchMetadata,
-  getMnemonic,
-  setMetadata
-} from '../../plugin/utils'
+import { getMnemonic } from '../../plugin/utils'
 import { makeProcessor } from '../db/makeProcessor'
 import {
   fromEdgeTransaction,
@@ -31,7 +27,6 @@ import { makeBlockBook } from '../network/BlockBook'
 import { calculateFeeRate } from './makeSpendHelper'
 import { makeUtxoEngineState } from './makeUtxoEngineState'
 import { makeUtxoWalletTools } from './makeUtxoWalletTools'
-import { makeMutexor } from './mutexor'
 import { createPayment, getPaymentDetails, sendPayment } from './paymentRequest'
 import { UTXOTxOtherParams } from './types'
 import {
@@ -63,8 +58,6 @@ export async function makeUtxoEngine(
     throw new Error(message)
   }
 
-  const mutexor = makeMutexor()
-
   // Merge in the xpriv into the local copy of wallet keys
   walletInfo.keys[
     getXprivKey({ coin: currencyInfo.network })
@@ -82,7 +75,7 @@ export async function makeUtxoEngine(
   })
 
   const blockBook = makeBlockBook({ emitter, log: io.console })
-  let metadata = await fetchMetadata(walletLocalDisklet)
+  const metadata = await makeMetadata({ disklet: walletLocalDisklet, emitter })
   const processor = await makeProcessor({
     disklet: walletLocalDisklet,
     emitter
@@ -91,8 +84,7 @@ export async function makeUtxoEngine(
     ...config,
     walletTools,
     processor,
-    blockBook,
-    metadata
+    blockBook
   })
 
   emitter.on(
@@ -108,21 +100,6 @@ export async function makeUtxoEngine(
       ])
     }
   )
-
-  emitter.on(
-    EngineEvent.BALANCE_CHANGED,
-    async (currencyCode: string, nativeBalance: string) => {
-      await mutexor('balanceChanged').runExclusive(async () => {
-        metadata.balance = nativeBalance
-        await setMetadata(walletLocalDisklet, metadata)
-      })
-    }
-  )
-
-  emitter.on(EngineEvent.BLOCK_HEIGHT_CHANGED, async (height: number) => {
-    metadata.lastSeenBlockHeight = height
-    await setMetadata(walletLocalDisklet, metadata)
-  })
 
   const fns: EdgeCurrencyEngine = {
     async startEngine(): Promise<void> {
@@ -357,7 +334,7 @@ export async function makeUtxoEngine(
       await state.stop()
       // now get rid of all the db information
       await processor.clearAll()
-      metadata = await clearMetadata(walletLocalDisklet)
+      await metadata.clear()
 
       // finally restart the state
       await state.start()
@@ -422,35 +399,17 @@ export async function makeUtxoEngine(
       let success: (
         value: EdgeTransaction | PromiseLike<EdgeTransaction>
       ) => void
-      let failure: (reason?: any) => void
+      let failure: (reason?: never) => void
       const end: Promise<EdgeTransaction> = new Promise((resolve, reject) => {
         success = resolve
         failure = reject
       })
       const tmpDisklet = walletLocalDisklet
-      const tmpMetadata = await fetchMetadata(tmpDisklet)
-
       const tmpEmitter = new EngineEmitter()
-      tmpEmitter.on(
-        EngineEvent.BALANCE_CHANGED,
-        async (currencyCode: string, nativeBalance: string) => {
-          metadata.balance = nativeBalance
-          await setMetadata(tmpDisklet, tmpMetadata)
-        }
-      )
-      tmpEmitter.on(
-        EngineEvent.BLOCK_HEIGHT_CHANGED,
-        async (height: number) => {
-          metadata.lastSeenBlockHeight = height
-          await setMetadata(tmpDisklet, tmpMetadata)
-        }
-      )
-
-      const tmpProcessor = await makeProcessor({
-        disklet: tmpDisklet,
-        emitter: tmpEmitter
-      })
-      const blockBook = makeBlockBook({ emitter: tmpEmitter, log: io.console })
+      const tmpConfig = { disklet: tmpDisklet, emitter: tmpEmitter }
+      const tmpMetadata = await makeMetadata(tmpConfig)
+      const tmpProcessor = await makeProcessor(tmpConfig)
+      const tmpBlockBook = makeBlockBook(tmpConfig)
       const tmpWalletTools = makeUtxoWalletTools({
         keys: { wifKeys: privateKeys },
         coin: currencyInfo.network,
@@ -459,8 +418,8 @@ export async function makeUtxoEngine(
 
       tmpEmitter.on(EngineEvent.ADDRESSES_CHECKED, async (ratio: number) => {
         if (ratio === 1) {
-          await engineState.stop()
-          await blockBook.disconnect()
+          await tmpState.stop()
+          await tmpBlockBook.disconnect()
 
           const utxos = await processor.fetchAllUtxos()
           if (utxos === null || utxos.length < 1) {
@@ -479,7 +438,7 @@ export async function makeUtxoEngine(
         }
       })
 
-      const engineState = makeUtxoEngineState({
+      const tmpState = makeUtxoEngineState({
         ...config,
         options: {
           ...config.options,
@@ -492,10 +451,9 @@ export async function makeUtxoEngine(
         },
         walletTools: tmpWalletTools,
         processor: tmpProcessor,
-        blockBook,
-        metadata: tmpMetadata
+        blockBook: tmpBlockBook
       })
-      await engineState.start()
+      await tmpState.start()
       return end
     }
   }

--- a/test/common/plugin/makeMetadata.spec.ts
+++ b/test/common/plugin/makeMetadata.spec.ts
@@ -1,0 +1,46 @@
+import * as chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { Disklet, makeMemoryDisklet } from 'disklet'
+
+import {
+  EngineEmitter,
+  EngineEvent
+} from '../../../src/common/plugin/makeEngineEmitter'
+import { makeMetadata, Metadata } from '../../../src/common/plugin/makeMetadata'
+
+chai.should()
+chai.use(chaiAsPromised)
+
+const wait = async (seconds: number): Promise<void> =>
+  await new Promise(resolve => setTimeout(resolve, seconds * 1000))
+
+describe('makeMetadata', () => {
+  const memory: any = {}
+  let disklet: Disklet
+  let metadata: Metadata
+  const emitter = new EngineEmitter()
+
+  before(async () => {
+    disklet = makeMemoryDisklet(memory)
+    metadata = await makeMetadata({
+      disklet,
+      emitter
+    })
+  })
+
+  describe('block height update', () => {
+    it('should only ever increase the block height', async function () {
+      this.timeout(3000)
+
+      metadata.lastSeenBlockHeight.should.eql(0)
+
+      emitter.emit(EngineEvent.BLOCK_HEIGHT_CHANGED, 10)
+      await wait(1)
+      metadata.lastSeenBlockHeight.should.eql(10)
+
+      emitter.emit(EngineEvent.BLOCK_HEIGHT_CHANGED, 5)
+      await wait(1)
+      metadata.lastSeenBlockHeight.should.eql(10)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4749,6 +4749,15 @@ memlet@^0.0.3:
     chai-as-promised "^7.1.1"
     disklet "^0.4.5"
 
+memlet@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/memlet/-/memlet-0.0.4.tgz#447a4aa1cd0eb5bdff13adad4b3065371d55860d"
+  integrity sha512-fNRgJcUBotTpSAfEljNWJPeLPnRDmn8y/PAzYMrLHds2GeVA4gYTjSOgiLqQnFsP+Y+k+Ae31Am53DH6g6+ynA==
+  dependencies:
+    "@types/chai-as-promised" "^7.1.3"
+    chai-as-promised "^7.1.1"
+    disklet "^0.4.5"
+
 memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
@@ -6489,6 +6498,8 @@ rxjs@^6.6.3:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
   integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"


### PR DESCRIPTION
It creates a metadata object that listens to events from the engine and updates the wallet balance.
It listens for an event when an address balance changes and mutexes updating the wallet balance.
It reduces code duplication when sweeping a private key for the emitter.