### PR TITLE
Multi socket

### DIFF
--- a/src/common/plugin/pluginState.ts
+++ b/src/common/plugin/pluginState.ts
@@ -1,0 +1,225 @@
+// Typescript translation from original code in edge-currency-bitcoin
+
+import { Disklet, navigateDisklet } from 'disklet'
+import { EdgeIo, EdgeLog } from 'edge-core-js'
+
+import { UtxoEngineState } from '../utxobased/engine/makeUtxoEngineState'
+import { ServerCache, ServerInfo } from './serverCache.js'
+
+const InfoServer = 'https://info1.edge.app/v1'
+const FixCurrencyCode = (currencyCode: string): string => {
+  switch (currencyCode) {
+    case 'BTC':
+      return 'BC1'
+    case 'DGB':
+      return 'DGB1'
+    case 'FIRO':
+      return 'XZC'
+    default:
+      return currencyCode
+  }
+}
+
+/** A JSON object (as opposed to an array or primitive). */
+interface JsonObject {
+  [name: string]: unknown
+}
+
+export interface CurrencySettings {
+  customFeeSettings: string[]
+  electrumServers: string[]
+  disableFetchingServers?: boolean
+}
+
+/**
+ * This object holds the plugin-wide per-currency caches.
+ * Engine plugins are responsible for keeping it up to date.
+ */
+export interface PluginStateSettings {
+  io: EdgeIo
+  defaultSettings: CurrencySettings
+  currencyCode: string
+  pluginId: string
+  log: EdgeLog
+}
+
+export class PluginState extends ServerCache {
+  // On-disk server information:
+  // serverCache: ServerCache
+
+  /**
+   * Begins notifying the engine of state changes. Used at connection time.
+   */
+  addEngine(engineState: UtxoEngineState): void {
+    this.engines.push(engineState)
+  }
+
+  /**
+   * Stops notifying the engine of state changes. Used at disconnection time.
+   */
+  removeEngine(engineState: UtxoEngineState): void {
+    this.engines = this.engines.filter(engine => engine !== engineState)
+  }
+
+  dumpData(): JsonObject {
+    return {
+      'pluginState.servers_': this.servers_
+    }
+  }
+
+  // ------------------------------------------------------------------------
+  // Private stuff
+  // ------------------------------------------------------------------------
+  io: EdgeIo
+  disableFetchingServers: boolean
+  defaultServers: string[]
+  infoServerUris: string
+
+  engines: UtxoEngineState[]
+  disklet: Disklet
+
+  serverCacheJson: { [serverUrl: string]: ServerInfo }
+  pluginId: string
+
+  constructor({
+    io,
+    defaultSettings,
+    currencyCode,
+    pluginId,
+    log
+  }: PluginStateSettings) {
+    super(log)
+    this.io = io
+    this.defaultServers = defaultSettings.electrumServers
+    this.disableFetchingServers = !!(
+      defaultSettings.disableFetchingServers ?? false
+    )
+    // Rename the bitcoin currencyCode to get the new version of the server list
+    const fixedCode = FixCurrencyCode(currencyCode)
+    this.infoServerUris = `${JSON.stringify(
+      InfoServer
+    )}/electrumServers/${JSON.stringify(fixedCode)}`
+    this.engines = []
+    this.disklet = navigateDisklet(io.disklet, 'plugins/' + pluginId)
+
+    this.pluginId = pluginId
+    this.serverCacheJson = {}
+  }
+
+  async load(): Promise<PluginState> {
+    try {
+      const serverCacheText = await this.disklet.getText('serverCache.json')
+      const serverCacheJson = JSON.parse(serverCacheText)
+      // TODO: Validate JSON
+
+      this.serverCacheJson = serverCacheJson
+    } catch (e) {
+      this.log(
+        `${this.pluginId}: Failed to load server cache: ${JSON.stringify(e)}`
+      )
+    }
+
+    // Fetch servers in the background:
+    this.fetchServers().catch(e => {
+      this.log(`${this.pluginId} - ${JSON.stringify(e.toString())}`)
+    })
+
+    return this
+  }
+
+  async clearCache(): Promise<void> {
+    this.clearServerCache()
+    this.serverCacheDirty = true
+    await this.saveServerCache()
+    await this.fetchServers()
+  }
+
+  async saveServerCache(): Promise<void> {
+    // this.printServerCache()
+    if (this.serverCacheDirty) {
+      try {
+        await this.disklet.setText(
+          'serverCache.json',
+          JSON.stringify(this.servers_)
+        )
+        this.serverCacheDirty = false
+        this.cacheLastSave_ = Date.now()
+        this.log(`${this.pluginId} - Saved server cache`)
+      } catch (e) {
+        this.log(`${this.pluginId} - ${JSON.stringify(e.toString())}`)
+      }
+    }
+  }
+
+  dirtyServerCache(serverUrl: string): void {
+    this.serverCacheDirty = true
+    for (const engine of this.engines) {
+      if (engine.processedPercent === 1) {
+        for (const uri of engine.serverList) {
+          if (uri === serverUrl) {
+            this.saveServerCache().catch(e => {
+              this.log(`${this.pluginId} - ${JSON.stringify(e.toString())}`)
+            })
+            return
+          }
+        }
+      }
+    }
+  }
+
+  async fetchServers(): Promise<void> {
+    const { io } = this
+    let serverList = this.defaultServers
+    if (!this.disableFetchingServers) {
+      try {
+        this.log(`${this.pluginId} - GET ${this.infoServerUris}`)
+        const result = await io.fetch(this.infoServerUris)
+        if (!result.ok) {
+          this.log(
+            `${this.pluginId} - Fetching ${this.infoServerUris} failed with ${result.status}`
+          )
+        } else {
+          serverList = await result.json()
+        }
+      } catch (e) {
+        this.log(e)
+      }
+    }
+    if (!Array.isArray(serverList)) {
+      serverList = this.defaultServers
+    }
+    this.serverCacheLoad(this.serverCacheJson, serverList)
+    await this.saveServerCache()
+
+    // Tell the engines about the new servers:
+    for (const engine of this.engines) {
+      engine.refillServers()
+    }
+  }
+
+  async updateServers(settings: JsonObject): Promise<void> {
+    const { electrumServers, disableFetchingServers } = settings
+    if (typeof disableFetchingServers === 'boolean') {
+      this.disableFetchingServers = disableFetchingServers
+    }
+    if (Array.isArray(electrumServers)) {
+      this.defaultServers = electrumServers
+    }
+    const engines = []
+    const disconnects = []
+    for (const engine of this.engines) {
+      engines.push(engine)
+      engine.serverList = []
+      disconnects.push(engine.stop())
+    }
+    await Promise.all(disconnects)
+    this.clearServerCache()
+    this.serverCacheJson = {}
+    this.serverCacheDirty = true
+    await this.saveServerCache()
+    await this.fetchServers()
+    for (const engine of engines) {
+      await engine.stop()
+    }
+  }
+}

--- a/src/common/plugin/pluginState.ts
+++ b/src/common/plugin/pluginState.ts
@@ -155,7 +155,7 @@ export class PluginState extends ServerCache {
     this.serverCacheDirty = true
     for (const engine of this.engines) {
       if (engine.processedPercent === 1) {
-        for (const uri of engine.serverList) {
+        for (const uri of engine.getServerList()) {
           if (uri === serverUrl) {
             this.saveServerCache().catch(e => {
               this.log(`${this.pluginId} - ${JSON.stringify(e.toString())}`)
@@ -209,7 +209,7 @@ export class PluginState extends ServerCache {
     const disconnects = []
     for (const engine of this.engines) {
       engines.push(engine)
-      engine.serverList = []
+      engine.setServerList([])
       disconnects.push(engine.stop())
     }
     await Promise.all(disconnects)

--- a/src/common/plugin/serverCache.ts
+++ b/src/common/plugin/serverCache.ts
@@ -1,0 +1,310 @@
+// Typescript translation from original code in edge-currency-bitcoin
+
+import { EdgeLog } from 'edge-core-js'
+
+export interface ServerInfo {
+  serverUrl: string
+  serverScore: number
+  responseTime: number
+  numResponseTimes: number
+}
+
+const RESPONSE_TIME_UNINITIALIZED = 999999999
+const MAX_SCORE = 500
+const MIN_SCORE = -100
+const DROPPED_SERVER_SCORE = -100
+const RE_ADDED_SERVER_SCORE = -10
+let lastScoreUpTime_: number = Date.now()
+
+export class ServerCache {
+  servers_: { [serverUrl: string]: ServerInfo } = {}
+  serverCacheDirty = false
+  cacheLastSave_ = 0
+  log: EdgeLog
+
+  constructor(log: EdgeLog) {
+    this.log = log
+    this.clearServerCache()
+  }
+
+  dirtyServerCache(_url: string): void {
+    this.serverCacheDirty = true
+  }
+
+  /**
+   * Loads the server cache with new and old servers
+   * @param oldServers: Map of ServerInfo objects by serverUrl. This should come from disk
+   * @param newServers: Array<string> of new servers downloaded from the info server
+   */
+  serverCacheLoad(
+    oldServers: { [serverUrl: string]: ServerInfo },
+    newServers: string[] = []
+  ): void {
+    //
+    // Add any new servers coming out of the info server
+    //
+    for (const newServer of newServers) {
+      if (oldServers[newServer] === undefined) {
+        const serverScoreObj: ServerInfo = {
+          serverUrl: newServer,
+          serverScore: 0,
+          responseTime: RESPONSE_TIME_UNINITIALIZED,
+          numResponseTimes: 0
+        }
+        oldServers[newServer] = serverScoreObj
+      }
+    }
+
+    //
+    // If there is a cached server (oldServers) that is not on the newServers array, then set it's score to -1
+    // to reduce chances of using it.
+    //
+    for (const serverUrl in oldServers) {
+      const oldServer = oldServers[serverUrl]
+      let match = false
+      for (const newServerUrl of newServers) {
+        if (newServerUrl === serverUrl) {
+          match = true
+          break
+        }
+      }
+
+      let serverScore = oldServer.serverScore
+      if (!match) {
+        if (serverScore > DROPPED_SERVER_SCORE) {
+          serverScore = DROPPED_SERVER_SCORE
+        }
+      } else {
+        if (serverScore < RE_ADDED_SERVER_SCORE) {
+          serverScore = RE_ADDED_SERVER_SCORE
+        }
+      }
+
+      if (this.cacheLastSave_ === 0) {
+        serverScore = Math.min(serverScore, MAX_SCORE - 100)
+      }
+
+      if (serverUrl.startsWith('wss') && serverScore > 0) {
+        serverScore = 0
+        oldServer.responseTime = RESPONSE_TIME_UNINITIALIZED
+      }
+
+      oldServer.serverScore = serverScore
+      this.servers_[serverUrl] = oldServer
+      this.dirtyServerCache(serverUrl)
+    }
+  }
+
+  clearServerCache(): void {
+    this.servers_ = {}
+    this.serverCacheDirty = false
+    this.cacheLastSave_ = Date.now()
+    lastScoreUpTime_ = Date.now()
+  }
+
+  printServerCache(): void {
+    this.log('**** printServerCache ****')
+    const serverInfos: ServerInfo[] = []
+    for (const s in this.servers_) {
+      serverInfos.push(this.servers_[s])
+    }
+    // Sort by score
+    serverInfos.sort((a: ServerInfo, b: ServerInfo) => {
+      return b.serverScore - a.serverScore
+    })
+
+    for (const s of serverInfos) {
+      const score = s.serverScore.toString()
+      const response = s.responseTime.toString()
+      const numResponse = s.numResponseTimes.toString()
+      const url = s.serverUrl
+      this.log(`ServerCache ${score} ${response}ms ${numResponse} ${url}`)
+    }
+    this.log('**************************')
+  }
+
+  serverScoreUp(
+    serverUrl: string,
+    responseTimeMilliseconds: number,
+    changeScore = 1
+  ): void {
+    const serverInfo: ServerInfo = this.servers_[serverUrl]
+
+    serverInfo.serverScore += changeScore
+    if (serverInfo.serverScore > MAX_SCORE) {
+      serverInfo.serverScore = MAX_SCORE
+    }
+    lastScoreUpTime_ = Date.now()
+
+    if (responseTimeMilliseconds !== 0) {
+      this.setResponseTime(serverUrl, responseTimeMilliseconds)
+    }
+
+    this.log(
+      `${serverUrl}: score UP to ${serverInfo.serverScore} ${responseTimeMilliseconds}ms`
+    )
+    this.dirtyServerCache(serverUrl)
+  }
+
+  serverScoreDown(serverUrl: string, changeScore = 10): void {
+    const currentTime = Date.now()
+    if (currentTime - lastScoreUpTime_ > 60000) {
+      // It has been over 1 minute since we got an up-vote for any server.
+      // Assume the network is down and don't penalize anyone for now
+      this.log(`${serverUrl}: score DOWN cancelled`)
+      return
+    }
+    const serverInfo: ServerInfo = this.servers_[serverUrl]
+    serverInfo.serverScore -= changeScore
+    if (serverInfo.serverScore < MIN_SCORE) {
+      serverInfo.serverScore = MIN_SCORE
+    }
+
+    if (serverInfo.numResponseTimes === 0) {
+      this.setResponseTime(serverUrl, 9999)
+    }
+
+    this.log(`${serverUrl}: score DOWN to ${serverInfo.serverScore}`)
+    this.dirtyServerCache(serverUrl)
+  }
+
+  setResponseTime(serverUrl: string, responseTimeMilliseconds: number): void {
+    const serverInfo: ServerInfo = this.servers_[serverUrl]
+    serverInfo.numResponseTimes++
+
+    const oldTime = serverInfo.responseTime
+    let newTime = 0
+    if (RESPONSE_TIME_UNINITIALIZED === oldTime) {
+      newTime = responseTimeMilliseconds
+    } else {
+      // Every 10th setting of response time, decrease effect of prior values by 5x
+      if (serverInfo.numResponseTimes % 10 === 0) {
+        newTime = (oldTime + responseTimeMilliseconds * 4) / 5
+      } else {
+        newTime = (oldTime + responseTimeMilliseconds) / 2
+      }
+    }
+    serverInfo.responseTime = newTime
+    this.dirtyServerCache(serverUrl)
+  }
+
+  getServers(
+    numServersWanted: number,
+    includePatterns: string[] = []
+  ): string[] {
+    if (this.servers_ == null || Object.keys(this.servers_).length === 0) {
+      return []
+    }
+
+    let serverInfos: ServerInfo[] = []
+    let newServerInfos: ServerInfo[] = []
+    //
+    // Find new servers and cache them away
+    //
+    for (const s in this.servers_) {
+      const server = this.servers_[s]
+      serverInfos.push(server)
+      if (
+        server.responseTime === RESPONSE_TIME_UNINITIALIZED &&
+        server.serverScore === 0
+      ) {
+        newServerInfos.push(server)
+      }
+    }
+    if (serverInfos.length === 0) {
+      return []
+    }
+    if (includePatterns.length > 0) {
+      const filter = (server: ServerInfo): boolean => {
+        for (const pattern of includePatterns) {
+          // make sure that the server URL starts with 'wss'
+          if (server.serverUrl.indexOf(pattern) === 0) return true
+        }
+        return false
+      }
+      serverInfos = serverInfos.filter(filter)
+      newServerInfos = newServerInfos.filter(filter)
+    }
+    // Sort by score
+    serverInfos.sort((a: ServerInfo, b: ServerInfo) => {
+      return b.serverScore - a.serverScore
+    })
+
+    //
+    // Take the top 50% of servers that have
+    // 1. A score within 100 points of the highest score
+    // 2. And a positive score of at least 5
+    // 3. And a response time that is not RESPONSE_TIME_UNINITIALIZED
+    //
+    // Then sort those top servers by response time from lowest to highest
+    //
+
+    const startServerInfo = serverInfos[0]
+    let numServerPass = 0
+    let serverEnd = 0
+    for (let i = 0; i < serverInfos.length; i++) {
+      const serverInfo = serverInfos[i]
+      if (serverInfo.serverScore < startServerInfo.serverScore - 100) {
+        continue
+      }
+      if (serverInfo.serverScore < 5) {
+        continue
+      }
+      if (serverInfo.responseTime >= RESPONSE_TIME_UNINITIALIZED) {
+        continue
+      }
+      numServerPass++
+      if (numServerPass < numServersWanted) {
+        continue
+      }
+      if (numServerPass >= serverInfos.length / 2) {
+        continue
+      }
+      serverEnd = i
+    }
+
+    let topServerInfos = serverInfos.slice(0, serverEnd)
+    topServerInfos.sort((a: ServerInfo, b: ServerInfo) => {
+      return a.responseTime - b.responseTime
+    })
+    topServerInfos = topServerInfos.concat(serverInfos.slice(serverEnd))
+
+    const servers = []
+    let numServers = 0
+    let numNewServers = 0
+    for (const serverInfo of topServerInfos) {
+      numServers++
+      servers.push(serverInfo.serverUrl)
+      if (
+        serverInfo.responseTime === RESPONSE_TIME_UNINITIALIZED &&
+        serverInfo.serverScore === 0
+      ) {
+        numNewServers++
+      }
+
+      if (numServers >= numServersWanted) {
+        break
+      }
+
+      if (numServers >= numServersWanted / 2 && numNewServers === 0) {
+        if (newServerInfos.length >= numServersWanted - numServers) {
+          break
+        }
+      }
+    }
+
+    // If this list does not have a new server in it, try to add one as we always want to give new
+    // servers a try.
+    if (numNewServers === 0) {
+      for (const serverInfo of newServerInfos) {
+        servers.unshift(serverInfo.serverUrl)
+        numServers++
+        if (numServers >= numServersWanted) {
+          break
+        }
+      }
+    }
+
+    return servers
+  }
+}

--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -8,6 +8,7 @@ import {
 
 import { IUTXO } from '../utxobased/db/types'
 import { EngineEmitter } from './makeEngineEmitter'
+import { PluginState } from './pluginState'
 
 // this enumerates the network types of single coins. Can be expanded to add regtest, signet, stagenet etc.
 export enum NetworkEnum {
@@ -69,6 +70,7 @@ export interface EngineConfig {
   currencyTools: EdgeCurrencyTools
   options: EngineOptions
   io: EdgeIo
+  pluginState: PluginState
 }
 
 interface EngineOptions extends EdgeCurrencyEngineOptions {

--- a/src/common/utxobased/engine/constants.ts
+++ b/src/common/utxobased/engine/constants.ts
@@ -1,3 +1,7 @@
 export const BLOCKBOOK_TXS_PER_PAGE = 10
 
 export const CACHE_THROTTLE = 0.05
+
+export const MAX_CONNECTIONS = 2
+
+export const NEW_CONNECTIONS = 8

--- a/src/common/utxobased/engine/makeServerStates.ts
+++ b/src/common/utxobased/engine/makeServerStates.ts
@@ -1,0 +1,344 @@
+import { EdgeLog, EdgeWalletInfo } from 'edge-core-js'
+import { EdgeTransaction } from 'edge-core-js/lib/types/types'
+import { parse } from 'uri-js'
+
+import { EngineEmitter, EngineEvent } from '../../plugin/makeEngineEmitter'
+import { PluginState } from '../../plugin/pluginState'
+import {
+  BlockBook,
+  makeBlockBook,
+  WatchAddressesCB,
+  WatchBlocksCB
+} from '../network/BlockBook'
+import Deferred from '../network/Deferred'
+import { WsTask } from '../network/Socket'
+import { pushUpdate, removeIdFromQueue } from '../network/socketQueue'
+import { MAX_CONNECTIONS, NEW_CONNECTIONS } from './constants'
+
+interface ServerState {
+  subscribedBlocks: boolean
+  txids: Set<string>
+  addresses: Set<string>
+}
+
+interface ServerStateConfig {
+  engineStarted: boolean
+  walletInfo: EdgeWalletInfo
+  pluginState: PluginState
+  emitter: EngineEmitter
+  log: EdgeLog
+}
+
+export interface ServerStates {
+  setPickNextTaskCB: (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    callback: (uri: string) => Promise<boolean | WsTask<any> | undefined>
+  ) => void
+  stop: () => void
+  serverCanGetTx: (uri: string, txid: string) => boolean
+  serverCanGetAddress: (uri: string, address: string) => boolean
+  serverScoreUp: (uri: string, score: number) => void
+  getServerState: (uri: string) => ServerState | undefined
+  refillServers: () => void
+  getServerList: () => string[]
+  setServerList: (updatedServerList: string[]) => void
+  broadcastTx: (transaction: EdgeTransaction) => Promise<string>
+  watchAddresses: (
+    uri: string,
+    addresses: string[],
+    cb: WatchAddressesCB,
+    deferredAddressSub: Deferred<unknown>
+  ) => void
+  watchBlocks: (
+    uri: string,
+    cb: WatchBlocksCB,
+    deferredBlockSub: Deferred<unknown>
+  ) => void
+}
+
+export function makeServerStates(config: ServerStateConfig): ServerStates {
+  const { engineStarted, walletInfo, pluginState, emitter, log } = config
+
+  const serverStates = new Map<string, ServerState>()
+
+  const connections = new Map<string, BlockBook>()
+  let serverList: string[] = []
+  let reconnectCounter = 0
+  let reconnectTimer: ReturnType<typeof setTimeout> = setTimeout(() => {
+    return
+  }, 0)
+  let pickNextTaskCB: (
+    uri: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) => Promise<boolean | WsTask<any> | undefined>
+
+  const setPickNextTaskCB = (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    callback: (uri: string) => Promise<boolean | WsTask<any> | undefined>
+  ): void => {
+    pickNextTaskCB = callback
+  }
+
+  const stop = async (): Promise<void> => {
+    removeIdFromQueue(walletInfo.id)
+    clearTimeout(reconnectTimer)
+    for (const uri of connections.keys()) {
+      const blockBook = connections.get(uri)
+      if (blockBook == null) continue
+      await blockBook.disconnect()
+    }
+  }
+
+  const reconnect = (): void => {
+    if (engineStarted) {
+      if (reconnectCounter < 5) reconnectCounter++
+      reconnectTimer = setTimeout(() => {
+        clearTimeout(reconnectTimer)
+        refillServers()
+      }, reconnectCounter * 1000)
+    }
+  }
+
+  const refillServers = (): void => {
+    pushUpdate({
+      id: walletInfo.id,
+      updateFunc: () => {
+        doRefillServers()
+      }
+    })
+  }
+
+  const doRefillServers = (): void => {
+    const includePatterns = ['wss:']
+    if (serverList.length === 0) {
+      serverList = pluginState.getServers(NEW_CONNECTIONS, includePatterns)
+    }
+    log(`refillServers: Top ${NEW_CONNECTIONS} servers:`, serverList)
+    let chanceToBePicked = 1.25
+    while (connections.size < MAX_CONNECTIONS) {
+      if (serverList.length === 0) break
+      const uri = serverList.shift()
+      if (uri == null) {
+        reconnect()
+        break
+      }
+      if (connections.get(uri) != null) {
+        continue
+      }
+      // Validate the URI of server to make sure it is valid
+      const parsed = parse(uri)
+      if (
+        parsed.scheme == null ||
+        parsed.scheme.length < 3 ||
+        parsed.host == null
+      ) {
+        continue
+      }
+      chanceToBePicked -= chanceToBePicked > 0.5 ? 0.25 : 0
+      if (Math.random() > chanceToBePicked) {
+        serverList.push(uri)
+        continue
+      }
+      const shortUrl = `${uri.replace('wss://', '').replace('/websocket', '')}:`
+
+      emitter.on(EngineEvent.CONNECTION_OPEN, () => {
+        reconnectCounter = 0
+        log(`${shortUrl} ** Connected **`)
+      })
+      emitter.on(EngineEvent.CONNECTION_CLOSE, (error?: Error) => {
+        connections.delete(uri)
+        serverStates.delete(uri)
+        const msg =
+          error != null ? ` !! Connection ERROR !! ${error.message}` : ''
+        log(`${shortUrl} onClose ${msg}`)
+        if (error != null) {
+          pluginState.serverScoreDown(uri)
+        }
+        reconnect()
+      })
+      emitter.on(EngineEvent.CONNECTION_TIMER, (queryDate: number) => {
+        const queryTime = Date.now() - queryDate
+        log(`${shortUrl} returned version in ${queryTime}ms`)
+        pluginState.serverScoreUp(uri, queryTime)
+      })
+      emitter.on(EngineEvent.BLOCK_HEIGHT_CHANGED, (height: number) => {
+        log(`${shortUrl} returned height: ${height}`)
+        const serverState = serverStates.get(uri)
+        if (serverState == null) {
+          serverStates.set(uri, {
+            subscribedBlocks: true,
+            txids: new Set(),
+            addresses: new Set()
+          })
+        } else if (!serverState.subscribedBlocks) {
+          serverState.subscribedBlocks = true
+        }
+      })
+
+      serverStates.set(uri, {
+        subscribedBlocks: false,
+        txids: new Set(),
+        addresses: new Set()
+      })
+
+      const onQueueSpaceCB = async (): Promise<
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        WsTask<any> | boolean | undefined
+      > => {
+        const blockBook = connections.get(uri)
+        if (blockBook == null) {
+          return
+        }
+        const task = await pickNextTaskCB(uri)
+        if (task != null && typeof task !== 'boolean') {
+          const taskMessage = `${task.method} params: ${JSON.stringify(
+            task.params
+          )}`
+          log(`${shortUrl} nextTask: ${taskMessage}`)
+        }
+        return task
+      }
+
+      connections.set(
+        uri,
+        makeBlockBook({
+          wsAddress: uri,
+          emitter,
+          log,
+          onQueueSpaceCB,
+          walletId: walletInfo.id
+        })
+      )
+
+      const blockBook = connections.get(uri)
+      if (blockBook == null) continue
+      blockBook
+        .connect()
+        .then(async () => {
+          const queryTime = Date.now()
+          const { bestHeight } = await blockBook.fetchInfo()
+          pluginState.serverScoreUp(uri, Date.now() - queryTime)
+          emitter.emit(EngineEvent.BLOCK_HEIGHT_CHANGED, bestHeight)
+        })
+        .catch(e => {
+          log.error(`${JSON.stringify(e.message)}`)
+        })
+    }
+  }
+
+  const serverCanGetTx = (uri: string, txid: string): boolean => {
+    const serverState = serverStates.get(uri)
+    if (serverState == null) return false
+    if (serverState.txids.has(txid)) return true
+
+    for (const state of serverStates.values()) {
+      if (state.txids.has(txid)) return false
+    }
+    return true
+  }
+
+  const serverCanGetAddress = (uri: string, address: string): boolean => {
+    const serverState = serverStates.get(uri)
+    if (serverState == null) return false
+    if (serverState.addresses.has(address)) return true
+
+    for (const state of serverStates.values()) {
+      if (state.addresses.has(address)) return false
+    }
+    return true
+  }
+
+  const serverScoreUp = (uri: string, score: number): void => {
+    pluginState.serverScoreUp(uri, score)
+  }
+
+  const getServerState = (uri: string): ServerState | undefined => {
+    return serverStates.get(uri)
+  }
+
+  const getServerList = (): string[] => {
+    return serverList
+  }
+
+  const setServerList = (updatedServerList: string[]): void => {
+    serverList = updatedServerList
+  }
+
+  const broadcastTx = async (transaction: EdgeTransaction): Promise<string> => {
+    return await new Promise((resolve, reject) => {
+      const uris = Object.keys(connections).filter(uri => {
+        const blockBook = connections.get(uri)
+        if (blockBook == null) return false
+        return blockBook.isConnected
+      })
+      if (uris == null || uris.length < 1) {
+        reject(
+          new Error('No available connections\nCheck your internet signal')
+        )
+      }
+      let resolved = false
+      let bad = 0
+      for (const uri of uris) {
+        const blockBook = connections.get(uri)
+        if (blockBook == null) continue
+        blockBook
+          .broadcastTx(transaction)
+          .then(response => {
+            if (!resolved) {
+              resolved = true
+              resolve(response.result)
+            }
+          })
+          .catch((e?: Error) => {
+            if (++bad === uris.length) {
+              const msg = e != null ? `With error ${e.message}` : ''
+              log.error(
+                `broadcastTx fail: ${JSON.stringify(transaction)}\n${msg}`
+              )
+              reject(e)
+            }
+          })
+      }
+    })
+  }
+
+  const watchAddresses = (
+    uri: string,
+    addresses: string[],
+    cb: WatchAddressesCB,
+    deferredAddressSub: Deferred<unknown>
+  ): void => {
+    const blockbook = connections.get(uri)
+    if (blockbook == null)
+      throw new Error(`No blockbook connection with ${uri}`)
+    blockbook.watchAddresses(addresses, cb, deferredAddressSub)
+  }
+
+  const watchBlocks = (
+    uri: string,
+    cb: WatchBlocksCB,
+    deferredBlockSub: Deferred<unknown>
+  ): void => {
+    const blockbook = connections.get(uri)
+    if (blockbook == null)
+      throw new Error(`No blockbook connection with ${uri}`)
+    blockbook.watchBlocks(cb, deferredBlockSub)
+  }
+
+  refillServers()
+
+  return {
+    setPickNextTaskCB,
+    stop,
+    serverCanGetTx,
+    serverCanGetAddress,
+    serverScoreUp,
+    getServerState,
+    refillServers,
+    getServerList,
+    setServerList,
+    broadcastTx,
+    watchAddresses,
+    watchBlocks
+  }
+}

--- a/src/common/utxobased/network/BlockBook.ts
+++ b/src/common/utxobased/network/BlockBook.ts
@@ -15,6 +15,10 @@ import {
 import Deferred from './Deferred'
 import { makeSocket, OnQueueSpaceCB } from './Socket'
 
+export interface ITransactionBroadcastResponse {
+  result: string // txid
+}
+
 export interface INewTransactionResponse {
   address: string
   tx: ITransaction
@@ -162,7 +166,9 @@ export interface BlockBook {
 
   fetchTransaction: (hash: string) => Promise<ITransaction>
 
-  broadcastTx: (transaction: EdgeTransaction) => Promise<void>
+  broadcastTx: (
+    transaction: EdgeTransaction
+  ) => Promise<ITransactionBroadcastResponse>
 }
 
 export interface BlockHeightEmitter {
@@ -173,12 +179,14 @@ interface BlockBookConfig {
   emitter: EngineEmitter
   wsAddress?: string
   log: EdgeLog
+  walletId: string
+  onQueueSpaceCB: OnQueueSpaceCB
 }
 
 const baseUri = 'btc1.trezor.io'
 
 export function makeBlockBook(config: BlockBookConfig): BlockBook {
-  const { emitter, log } = config
+  const { emitter, log, onQueueSpaceCB, walletId } = config
   const baseWSAddress = config.wsAddress ?? `wss://${baseUri}/websocket`
 
   const instance: BlockBook = {
@@ -195,23 +203,12 @@ export function makeBlockBook(config: BlockBookConfig): BlockBook {
     broadcastTx
   }
 
-  emitter.on(EngineEvent.CONNECTION_OPEN, () => {
-    return
-  })
-  emitter.on(EngineEvent.CONNECTION_CLOSE, (error?: Error) => {
-    log.warn(error)
-  })
-  emitter.on(EngineEvent.CONNECTION_TIMER, (_queryTime: number) => {
-    return
-  })
-  emitter.on(EngineEvent.CONNECTION_TIMER, (_queryTime: number) => {
-    return
-  })
-
   const socket = makeSocket(baseWSAddress, {
     healthCheck: ping,
+    onQueueSpaceCB,
     log,
-    emitter
+    emitter,
+    walletId
   })
 
   async function connect(): Promise<void> {
@@ -291,8 +288,10 @@ export function makeBlockBook(config: BlockBookConfig): BlockBook {
     })
   }
 
-  async function broadcastTx(transaction: EdgeTransaction): Promise<void> {
-    await promisifyWsMessage(broadcastTxMessage(transaction))
+  async function broadcastTx(
+    transaction: EdgeTransaction
+  ): Promise<ITransactionBroadcastResponse> {
+    return await promisifyWsMessage(broadcastTxMessage(transaction))
   }
 
   return instance

--- a/src/common/utxobased/network/BlockBook.ts
+++ b/src/common/utxobased/network/BlockBook.ts
@@ -119,6 +119,10 @@ interface IServerInfo {
 }
 
 type Callback = () => void | Promise<void>
+export type WatchAddressesCB = (
+  response: INewTransactionResponse
+) => void | Promise<void>
+export type WatchBlocksCB = () => void | Promise<void>
 
 export interface BlockBook {
   isConnected: boolean

--- a/src/common/utxobased/network/socketQueue.ts
+++ b/src/common/utxobased/network/socketQueue.ts
@@ -8,7 +8,7 @@ interface UpdateQueue {
 }
 
 const updateQueue: UpdateQueue[] = []
-let timeOut: NodeJS.Timeout
+let timeOut: ReturnType<typeof setTimeout>
 
 export function pushUpdate(update: UpdateQueue): void {
   if (updateQueue.length === 0) {

--- a/test/common/utxobased/network/BlockBook.spec.ts
+++ b/test/common/utxobased/network/BlockBook.spec.ts
@@ -9,6 +9,7 @@ import {
   makeBlockBook
 } from '../../../../src/common/utxobased/network/BlockBook'
 import Deferred from '../../../../src/common/utxobased/network/Deferred'
+import { WsTask } from '../../../../src/common/utxobased/network/Socket'
 
 chai.should()
 
@@ -57,9 +58,18 @@ describe('BlockBook notifications tests with dummy server', function () {
     log.error = (..._args: unknown[]): void => {
       return
     }
+
+    const onQueueSpaceCB = async (
+      _uri: string
+    ): Promise<WsTask<unknown> | undefined> => {
+      return
+    }
+
     blockBook = makeBlockBook({
       emitter,
       log,
+      walletId: '',
+      onQueueSpaceCB,
       wsAddress: 'ws://localhost:8080'
     })
     await blockBook.connect()
@@ -135,8 +145,14 @@ describe('BlockBook', function () {
   }
   let blockBook: BlockBook
 
+  const onQueueSpaceCB = async (
+    _uri: string
+  ): Promise<WsTask<unknown> | undefined> => {
+    return
+  }
+
   beforeEach(async () => {
-    blockBook = makeBlockBook({ emitter, log })
+    blockBook = makeBlockBook({ emitter, log, walletId: '', onQueueSpaceCB })
     await blockBook.connect()
   })
 


### PR DESCRIPTION
Just opened for visibility, review has to wait until PickNextTask is merged.

Add support for multiple sockets. This introduces more caches for each of the sockets, a plugin state object that holds servers in a queue and code to select servers for connections by their score.