### PR TITLE
Fetch info fix

### DIFF
--- a/src/common/utxobased/network/BlockBook.ts
+++ b/src/common/utxobased/network/BlockBook.ts
@@ -172,13 +172,17 @@ export function makeBlockBook(config: BlockBookConfig): BlockBook {
     broadcastTx
   }
 
-  emitter.on(EngineEvent.CONNECTION_OPEN, () => {})
+  emitter.on(EngineEvent.CONNECTION_OPEN, () => {
+    return
+  })
   emitter.on(EngineEvent.CONNECTION_CLOSE, (error?: Error) => {
     if (error != null) {
       throw new Error(`connection closing due to ${error.message}`)
     }
   })
-  emitter.on(EngineEvent.CONNECTION_TIMER, (queryTime: number) => {})
+  emitter.on(EngineEvent.CONNECTION_TIMER, (_queryTime: number) => {
+    return
+  })
   const onQueueSpace = (): potentialWsTask => {
     return {}
   }
@@ -217,7 +221,7 @@ export function makeBlockBook(config: BlockBookConfig): BlockBook {
     socket.submitTask(task)
   }
 
-  async function ping(): Promise<object> {
+  async function ping(): Promise<Record<string, unknown>> {
     return await promisifyWsMessage('ping')
   }
 

--- a/src/common/utxobased/network/BlockBook.ts
+++ b/src/common/utxobased/network/BlockBook.ts
@@ -83,6 +83,11 @@ export interface IAccountUTXO extends IUTXO {
   path?: string
 }
 
+interface IServerInfoVersion {
+  version: string
+  subversion: string
+}
+
 interface IServerInfo {
   name: string
   shortcut: string
@@ -92,6 +97,7 @@ interface IServerInfo {
   bestHash: string
   block0Hash: string
   testnet: boolean
+  backend?: IServerInfoVersion
 }
 
 type Callback = () => void | Promise<void>

--- a/test/common/utxobased/network/BlockBook.spec.ts
+++ b/test/common/utxobased/network/BlockBook.spec.ts
@@ -153,7 +153,8 @@ describe('BlockBook', function () {
         'bestHeight',
         'bestHash',
         'block0Hash',
-        'testnet'
+        'testnet',
+        'backend'
       )
     })
   })


### PR DESCRIPTION
Tests are currently broken, because a `backend` field was added to the blockbook `fetchinfo` call.