### PR TITLE
Exit mocha after tests complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "fix": "npm run lint -- --fix",
     "prepare": "npm-run-all clean -p build.*",
     "start": "node -r sucrase/register src/index.ts",
-    "test": "mocha -r sucrase/register 'test/**/*.spec.ts'",
+    "test": "mocha --exit -r sucrase/register 'test/**/*.spec.ts'",
     "lint": "eslint ."
   },
   "husky": {


### PR DESCRIPTION
Mocha does not exit if some asynchronous processes are not done yet.
This behavior is now overridden with the --exit flag.