### PR TITLE
EngineState: Set running=false when stopping

### DIFF
--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -146,6 +146,7 @@ export function makeUtxoEngineState(
     },
 
     async stop(): Promise<void> {
+      running = false
       // TODO: stop watching blocks
       // TODO: stop watching addresses
     },


### PR DESCRIPTION
Changes to run in commit 28ee922ede1e669f613156be7a2f70a08c680961 never set the state to false again.