### PR TITLE
Fix resync behavior

### DIFF
--- a/src/common/plugin/makeMetadata.ts
+++ b/src/common/plugin/makeMetadata.ts
@@ -13,7 +13,7 @@ interface MetadataConfig {
 }
 
 export interface Metadata extends LocalWalletMetadata {
-  clear: (currencyCode: string) => Promise<void>
+  clear: () => Promise<void>
 }
 
 export const makeMetadata = async (
@@ -39,7 +39,7 @@ export const makeMetadata = async (
 
   emitter.on(
     EngineEvent.BLOCK_HEIGHT_CHANGED,
-    async (uri: string, height: number) => {
+    async (_uri: string, height: number) => {
       if (height > cache.lastSeenBlockHeight) {
         cache.lastSeenBlockHeight = height
         await setMetadata(memlet, cache)
@@ -54,14 +54,9 @@ export const makeMetadata = async (
     get lastSeenBlockHeight() {
       return cache.lastSeenBlockHeight
     },
-    clear: async (currencyCode: string) => {
+    clear: async () => {
       await memlet.delete(metadataPath)
       cache = await resetMetadata(memlet)
-      emitter.emit(
-        EngineEvent.WALLET_BALANCE_CHANGED,
-        currencyCode,
-        cache.balance
-      )
     }
   }
 }

--- a/src/common/utxobased/engine/makeServerStates.ts
+++ b/src/common/utxobased/engine/makeServerStates.ts
@@ -87,6 +87,8 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
       if (blockBook == null) continue
       await blockBook.disconnect()
     }
+    connections.clear()
+    serverStates.clear()
   }
 
   const reconnect = (): void => {

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -341,7 +341,7 @@ export async function makeUtxoEngine(
       await processor.clearAll()
       // clear the networking cache
       await pluginState.clearCache()
-      await metadata.clear()
+      await metadata.clear(currencyInfo.currencyCode)
 
       // finally restart the state
       await state.start()

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -100,6 +100,11 @@ export async function makeUtxoEngine(
 
   const fns: EdgeCurrencyEngine = {
     async startEngine(): Promise<void> {
+      emitter.emit(
+        EngineEvent.WALLET_BALANCE_CHANGED,
+        config.currencyInfo.currencyCode,
+        metadata.balance
+      )
       await fees.start()
       await state.start()
     },
@@ -331,7 +336,7 @@ export async function makeUtxoEngine(
       await processor.clearAll()
       // clear the networking cache
       await pluginState.clearCache()
-      await metadata.clear(currencyInfo.currencyCode)
+      await metadata.clear()
 
       // finally restart the state
       await state.start()

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -93,6 +93,17 @@ export function makeUtxoEngineState(
     updateTransactionsCache: new Map()
   }
 
+  const clearTaskCache = (): void => {
+    taskCache.addressWatching = false
+    taskCache.blockWatching = false
+    taskCache.addressSubscribeCache.clear()
+    taskCache.transactionsCache.clear()
+    taskCache.utxosCache.clear()
+    taskCache.rawUtxosCache.clear()
+    taskCache.processedUtxosCache.clear()
+    taskCache.updateTransactionsCache.clear()
+  }
+
   let processedCount = 0
   let processedPercent = 0
   const onAddressChecked = async (): Promise<void> => {
@@ -174,6 +185,7 @@ export function makeUtxoEngineState(
 
     async stop(): Promise<void> {
       serverStates.stop()
+      clearTaskCache()
       running = false
     },
 


### PR DESCRIPTION
Fixes to the metadata cache to update the balance correctly when starting a resync and the serverCache to clear any lingering data and connections.