### PR TITLE
SetLookAhead: Remove interim set

### DIFF
--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -381,13 +381,16 @@ const setLookAhead = async (args: SetLookAheadArgs): Promise<void> => {
 
   let lastUsed = await getLastUsed()
   let addressCount = getAddressCount()
-  const addresses = new Set<string>()
 
   if (Object.keys(args.taskCache.addressSubscribeCache).length === 0) {
     for (let addressIndex = 0; addressIndex <= addressCount; addressIndex++) {
-      addresses.add(
+      args.taskCache.addressSubscribeCache[
         walletTools.getAddress({ ...partialPath, addressIndex }).address
-      )
+      ] = {
+        path: { format, branch },
+        processing: false
+      }
+      args.taskCache.addressWatching = false
     }
   }
 
@@ -403,27 +406,15 @@ const setLookAhead = async (args: SetLookAheadArgs): Promise<void> => {
       scriptPubkey,
       path
     })
-    addresses.add(address)
+    args.taskCache.addressSubscribeCache[address] = {
+      path: { format, branch },
+      processing: false
+    }
+    args.taskCache.addressWatching = false
 
     lastUsed = await getLastUsed()
     addressCount = getAddressCount()
   }
-
-  addToAddressSubscribeCache(args, addresses, { format, branch })
-}
-
-const addToAddressSubscribeCache = (
-  args: CommonArgs,
-  addresses: Set<string>,
-  path: ShortPath
-): void => {
-  addresses.forEach(address => {
-    args.taskCache.addressSubscribeCache[address] = {
-      path,
-      processing: false
-    }
-    args.taskCache.addressWatching = false
-  })
 }
 
 const addToTransactionCache = async (


### PR DESCRIPTION
The change did not change syncing/resyncing behavior in the wallet, but until we know which ES6 objects are safe to use, I'm not taking any chances.