### PR TITLE
RBF Support

### DIFF
--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -31,6 +31,8 @@ export enum EngineCurrencyType {
 export interface TxOptions {
   utxos?: IUTXO[]
   subtractFee?: boolean
+  setRBF?: boolean
+  rbfTxid?: string
 }
 
 export interface EngineCurrencyInfo extends EdgeCurrencyInfo {

--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -32,7 +32,6 @@ export interface TxOptions {
   utxos?: IUTXO[]
   subtractFee?: boolean
   setRBF?: boolean
-  rbfTxid?: string
 }
 
 export interface EngineCurrencyInfo extends EdgeCurrencyInfo {

--- a/src/common/utxobased/db/Models/baselet.ts
+++ b/src/common/utxobased/db/Models/baselet.ts
@@ -107,3 +107,10 @@ export const utxoIdsBySizeConfig: BaseletConfig<BaseType.RangeBase> = {
   type: BaseType.RangeBase,
   bucketSize: 100000
 }
+
+export type SpentUtxoById = IUTXO | undefined
+export const spentUtxoByIdConfig: BaseletConfig<BaseType.HashBase> = {
+  dbName: 'spentUtxoById',
+  type: BaseType.HashBase,
+  bucketSize: 6
+}

--- a/src/common/utxobased/db/makeBaselets.ts
+++ b/src/common/utxobased/db/makeBaselets.ts
@@ -17,6 +17,7 @@ import {
   RANGE_KEY,
   scriptPubkeyByPathConfig,
   scriptPubkeysByBalanceConfig,
+  spentUtxoByIdConfig,
   txByIdConfig,
   txIdsByBlockHeightConfig,
   txsByDateConfig,
@@ -74,7 +75,7 @@ export interface Baselets {
   address: <E extends Executor<'address'>>(fn: E) => Promise<ReturnType<E>>
   tx: <E extends Executor<'tx'>>(fn: E) => Promise<ReturnType<E>>
   utxo: <E extends Executor<'utxo'>>(fn: E) => Promise<ReturnType<E>>
-  all: AddressTables & TransactionTables & UTXOTables
+  all: AddressTables & TransactionTables & UTXOTables & SpentUTXOTables
 }
 
 type Executor<DatabaseName extends keyof Databases> = (
@@ -107,6 +108,10 @@ export interface UTXOTables {
   utxoIdsBySize: RangeBase
 }
 
+interface SpentUTXOTables {
+  spentUtxoById: HashBase
+}
+
 export const makeBaselets = async (
   config: MakeBaseletsConfig
 ): Promise<Baselets> => {
@@ -125,6 +130,7 @@ export const makeBaselets = async (
     createOrOpen(config.disklet, txByIdConfig),
     createOrOpen(config.disklet, txsByScriptPubkeyConfig),
     createOrOpen(config.disklet, utxoByIdConfig),
+    createOrOpen(config.disklet, spentUtxoByIdConfig),
     createOrOpen(config.disklet, utxoIdsByScriptPubkeyConfig)
   ])
 
@@ -140,6 +146,7 @@ export const makeBaselets = async (
     txById,
     txsByScriptPubkey,
     utxoById,
+    spentUtxoById,
     utxoIdsByScriptPubkey
   ] = hashBases
 
@@ -163,6 +170,10 @@ export const makeBaselets = async (
     utxoIdsBySize
   }
 
+  const spentUtxoBases: SpentUTXOTables = {
+    spentUtxoById
+  }
+
   return {
     async address<E extends Executor<'address'>>(
       fn: E
@@ -181,7 +192,8 @@ export const makeBaselets = async (
     all: {
       ...addressBases,
       ...txBases,
-      ...utxoBases
+      ...utxoBases,
+      ...spentUtxoBases
     }
   }
 }

--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -122,6 +122,12 @@ export interface Processor {
   saveUtxo: (utxo: IUTXO) => Promise<void>
 
   removeUtxo: (id: string) => Promise<IUTXO>
+
+  saveSpentUtxo: (utxo: IUTXO) => Promise<void>
+
+  removeSpentUtxo: (id: string) => Promise<void>
+
+  fetchSpentUtxo: (id: string) => Promise<UtxoById>
 }
 
 interface DumpDataReturn {
@@ -462,6 +468,19 @@ export async function makeProcessor(
       return await baselets.utxo(
         async tables => await deleteUtxo({ tables, id })
       )
+    },
+
+    async removeSpentUtxo(id: string): Promise<void> {
+      await baselets.all.spentUtxoById.delete('', [id])
+    },
+
+    async saveSpentUtxo(utxo: IUTXO): Promise<void> {
+      await baselets.all.spentUtxoById.insert('', utxo.id, utxo)
+    },
+
+    async fetchSpentUtxo(id: string): Promise<IUTXO> {
+      const [utxo] = await baselets.all.spentUtxoById.query('', [id])
+      return utxo
     }
   }
 
@@ -573,6 +592,18 @@ export async function makeProcessor(
     Parameters<typeof processor.removeUtxo>[0],
     Await<ReturnType<typeof processor.removeUtxo>>
   >(processor.removeUtxo)
+  processor.fetchSpentUtxo = await mutexDecorator<
+    Parameters<typeof processor.fetchSpentUtxo>[0],
+    Await<ReturnType<typeof processor.fetchSpentUtxo>>
+  >(processor.fetchSpentUtxo)
+  processor.saveSpentUtxo = await mutexDecorator<
+    Parameters<typeof processor.saveSpentUtxo>[0],
+    Await<ReturnType<typeof processor.saveSpentUtxo>>
+  >(processor.saveSpentUtxo)
+  processor.removeSpentUtxo = await mutexDecorator<
+    Parameters<typeof processor.removeSpentUtxo>[0],
+    Await<ReturnType<typeof processor.removeSpentUtxo>>
+  >(processor.removeSpentUtxo)
 
   return processor
 }

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -24,7 +24,7 @@ import {
   fromEdgeTransaction,
   toEdgeTransaction
 } from '../db/Models/ProcessorTransaction'
-import { IProcessorTransaction } from '../db/types'
+import { IProcessorTransaction, IUTXO } from '../db/types'
 import { makeTx, MakeTxTarget, signTx } from '../keymanager/keymanager'
 import { makeUtxoEngineState } from './makeUtxoEngineState'
 import { makeUtxoWalletTools } from './makeUtxoWalletTools'
@@ -277,17 +277,44 @@ export async function makeUtxoEngine(
       const freshChangeAddress =
         freshAddress.segwitAddress ?? freshAddress.publicAddress
       const utxos = options?.utxos ?? (await processor.fetchAllUtxos())
+      const setRBF = options?.setRBF ?? false
+      const rbfTxid = options?.rbfTxid
+      let maxUtxo: undefined | IUTXO
+      if (rbfTxid != null) {
+        const rbfTx = await processor.fetchTransaction(rbfTxid)
+        if (rbfTx == null) throw new Error('transaction not found')
+        const rbfFee = rbfTx?.fees
+        if (rbfFee == null)
+          throw new Error('could not get fee from replaceable transaction')
+        // double the fee used before
+        bs.mul(rbfFee, '2')
+        const rbfInputs = rbfTx.inputs
+        const maxInput = rbfInputs.reduce((a, b) =>
+          bs.gt(a.amount, b.amount) ? a : b
+        )
+        const maxId = `${maxInput.txId}_${maxInput.outputIndex}`
+        maxUtxo = await processor.fetchUtxo(maxId)
+        if (maxUtxo == null) {
+          maxUtxo = await processor.fetchSpentUtxo(maxId)
+        }
+        if (maxUtxo == null) {
+          throw new Error(
+            'transaction to be replaced found, but not its input utxos'
+          )
+        }
+      }
       const feeRate = parseInt(await fees.getRate(edgeSpendInfo))
       log.warn(`spend: Using fee rate ${feeRate} sat/B`)
       const subtractFee =
         options?.subtractFee != null ? options.subtractFee : false
       const tx = await makeTx({
         utxos,
+        forceUseUtxo: maxUtxo != null ? [maxUtxo] : [],
         targets,
         feeRate,
         coin: currencyInfo.network,
         network,
-        rbf: false,
+        setRBF,
         freshChangeAddress,
         subtractFee
       })

--- a/src/common/utxobased/keymanager/keymanager.ts
+++ b/src/common/utxobased/keymanager/keymanager.ts
@@ -14,7 +14,6 @@ import { cdsScriptTemplates } from './bitcoincashUtils/checkdatasig'
 import { Coin, CoinPrefixes } from './coin'
 import { getCoinFromString } from './coinmapper'
 import * as utxopicker from './utxopicker'
-import { Result as UTXOPickerResult } from './utxopicker'
 
 // in bitcoin these are bip44, bip49, bip84 xpub prefixes
 // other coins contain different formats which still need to be gathered.
@@ -197,10 +196,11 @@ export interface CreateTxReturn {
 
 export interface MakeTxArgs {
   network: NetworkEnum
+  forceUseUtxo: IUTXO[]
   utxos: IUTXO[]
   targets: MakeTxTarget[]
   feeRate: number
-  rbf: boolean
+  setRBF: boolean
   coin: string
   freshChangeAddress: string
   subtractFee?: boolean
@@ -211,7 +211,7 @@ export interface MakeTxTarget {
   value: number
 }
 
-interface MakeTxReturn extends Required<UTXOPickerResult> {
+interface MakeTxReturn extends Required<utxopicker.Result> {
   psbtBase64: string
 }
 
@@ -871,7 +871,7 @@ export function scriptPubkeyToElectrumScriptHash(scriptPubkey: string): string {
 
 export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
   let sequence = 0xffffffff
-  if (args.rbf) {
+  if (args.setRBF) {
     sequence -= 2
   }
 
@@ -882,8 +882,17 @@ export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
     sighashType = coin.sighash
   }
 
+  const useUtxos: utxopicker.UTXO[] = []
   const mappedUtxos: utxopicker.UTXO[] = []
-  for (const utxo of args.utxos) {
+
+  const mergedArray = [...args.utxos, ...args.forceUseUtxo]
+  const uniqueUtxos = [
+    ...mergedArray
+      .reduce((map, obj) => map.set(obj.id, obj), new Map())
+      .values()
+  ]
+
+  for (const utxo of uniqueUtxos) {
     // Cannot use a utxo without a script
     if (typeof utxo.script === 'undefined') continue
     const input: utxopicker.UTXO = {
@@ -907,7 +916,14 @@ export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
         input.redeemScript = Buffer.from(utxo.redeemScript, 'hex')
       }
     }
-    mappedUtxos.push(input)
+    let forceUsage = false
+    for (const forceUtxo of args.forceUseUtxo) {
+      if (forceUtxo.id === utxo.id) {
+        useUtxos.push(input)
+        forceUsage = true
+      }
+    }
+    if (!forceUsage) mappedUtxos.push(input)
   }
 
   const targets: utxopicker.Target[] = args.targets.map(target => {
@@ -926,11 +942,19 @@ export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
     coin: coin.name,
     network: args.network
   })
-  const subtractFee = args.subtractFee ?? false
-  const utxopicking = subtractFee
-    ? utxopicker.subtractFee
-    : utxopicker.accumulative
-  const result = utxopicking(mappedUtxos, targets, args.feeRate, changeScript)
+  const utxopicking =
+    args.forceUseUtxo != null ?? false
+      ? utxopicker.forceUseUtxo
+      : args.subtractFee ?? false
+      ? utxopicker.subtractFee
+      : utxopicker.accumulative
+  const result = utxopicking({
+    utxos: mappedUtxos,
+    useUtxos,
+    targets,
+    feeRate: args.feeRate,
+    changeScript
+  })
   if (result.inputs == null || result.outputs == null) {
     throw new Error('Make spend failed.')
   }

--- a/src/common/utxobased/keymanager/utxopicker.ts
+++ b/src/common/utxobased/keymanager/utxopicker.ts
@@ -1,3 +1,4 @@
 export * from './utxopicker/types'
 export * from './utxopicker/accumulative'
 export * from './utxopicker/subtractFee'
+export * from './utxopicker/forceUseUtxo'

--- a/src/common/utxobased/keymanager/utxopicker/forceUseUtxo.ts
+++ b/src/common/utxobased/keymanager/utxopicker/forceUseUtxo.ts
@@ -21,7 +21,7 @@ export function forceUseUtxo(args: UtxoPickerArgs): Result {
   const targetValue = utils.sumOrNaN(targets)
   const bytes = utils.transactionBytes(inputs, outputs)
   const fee = bytes * feeRate
-  // if the new feeRate is already covered by teaking the change, return
+  // if the new feeRate is already covered by lowering the change amount, return
   if (inValue >= targetValue + fee) {
     return utils.finalize(inputs, outputs, feeRate, changeScript)
   }

--- a/src/common/utxobased/keymanager/utxopicker/subtractFee.ts
+++ b/src/common/utxobased/keymanager/utxopicker/subtractFee.ts
@@ -1,12 +1,9 @@
-import { Output, Result, Target, UTXO } from './types'
+import { Output, Result, UtxoPickerArgs } from './types'
 import * as utils from './utils'
 
-export function subtractFee(
-  utxos: UTXO[],
-  targets: Target[],
-  feeRate: number,
-  _changeScript: string
-): Result {
+export function subtractFee(args: UtxoPickerArgs): Result {
+  const { utxos, targets, feeRate } = args
+
   const outputs: Output[] = targets.map(target => ({
     ...target,
     script: Buffer.from(target.script, 'hex')

--- a/src/common/utxobased/keymanager/utxopicker/types.ts
+++ b/src/common/utxobased/keymanager/utxopicker/types.ts
@@ -23,6 +23,14 @@ export interface Target {
   value: number
 }
 
+export interface UtxoPickerArgs {
+  utxos: UTXO[]
+  useUtxos?: UTXO[]
+  targets: Target[]
+  feeRate: number
+  changeScript: string
+}
+
 export interface Result {
   inputs?: Input[]
   outputs?: Output[]


### PR DESCRIPTION
Uses an interim UTXO data structure to keep hold of the already spent
UTXOs. They are removed again once a transaction confirms, and are added
when a transaction is broadcast.

Adds another fee strategy that allows the caller to force usage of a
certain array of UTXOs.