### PR TITLE
SocketEmitter: Split socket specific events from Engine

### DIFF
--- a/src/common/plugin/makeEngineEmitter.ts
+++ b/src/common/plugin/makeEngineEmitter.ts
@@ -34,18 +34,7 @@ export declare interface EngineEmitter {
       newTx: INewTransactionResponse
     ) => boolean) &
     ((event: EngineEvent.ADDRESSES_CHECKED, progressRatio: number) => boolean) &
-    ((event: EngineEvent.TXIDS_CHANGED, txids: EdgeTxidMap) => boolean) &
-    ((event: EngineEvent.CONNECTION_OPEN, uri: string) => void) &
-    ((
-      event: EngineEvent.CONNECTION_CLOSE,
-      uri: string,
-      error?: Error
-    ) => this) &
-    ((
-      event: EngineEvent.CONNECTION_TIMER,
-      uri: string,
-      queryTime: number
-    ) => this)
+    ((event: EngineEvent.TXIDS_CHANGED, txids: EdgeTxidMap) => boolean)
 
   on: ((
     event: EngineEvent.TRANSACTIONS_CHANGED,
@@ -87,18 +76,6 @@ export declare interface EngineEmitter {
     ((
       event: EngineEvent.TXIDS_CHANGED,
       listener: (txids: EdgeTxidMap) => Promise<void> | void
-    ) => this) &
-    ((
-      event: EngineEvent.CONNECTION_OPEN,
-      listener: (uri: string) => void
-    ) => this) &
-    ((
-      event: EngineEvent.CONNECTION_CLOSE,
-      listener: (uri: string, error?: Error) => void
-    ) => this) &
-    ((
-      event: EngineEvent.CONNECTION_TIMER,
-      listener: (uri: string, queryTime: number) => void
     ) => this)
 }
 export class EngineEmitter extends EventEmitter {}

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -129,7 +129,7 @@ export function makeUtxoEngineState(
     engineStarted,
     walletInfo,
     pluginState,
-    emitter,
+    engineEmitter: emitter,
     log
   })
   const commonArgs: CommonArgs = {

--- a/src/common/utxobased/network/MakeSocketEmitter.ts
+++ b/src/common/utxobased/network/MakeSocketEmitter.ts
@@ -1,0 +1,35 @@
+import { EventEmitter } from 'events'
+
+export declare interface SocketEmitter {
+  emit: ((event: SocketEvent.CONNECTION_OPEN, uri: string) => void) &
+    ((
+      event: SocketEvent.CONNECTION_CLOSE,
+      uri: string,
+      error?: Error
+    ) => boolean) &
+    ((
+      event: SocketEvent.CONNECTION_TIMER,
+      uri: string,
+      queryTime: number
+    ) => boolean)
+
+  on: ((
+    event: SocketEvent.CONNECTION_OPEN,
+    listener: (uri: string) => void
+  ) => this) &
+    ((
+      event: SocketEvent.CONNECTION_CLOSE,
+      listener: (uri: string, error?: Error) => void
+    ) => this) &
+    ((
+      event: SocketEvent.CONNECTION_TIMER,
+      listener: (uri: string, queryTime: number) => void
+    ) => this)
+}
+export class SocketEmitter extends EventEmitter {}
+
+export enum SocketEvent {
+  CONNECTION_OPEN = 'connection:open',
+  CONNECTION_CLOSE = 'connection:close',
+  CONNECTION_TIMER = 'connection:timer'
+}

--- a/src/common/utxobased/network/Socket.ts
+++ b/src/common/utxobased/network/Socket.ts
@@ -1,8 +1,8 @@
 import { EdgeLog } from 'edge-core-js'
 
-import { EngineEmitter, EngineEvent } from '../../plugin/makeEngineEmitter'
 import { removeItem } from '../../plugin/utils'
 import Deferred from './Deferred'
+import { SocketEmitter, SocketEvent } from './MakeSocketEmitter'
 import { setupWS } from './nodejsWS'
 import { pushUpdate, removeIdFromQueue } from './socketQueue'
 import { InnerSocket, InnerSocketCallbacks, ReadyState } from './types'
@@ -48,7 +48,7 @@ interface SocketConfig {
   queueSize?: number
   timeout?: number
   walletId: string
-  emitter: EngineEmitter
+  emitter: SocketEmitter
   log: EdgeLog
   healthCheck: () => Promise<Record<string, unknown>> // function for heartbeat, should submit task itself
   onQueueSpaceCB: OnQueueSpaceCB
@@ -116,7 +116,7 @@ export function makeSocket(uri: string, config: SocketConfig): Socket {
     }
     pendingMessages = {}
     try {
-      emitter.emit(EngineEvent.CONNECTION_CLOSE, uri, err)
+      emitter.emit(SocketEvent.CONNECTION_CLOSE, uri, err)
     } catch (e) {
       log.error(e.message)
     }
@@ -131,7 +131,7 @@ export function makeSocket(uri: string, config: SocketConfig): Socket {
     connected = true
     lastKeepAlive = Date.now()
     try {
-      emitter.emit(EngineEvent.CONNECTION_OPEN, uri)
+      emitter.emit(SocketEvent.CONNECTION_OPEN, uri)
     } catch (e) {
       handleError(e)
     }
@@ -220,7 +220,7 @@ export function makeSocket(uri: string, config: SocketConfig): Socket {
       config
         .healthCheck()
         .then(() => {
-          emitter.emit(EngineEvent.CONNECTION_TIMER, uri, now)
+          emitter.emit(SocketEvent.CONNECTION_TIMER, uri, now)
         })
         .catch((e: Error) => handleError(e))
     }


### PR DESCRIPTION
The EngineEmitter is split into an emitter that actually only handles
events in either engine/server states and an emitter that uniquely
handles socket events.