### PR TITLE
New processor transaction options

### DIFF
--- a/src/common/utxobased/db/Models/baselet.ts
+++ b/src/common/utxobased/db/Models/baselet.ts
@@ -3,7 +3,9 @@ import { BaseType } from 'baselet'
 import { AddressPath } from '../../../plugin/types'
 import { BaseletConfig, IAddress, IProcessorTransaction, IUTXO } from '../types'
 
+// deprecated
 export const RANGE_ID_KEY = 'idKey'
+// deprecated
 export const RANGE_KEY = 'rangeKey'
 
 export const addressPathToPrefix = (
@@ -17,6 +19,7 @@ export const scriptPubkeyByPathConfig: BaseletConfig<BaseType.CountBase> = {
   bucketSize: 50
 }
 
+// deprecated
 export type UsedFlagByScriptPubkey = boolean
 export const usedFlagByScriptPubkeyConfig: BaseletConfig<BaseType.HashBase> = {
   dbName: 'usedFlagByScriptPubkey',
@@ -31,6 +34,14 @@ export const addressByScriptPubkeyConfig: BaseletConfig<BaseType.HashBase> = {
   bucketSize: 8
 }
 
+export type LastUsedByFormatPath = number | undefined
+export const lastUsedByFormatPathConfig: BaseletConfig<BaseType.HashBase> = {
+  dbName: 'lastUsedByFormatPath',
+  type: BaseType.HashBase,
+  bucketSize: 8
+}
+
+// deprectated
 export type AddressPathByMRU = string
 export const addressPathByMRUConfig: BaseletConfig<BaseType.CountBase> = {
   dbName: 'addressPathByMRU',
@@ -45,9 +56,16 @@ export interface TxIdsByBlockHeight {
 export const txIdsByBlockHeightConfig: BaseletConfig<BaseType.RangeBase> = {
   dbName: 'txIdByConfirmations',
   type: BaseType.RangeBase,
-  bucketSize: 100000
+  bucketSize: 100000,
+  range: {
+    // deprecated - change to 'txIds'
+    id: RANGE_ID_KEY,
+    // deprecated - change to 'blockHeights'
+    key: RANGE_KEY
+  }
 }
 
+// deprecated
 export interface ScriptPubkeysByBalance {
   [RANGE_ID_KEY]: string
   [RANGE_KEY]: string
@@ -65,6 +83,7 @@ export const txByIdConfig: BaseletConfig<BaseType.HashBase> = {
   bucketSize: 6
 }
 
+// deprecated
 export interface TxsByScriptPubkey {
   [hash: string]: {
     ins: { [index: number]: true }
@@ -77,6 +96,7 @@ export const txsByScriptPubkeyConfig: BaseletConfig<BaseType.HashBase> = {
   bucketSize: 8
 }
 
+// deprecated - use TxIdsByDate instead
 export type TxsByDate = TxByDate[]
 interface TxByDate {
   [RANGE_ID_KEY]: string
@@ -88,6 +108,23 @@ export const txsByDateConfig: BaseletConfig<BaseType.RangeBase> = {
   bucketSize: 30 * 24 * 60 * 60 * 1000
 }
 
+export const txIdsByDateRangeKey = 'date'
+export const txIdsByDateRangeId = 'txId'
+export type TxIdsByDate = TxIdByDate[]
+interface TxIdByDate {
+  [txIdsByDateRangeKey]: string
+  [txIdsByDateRangeId]: string
+}
+export const txIdsByDateConfig: BaseletConfig<BaseType.RangeBase> = {
+  dbName: 'txIdsByDate',
+  type: BaseType.RangeBase,
+  bucketSize: 30 * 24 * 60 * 60 * 1000,
+  range: {
+    id: txIdsByDateRangeId,
+    key: txIdsByDateRangeKey
+  }
+}
+
 export type UtxoById = IUTXO | undefined
 export const utxoByIdConfig: BaseletConfig<BaseType.HashBase> = {
   dbName: 'utxoById',
@@ -95,6 +132,14 @@ export const utxoByIdConfig: BaseletConfig<BaseType.HashBase> = {
   bucketSize: 6
 }
 
+export type BlockHashByBlockHeight = string
+export const blockHashByBlockHeightConfig: BaseletConfig<BaseType.HashBase> = {
+  dbName: 'blockHashByBlockHeight',
+  type: BaseType.HashBase,
+  bucketSize: 30 * 24 * 60 * 60 * 1000
+}
+
+// deprecated
 export type UtxosByScriptPubkey = Array<{
   hash: string
   vout: number
@@ -105,6 +150,7 @@ export const utxoIdsByScriptPubkeyConfig: BaseletConfig<BaseType.HashBase> = {
   bucketSize: 8
 }
 
+// deprecated
 export interface UtxosBySize {
   [RANGE_ID_KEY]: string
   [RANGE_KEY]: string
@@ -115,6 +161,7 @@ export const utxoIdsBySizeConfig: BaseletConfig<BaseType.RangeBase> = {
   bucketSize: 100000
 }
 
+// deprecated
 export type SpentUtxoById = IUTXO | undefined
 export const spentUtxoByIdConfig: BaseletConfig<BaseType.HashBase> = {
   dbName: 'spentUtxoById',

--- a/src/common/utxobased/db/newProcessor.ts
+++ b/src/common/utxobased/db/newProcessor.ts
@@ -32,7 +32,7 @@ interface ProcessorConfig {
 
 interface InsertTransactionArgs {
   tx: IProcessorTransaction
-  scriptPubkey: string
+  scriptPubkey?: string
 }
 
 interface UpdateTransactionArgs {
@@ -229,23 +229,25 @@ export async function makeNewProcessor(
         // Use the existing transaction if it does exist.
         const transaction = processorTx ?? tx
 
-        // Mark the used inputs with the provided script pubkey
-        for (const input of transaction.inputs) {
-          if (input.scriptPubkey === scriptPubkey) {
-            if (!transaction.ourIns.includes(input.n.toString())) {
-              transaction.ourIns.push(input.n.toString())
+        if (scriptPubkey != null) {
+          // Mark the used inputs with the provided script pubkey
+          for (const input of transaction.inputs) {
+            if (input.scriptPubkey === scriptPubkey) {
+              if (!transaction.ourIns.includes(input.n.toString())) {
+                transaction.ourIns.push(input.n.toString())
+              }
             }
           }
-        }
-        for (const output of transaction.outputs) {
-          if (output.scriptPubkey === scriptPubkey) {
-            if (!transaction.ourOuts.includes(output.n.toString())) {
-              transaction.ourOuts.push(output.n.toString())
+          for (const output of transaction.outputs) {
+            if (output.scriptPubkey === scriptPubkey) {
+              if (!transaction.ourOuts.includes(output.n.toString())) {
+                transaction.ourOuts.push(output.n.toString())
+              }
             }
           }
-        }
 
-        transaction.ourAmount = calculateTxAmount(transaction)
+          transaction.ourAmount = calculateTxAmount(transaction)
+        }
 
         // Save tx by blockheight
         const txIdsByTransactionBlockHeight = await (

--- a/src/common/utxobased/db/newProcessor.ts
+++ b/src/common/utxobased/db/newProcessor.ts
@@ -1,0 +1,410 @@
+// We have AddressTables, TransactionTables and UTXOTables
+
+import { clearMemletCache } from 'baselet'
+import * as bs from 'biggystring'
+import { Disklet, navigateDisklet } from 'disklet'
+import { EdgeGetTransactionsOptions } from 'edge-core-js'
+
+import { AddressPath } from '../../plugin/types'
+import { makeBaselets } from './makeBaselets'
+import {
+  RANGE_ID_KEY,
+  RANGE_KEY,
+  TxIdsByDate,
+  txIdsByDateRangeId,
+  txIdsByDateRangeKey
+} from './Models/baselet'
+import {
+  IAddress,
+  IProcessorTransaction,
+  ITransactionInput,
+  ITransactionOutput,
+  IUTXO
+} from './types'
+
+const BASELET_DIR = 'tables'
+
+interface ProcessorConfig {
+  disklet: Disklet
+}
+
+/* Transaction table interfaces */
+
+interface InsertTransactionArgs {
+  tx: IProcessorTransaction
+  scriptPubkey: string
+}
+
+interface UpdateTransactionArgs {
+  txId: string
+  data: Pick<IProcessorTransaction, 'blockHeight'>
+}
+
+interface FetchTransactionArgs {
+  blockHeight?: number
+  blockHeightMax?: number
+  txId?: string
+  options?: EdgeGetTransactionsOptions
+}
+
+/* Address table interfaces */
+
+interface UpdateAddressArgs {
+  scriptPubkey: string
+  data: Partial<IAddress>
+}
+
+interface FetchAddressArgs {
+  path?: Omit<AddressPath, 'addressIndex'> | AddressPath
+  scriptPubkey?: string
+}
+
+/* Block height table interfaces */
+
+interface BlockHeightArgs {
+  height: number
+  blockHash: string
+  thresholdBlocks: number
+}
+
+export interface NewProcessor {
+  clearAll: () => Promise<void>
+
+  /* UTXO processing
+  **********************
+  Uses the following tables:
+  ========================== 
+  utxoById: main table
+  -------------------------------
+  Used to store UTXOs. Needs to be able to track UTXOs that are already used in
+  a transaction, but not confirmed yet */
+
+  insertUtxo: (utxo: IUTXO) => Promise<void>
+  // remove either all UTXOs if the array is empty, or as selected from an array
+  // of UTXO ids
+  removeUtxos: (utxoIds: string[]) => Promise<void>
+  // replaces a utxo with the same id, for example to set the 'used' flag
+  updateUtxo: (utxo: IUTXO) => Promise<void>
+  // fetch either all UTXOs if the array is empty or as selected from an array
+  // of UTXO ids
+  fetchUtxos: (utxoIds: string[]) => Promise<IUTXO[]>
+
+  /* Transaction processing
+  **********************
+  Uses the following tables:
+  ==========================
+  txById: main table
+  txsByScriptPubkey: index from script pubkey to txids, used to keep track of
+  and discover used addresses
+  txIdsByBlockHeight: index from block height to txid, used to change
+  confirmation height for unconfirmed transactions
+  txIdsByDate: index from date to txid, used for EdgeGetTransactionsOptions
+  querying
+  ------------------------------- 
+  Used to store transactions. Needs to be updated for confirmation
+  heights, and detecting used script pubkeys */
+
+  insertTransaction: (args: InsertTransactionArgs) => Promise<void>
+  numTransactions: () => number
+  removeTransaction: (txId: string) => Promise<void>
+  // update confirmation height
+  updateTransaction: (args: UpdateTransactionArgs) => Promise<void>
+  fetchTransactions: (
+    args: FetchTransactionArgs
+  ) => Promise<IProcessorTransaction[]>
+
+  /* Address processing
+  *********************
+  Uses the following tables:
+  ===============================
+  addressByScriptPubkey: main table
+  scriptPubkeyByPath: index from path to script pubkey
+  lastUsedByFormatPath: index from path to last used address derivation index
+  ------------------------------- 
+  Used to store script pubkeys / addresses. Needs to be updated for 'used' flag
+  and path */
+
+  insertAddress: (args: IAddress) => Promise<void>
+  // used to calculate total number of addresses
+  numAddressesByFormatPath: (path: Omit<AddressPath, 'addressIndex'>) => number
+  // get the last used address index for a specific format
+  lastUsedScriptPubkeyByFormatPath: (
+    path: Omit<AddressPath, 'addressIndex'>
+  ) => Promise<string>
+  // update to set the path or the used flag
+  updateAddress: (args: UpdateAddressArgs) => Promise<void>
+  fetchAddresses: (args: FetchAddressArgs) => Promise<IAddress[]>
+
+  /* Block processing
+  *******************
+  Uses the following tables:
+  ==========================
+  blockHashByBlockHeight: main table
+  ----------------------------------
+  Used to store block height / block hash pairs. Saved until a certain threshold
+  is reached */
+
+  // insert a new block height / block hash pair. Evicts pairs further back in
+  // history than the threshold blocks
+  insertBlockHash: (args: BlockHeightArgs) => Promise<void>
+  fetchBlockHash: (height: number) => Promise<string[]>
+}
+
+export async function makeNewProcessor(
+  config: ProcessorConfig
+): Promise<NewProcessor> {
+  const disklet = navigateDisklet(config.disklet, BASELET_DIR)
+  let baselets = await makeBaselets({ disklet })
+
+  /**
+   * Calculates the transaction value supplied (negative) or received (positive). In order to calculate
+   * a value, the `ourIns` and `ourOuts` of the object must be populated with indices.
+   * @param tx {IProcessorTransaction} A transaction object with `ourIns` and `ourOuts` populated
+   */
+  const calculateTxAmount = (tx: IProcessorTransaction): string => {
+    interface TxIndexMap {
+      [index: string]: ITransactionInput | ITransactionOutput
+    }
+    let ourAmount = '0'
+    let txIndexMap: TxIndexMap = {}
+    for (const input of tx.inputs) {
+      txIndexMap[input.n.toString()] = input
+    }
+    for (const i of tx.ourIns) {
+      const input = txIndexMap[i]
+      ourAmount = bs.sub(ourAmount, input.amount)
+    }
+    txIndexMap = {}
+    for (const output of tx.outputs) {
+      txIndexMap[output.n.toString()] = output
+    }
+    for (const i of tx.ourOuts) {
+      const output = txIndexMap[i]
+      ourAmount = bs.add(ourAmount, output.amount)
+    }
+    return ourAmount
+  }
+
+  const processor: NewProcessor = {
+    async clearAll(): Promise<void> {
+      await clearMemletCache()
+      // why is this delay needed?
+      await new Promise(resolve => setTimeout(resolve, 0))
+      await disklet.delete('.')
+      baselets = await makeBaselets({ disklet })
+    },
+
+    async insertUtxo(_utxo: IUTXO): Promise<void> {
+      return
+    },
+
+    async removeUtxos(_utxoIds: string[]): Promise<void> {
+      return
+    },
+
+    async updateUtxo(_utxo: IUTXO): Promise<void> {
+      return
+    },
+
+    async fetchUtxos(_utxoIds: string[]): Promise<IUTXO[]> {
+      return []
+    },
+
+    async insertTransaction(args: InsertTransactionArgs): Promise<void> {
+      const { scriptPubkey, tx } = args
+      return await baselets.tx(async tables => {
+        // Check if the transaction already exists
+        const processorTx:
+          | IProcessorTransaction
+          | undefined = await tables.txById
+          .query('', [tx.txid])
+          .then(transactions => transactions[0])
+          .catch(_ => undefined)
+        if (processorTx == null) {
+          await tables.txIdsByDate.insert('', {
+            [txIdsByDateRangeId]: tx.txid,
+            [txIdsByDateRangeKey]: tx.date
+          })
+        }
+        // Use the existing transaction if it does exist.
+        const transaction = processorTx ?? tx
+
+        // Mark the used inputs with the provided script pubkey
+        for (const input of transaction.inputs) {
+          if (input.scriptPubkey === scriptPubkey) {
+            if (!transaction.ourIns.includes(input.n.toString())) {
+              transaction.ourIns.push(input.n.toString())
+            }
+          }
+        }
+        for (const output of transaction.outputs) {
+          if (output.scriptPubkey === scriptPubkey) {
+            if (!transaction.ourOuts.includes(output.n.toString())) {
+              transaction.ourOuts.push(output.n.toString())
+            }
+          }
+        }
+
+        transaction.ourAmount = calculateTxAmount(transaction)
+
+        // Save tx by blockheight
+        const txIdsByTransactionBlockHeight = await (
+          await tables.txIdsByBlockHeight.query('', transaction.blockHeight)
+        )
+          .reverse()
+          .map(({ [RANGE_ID_KEY]: id }) => id)
+        if (!txIdsByTransactionBlockHeight.includes(transaction.txid)) {
+          await tables.txIdsByBlockHeight.insert('', {
+            [RANGE_ID_KEY]: transaction.txid,
+            [RANGE_KEY]: transaction.blockHeight
+          })
+        }
+
+        // Save transaction
+        await tables.txById.insert('', transaction.txid, transaction)
+      })
+    },
+
+    numTransactions(): number {
+      return baselets.all.txIdsByDate.size('')
+    },
+
+    async removeTransaction(_txId: string): Promise<void> {
+      return
+    },
+
+    async updateTransaction(args: UpdateTransactionArgs): Promise<void> {
+      const { data, txId } = args
+      return await baselets.tx(async tables => {
+        const [tx]: IProcessorTransaction[] = await tables.txById.query('', [
+          txId
+        ])
+        if (data.blockHeight != null && data.blockHeight !== tx.blockHeight) {
+          await tables.txIdsByBlockHeight.delete('', tx.blockHeight, txId)
+          await tables.txIdsByBlockHeight.insert('', {
+            [RANGE_ID_KEY]: txId,
+            [RANGE_KEY]: data.blockHeight
+          })
+
+          tx.blockHeight = data.blockHeight
+        }
+
+        await tables.txById.insert('', txId, tx)
+      })
+    },
+
+    async fetchTransactions(
+      args: FetchTransactionArgs
+    ): Promise<IProcessorTransaction[]> {
+      const { blockHeightMax, txId, options } = args
+      let { blockHeight } = args
+      const txs: IProcessorTransaction[] = []
+      await baselets.tx(async tables => {
+        // Fetch transactions by id
+        if (txId != null) {
+          const txById: IProcessorTransaction[] = await tables.txById.query(
+            '',
+            [txId]
+          )
+          txs.push(...txById)
+        }
+        // Fetch transactions by min block height
+        if (blockHeightMax != null && blockHeight == null) blockHeight = 0
+        if (blockHeight != null) {
+          const txIdsByMinBlockHeight = await (
+            await tables.txIdsByBlockHeight.query(
+              '',
+              blockHeight,
+              blockHeightMax
+            )
+          )
+            .reverse()
+            .map(({ [RANGE_ID_KEY]: id }) => id)
+
+          const txsById: IProcessorTransaction[] = await tables.txById.query(
+            '',
+            txIdsByMinBlockHeight
+          )
+          txs.push(...txsById)
+        }
+        if (options != null) {
+          const {
+            startEntries,
+            startIndex,
+            startDate = new Date(0),
+            endDate = new Date()
+          } = options
+
+          // Fetch transaction IDs ordered by date
+          let txData: TxIdsByDate
+          if (startEntries != null && startIndex != null) {
+            txData = await tables.txIdsByDate.queryByCount(
+              '',
+              startEntries,
+              startIndex
+            )
+          } else {
+            txData = await tables.txIdsByDate.query(
+              '',
+              startDate.getTime(),
+              endDate.getTime()
+            )
+          }
+          const txIdsByOptions = await txData
+            .reverse()
+            .map(({ [txIdsByDateRangeId]: id }) => id)
+
+          const txsByOptions = await tables.txById.query('', txIdsByOptions)
+          // Make sure only existing transactions are included
+          txs.push(...txsByOptions.filter(tx => tx != null))
+        }
+      })
+      return txs
+    },
+
+    async insertAddress(_args: IAddress): Promise<void> {
+      return
+    },
+
+    numAddressesByFormatPath(_path: Omit<AddressPath, 'addressIndex'>): number {
+      return 0
+    },
+
+    async lastUsedScriptPubkeyByFormatPath(
+      _path: Omit<AddressPath, 'addressIndex'>
+    ): Promise<string> {
+      return ''
+    },
+
+    async updateAddress(_args: UpdateAddressArgs): Promise<void> {
+      return
+    },
+
+    async fetchAddresses(_args: FetchAddressArgs): Promise<IAddress[]> {
+      return []
+    },
+
+    async insertBlockHash(args: BlockHeightArgs): Promise<void> {
+      const { height, blockHash, thresholdBlocks } = args
+      return await baselets.block(async tables => {
+        if (height - thresholdBlocks > 0)
+          await tables.blockHashByBlockHeight.delete('', [
+            (height - thresholdBlocks).toString()
+          ])
+        await tables.blockHashByBlockHeight.insert(
+          '',
+          height.toString(),
+          blockHash
+        )
+      })
+    },
+
+    async fetchBlockHash(height: number): Promise<string[]> {
+      return await baselets.block(
+        async tables =>
+          await tables.blockHashByBlockHeight.query('', [height.toString()])
+      )
+    }
+  }
+  return processor
+}

--- a/src/common/utxobased/db/types.ts
+++ b/src/common/utxobased/db/types.ts
@@ -45,6 +45,7 @@ export interface IProcessorTransaction {
 export interface ITransactionOutput {
   amount: string
   scriptPubkey: string
+  n: number
 }
 
 export interface ITransactionInput extends ITransactionOutput {
@@ -56,6 +57,10 @@ export interface BaseletConfig<T extends BaseType> {
   dbName: string
   type: T
   bucketSize: number
+  range?: {
+    id: string
+    key: string
+  }
 }
 
 export type Baselet = HashBase | CountBase | RangeBase

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -1026,6 +1026,7 @@ const processRawTx = (args: ProcessRawTxArgs): IProcessorTransaction => {
     inputs: tx.vin.map(input => ({
       txId: input.txid,
       outputIndex: input.vout, // case for tx `fefac8c22ba1178df5d7c90b78cc1c203d1a9f5f5506f7b8f6f469fa821c2674` no `vout` for input
+      n: input.n,
       scriptPubkey: validScriptPubkeyFromAddress({
         address: input.addresses[0],
         coin: currencyInfo.network,
@@ -1034,7 +1035,7 @@ const processRawTx = (args: ProcessRawTxArgs): IProcessorTransaction => {
       amount: input.value
     })),
     outputs: tx.vout.map(output => ({
-      index: output.n,
+      n: output.n,
       scriptPubkey:
         output.hex ??
         validScriptPubkeyFromAddress({

--- a/src/common/utxobased/network/BlockBook.ts
+++ b/src/common/utxobased/network/BlockBook.ts
@@ -76,6 +76,7 @@ export interface ITransaction {
   vin: Array<{
     txid: string
     vout: number
+    n: number
     value: string
     addresses: string[]
     hex?: string

--- a/test/common/utxobased/db/NewProcessor.spec.ts
+++ b/test/common/utxobased/db/NewProcessor.spec.ts
@@ -1,0 +1,323 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import * as chai from 'chai'
+import { expect } from 'chai'
+import { makeMemoryDisklet } from 'disklet'
+
+import {
+  makeNewProcessor,
+  NewProcessor
+} from '../../../../src/common/utxobased/db/newProcessor'
+import {
+  IProcessorTransaction,
+  ITransactionInput,
+  ITransactionOutput
+} from '../../../../src/common/utxobased/db/types'
+
+chai.should()
+
+describe('Processor transactions tests', () => {
+  function assertNumTransactions(
+    expectedNum: number,
+    processor: NewProcessor
+  ): void {
+    const num = processor.numTransactions()
+    expect(num).eql(expectedNum)
+  }
+
+  it('empty transaction baselets', async () => {
+    const storage = {}
+    const disklet = makeMemoryDisklet(storage)
+
+    const processor = await makeNewProcessor({ disklet })
+    assertNumTransactions(0, processor)
+  })
+
+  it('insert a transaction to transaction baselets', async () => {
+    const storage = {}
+    const disklet = makeMemoryDisklet(storage)
+    const processor = await makeNewProcessor({ disklet })
+
+    const input1: ITransactionInput = {
+      txId: 'random',
+      outputIndex: 0,
+      scriptPubkey: 'pubkeyin1',
+      n: 0,
+      amount: '1'
+    }
+    const output1: ITransactionOutput = {
+      amount: '1',
+      n: 0,
+      scriptPubkey: 'pubkeyout1'
+    }
+    const output2: ITransactionOutput = {
+      amount: '1',
+      n: 1,
+      scriptPubkey: 'pubkeyout2'
+    }
+    const transaction1: IProcessorTransaction = {
+      txid: 'transaction1',
+      hex: '',
+      blockHeight: 1,
+      date: new Date(10).getTime(),
+      fees: '1',
+      inputs: [input1],
+      outputs: [output1, output2],
+      ourIns: [],
+      ourOuts: [],
+      ourAmount: '0'
+    }
+
+    await processor.insertTransaction({
+      tx: transaction1,
+      scriptPubkey: output1.scriptPubkey
+    })
+
+    assertNumTransactions(1, processor)
+    const [tx1] = await processor.fetchTransactions({ txId: transaction1.txid })
+    expect(tx1.ourOuts[0]).to.eqls('0')
+    expect(tx1.ourAmount).to.eqls('1')
+    const [txByBlockHeight1] = await processor.fetchTransactions({
+      blockHeight: 1
+    })
+    expect(txByBlockHeight1.blockHeight).to.eqls(1)
+
+    // insert the same transaction, but with a script pubkey referencing an input
+    await processor.insertTransaction({
+      tx: transaction1,
+      scriptPubkey: input1.scriptPubkey
+    })
+
+    const [tx2] = await processor.fetchTransactions({ txId: transaction1.txid })
+    expect(tx2.ourOuts[0]).to.eqls('0')
+    expect(tx2.ourIns[0]).to.eqls('0')
+    expect(tx2.ourAmount).to.eqls('0')
+
+    // insert the same transaction, but with a script pubkey referencing another output
+    await processor.insertTransaction({
+      tx: transaction1,
+      scriptPubkey: output2.scriptPubkey
+    })
+
+    const [tx3] = await processor.fetchTransactions({ txId: transaction1.txid })
+    expect(tx3.ourOuts[1]).to.eqls('1')
+    expect(tx3.ourIns[0]).to.eqls('0')
+    expect(tx3.ourAmount).to.eqls('1')
+
+    const [tx4] = await processor.fetchTransactions({ options: {} })
+    expect(tx4).not.to.be.undefined
+
+    await processor
+      .fetchTransactions({
+        options: { startDate: new Date(11), endDate: new Date(15) }
+      })
+      .should.be.rejectedWith(
+        'At least one hash is required to query database.'
+      )
+
+    const [tx6] = await processor.fetchTransactions({
+      options: {
+        startDate: new Date(9),
+        endDate: new Date(15)
+      }
+    })
+    expect(tx6).not.to.be.undefined
+  })
+
+  it('insert multiple transactions to baselets', async () => {
+    const storage = {}
+    const disklet = makeMemoryDisklet(storage)
+    const processor = await makeNewProcessor({ disklet })
+
+    const input1: ITransactionInput = {
+      txId: 'random',
+      outputIndex: 0,
+      scriptPubkey: 'pubkeyin1',
+      n: 0,
+      amount: '1'
+    }
+    const output1: ITransactionOutput = {
+      amount: '1',
+      n: 0,
+      scriptPubkey: 'pubkeyout1'
+    }
+    const output2: ITransactionOutput = {
+      amount: '1',
+      n: 1,
+      scriptPubkey: 'pubkeyout2'
+    }
+    const transaction1: IProcessorTransaction = {
+      txid: 'transaction1',
+      hex: '',
+      blockHeight: 1,
+      date: new Date(10).getTime(),
+      fees: '1',
+      inputs: [input1],
+      outputs: [output1, output2],
+      ourIns: [],
+      ourOuts: [],
+      ourAmount: '0'
+    }
+
+    const transaction2: IProcessorTransaction = {
+      txid: 'transaction2',
+      hex: '',
+      blockHeight: 1,
+      date: new Date(20).getTime(),
+      fees: '1',
+      inputs: [input1],
+      outputs: [output1, output2],
+      ourIns: [],
+      ourOuts: [],
+      ourAmount: '0'
+    }
+
+    await processor.insertTransaction({
+      tx: transaction1,
+      scriptPubkey: output1.scriptPubkey
+    })
+    await processor.insertTransaction({
+      tx: transaction2,
+      scriptPubkey: output2.scriptPubkey
+    })
+
+    assertNumTransactions(2, processor)
+    const [tx1] = await processor.fetchTransactions({ txId: transaction1.txid })
+    expect(tx1.ourOuts[0]).to.eqls('0')
+    expect(tx1.ourAmount).to.eqls('1')
+    const txsByBlockHeight = await processor.fetchTransactions({
+      blockHeight: 1
+    })
+    expect(txsByBlockHeight[0].blockHeight).to.eqls(1)
+    expect(txsByBlockHeight[1].blockHeight).to.eqls(1)
+
+    await processor.insertTransaction({
+      tx: transaction1,
+      scriptPubkey: input1.scriptPubkey
+    })
+
+    const [tx2] = await processor.fetchTransactions({ txId: transaction1.txid })
+    expect(tx2.ourOuts[0]).to.eqls('0')
+    expect(tx2.ourIns[0]).to.eqls('0')
+    expect(tx2.ourAmount).to.eqls('0')
+
+    await processor.insertTransaction({
+      tx: transaction1,
+      scriptPubkey: output2.scriptPubkey
+    })
+
+    const [tx3] = await processor.fetchTransactions({ txId: transaction1.txid })
+    expect(tx3.ourOuts[1]).to.eqls('1')
+    expect(tx3.ourIns[0]).to.eqls('0')
+    expect(tx3.ourAmount).to.eqls('1')
+
+    const [tx4] = await processor.fetchTransactions({ options: {} })
+    expect(tx4).not.to.be.undefined
+
+    const [tx5] = await processor.fetchTransactions({
+      options: {
+        startDate: new Date(11),
+        endDate: new Date(20)
+      }
+    })
+    expect(tx5).not.to.be.undefined
+
+    const tx6 = await processor.fetchTransactions({
+      options: {
+        startDate: new Date(9),
+        endDate: new Date(21)
+      }
+    })
+    expect(tx6.length).to.eqls(2)
+  })
+
+  it('update transaction blockheight in transaction baselets', async () => {
+    const storage = {}
+    const disklet = makeMemoryDisklet(storage)
+    const processor = await makeNewProcessor({ disklet })
+
+    const input1: ITransactionInput = {
+      txId: 'random',
+      outputIndex: 0,
+      scriptPubkey: 'pubkeyin1',
+      n: 0,
+      amount: '1'
+    }
+    const output1: ITransactionOutput = {
+      amount: '1',
+      n: 0,
+      scriptPubkey: 'pubkeyout1'
+    }
+    const output2: ITransactionOutput = {
+      amount: '1',
+      n: 1,
+      scriptPubkey: 'pubkeyout2'
+    }
+    const transaction1: IProcessorTransaction = {
+      txid: 'transaction1',
+      hex: '',
+      blockHeight: 1,
+      date: new Date(10).getTime(),
+      fees: '1',
+      inputs: [input1],
+      outputs: [output1, output2],
+      ourIns: [],
+      ourOuts: [],
+      ourAmount: '0'
+    }
+
+    const transaction2: IProcessorTransaction = {
+      txid: 'transaction2',
+      hex: '',
+      blockHeight: 1,
+      date: new Date(20).getTime(),
+      fees: '1',
+      inputs: [input1],
+      outputs: [output1, output2],
+      ourIns: [],
+      ourOuts: [],
+      ourAmount: '0'
+    }
+
+    await processor.insertTransaction({
+      tx: transaction1,
+      scriptPubkey: output1.scriptPubkey
+    })
+    await processor.insertTransaction({
+      tx: transaction2,
+      scriptPubkey: output2.scriptPubkey
+    })
+
+    const txsByBlockHeight = await processor.fetchTransactions({
+      blockHeight: 1
+    })
+    expect(txsByBlockHeight.length).to.be.eqls(2)
+    expect(txsByBlockHeight[0].blockHeight).to.eqls(1)
+    expect(txsByBlockHeight[1].blockHeight).to.eqls(1)
+
+    await processor.updateTransaction({
+      txId: transaction2.txid,
+      data: { blockHeight: 10 }
+    })
+
+    // should return for a single block height
+    const txsByBlockHeight1 = await processor.fetchTransactions({
+      blockHeight: 1
+    })
+    expect(txsByBlockHeight1.length).to.be.eqls(1)
+    expect(txsByBlockHeight1[0].blockHeight).to.eqls(1)
+
+    // should return between (including) a range of block heights
+    const txsByBlockHeight2 = await processor.fetchTransactions({
+      blockHeight: 1,
+      blockHeightMax: 10
+    })
+    expect(txsByBlockHeight2.length).to.be.equals(2)
+
+    // should return by a range of block heights from 0 to 10
+    const txsByBlockHeight3 = await processor.fetchTransactions({
+      blockHeightMax: 10
+    })
+    expect(txsByBlockHeight3.length).to.be.equals(2)
+    expect(txsByBlockHeight3[0].blockHeight).to.be.equals(10)
+  })
+})


### PR DESCRIPTION
This is required for the engine's saveTx function. Any transaction inserted without a scriptPubkey won't get its ourIns and ourOuts filled. The EngineState should therefore always include a scriptPubkey when inserting a transaction.