### PR TITLE
Fix lastUsed function signature

### DIFF
--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -119,7 +119,7 @@ export interface Processor {
   // get the last used address index for a specific format
   lastUsedIndexByFormatPath: (
     path: Omit<AddressPath, 'addressIndex'>
-  ) => Promise<number>
+  ) => Promise<number | undefined>
   fetchAddresses: (args: AddressPath | string) => Promise<IAddress>
 
   /* Block processing
@@ -504,7 +504,7 @@ export async function makeProcessor(
 
     async lastUsedIndexByFormatPath(
       path: Omit<AddressPath, 'addressIndex'>
-    ): Promise<number> {
+    ): Promise<number | undefined> {
       const [addressIndex] = await baselets.address(async tables => {
         return await tables.lastUsedByFormatPath.query('', [
           addressPathToPrefix(path)

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -400,7 +400,7 @@ const setLookAhead = async (args: SetLookAheadArgs): Promise<void> => {
     }
 
     const getLastUsed = async (): Promise<number> =>
-      await processor.lastUsedIndexByFormatPath({ ...partialPath })
+      (await processor.lastUsedIndexByFormatPath({ ...partialPath })) ?? -1
     const getAddressCount = (): number =>
       processor.numAddressesByFormatPath(partialPath)
 
@@ -416,7 +416,7 @@ const setLookAhead = async (args: SetLookAheadArgs): Promise<void> => {
       }
     }
 
-    while (lastUsed + currencyInfo.gapLimit > addressCount) {
+    while (lastUsed + currencyInfo.gapLimit >= addressCount) {
       const path: AddressPath = {
         ...partialPath,
         addressIndex: addressCount


### PR DESCRIPTION
Also ended up fixing an off-by-one error in the setLookAhead while loop.
    
The initial conditions and last valid iteration, around the edges
of the control logic in the while loop with gap limit 20 are now:

```
lastUsed: -1 , addressCount: 0 => -1 + 20 >= 19
lastUsed: 0, addressCount: 0 => 0 + 20 >= 20
```