### PR TITLE
Processor address fixups

### DIFF
--- a/src/common/utxobased/db/Models/ProcessorTransaction.ts
+++ b/src/common/utxobased/db/Models/ProcessorTransaction.ts
@@ -34,7 +34,7 @@ export const toEdgeTransaction = async (
   const ourReceiveAddresses: string[] = []
   for (const out of tx.ourOuts) {
     const { scriptPubkey } = tx.outputs[parseInt(out)]
-    const address = await processor.fetchAddresses(scriptPubkey)
+    const address = await processor.fetchAddress(scriptPubkey)
     if (address?.path != null) {
       const { address: addrStr } = walletTools.scriptPubkeyToAddress({
         scriptPubkey,

--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -120,7 +120,7 @@ export interface Processor {
   lastUsedIndexByFormatPath: (
     path: Omit<AddressPath, 'addressIndex'>
   ) => Promise<number | undefined>
-  fetchAddresses: (args: AddressPath | string) => Promise<IAddress | undefined>
+  fetchAddress: (args: AddressPath | string) => Promise<IAddress | undefined>
 
   /* Block processing
   *******************
@@ -247,9 +247,9 @@ export async function makeProcessor(
         const processorTx:
           | IProcessorTransaction
           | undefined = await tables.txById
-            .query('', [tx.txid])
-            .then(transactions => transactions[0])
-            .catch(_ => undefined)
+          .query('', [tx.txid])
+          .then(transactions => transactions[0])
+          .catch(_ => undefined)
         if (processorTx == null) {
           await tables.txIdsByDate.insert('', {
             [txIdsByDateRangeId]: tx.txid,
@@ -513,7 +513,7 @@ export async function makeProcessor(
       return addressIndex
     },
 
-    async fetchAddresses(
+    async fetchAddress(
       fetchAddressArg: AddressPath | string
     ): Promise<IAddress | undefined> {
       return await baselets.address(async tables => {

--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -120,7 +120,7 @@ export interface Processor {
   lastUsedIndexByFormatPath: (
     path: Omit<AddressPath, 'addressIndex'>
   ) => Promise<number | undefined>
-  fetchAddresses: (args: AddressPath | string) => Promise<IAddress>
+  fetchAddresses: (args: AddressPath | string) => Promise<IAddress | undefined>
 
   /* Block processing
   *******************
@@ -247,9 +247,9 @@ export async function makeProcessor(
         const processorTx:
           | IProcessorTransaction
           | undefined = await tables.txById
-          .query('', [tx.txid])
-          .then(transactions => transactions[0])
-          .catch(_ => undefined)
+            .query('', [tx.txid])
+            .then(transactions => transactions[0])
+            .catch(_ => undefined)
         if (processorTx == null) {
           await tables.txIdsByDate.insert('', {
             [txIdsByDateRangeId]: tx.txid,
@@ -515,7 +515,7 @@ export async function makeProcessor(
 
     async fetchAddresses(
       fetchAddressArg: AddressPath | string
-    ): Promise<IAddress> {
+    ): Promise<IAddress | undefined> {
       return await baselets.address(async tables => {
         if (typeof fetchAddressArg === 'string') {
           // if it is a string, it is a scriptPubkey
@@ -533,6 +533,9 @@ export async function makeProcessor(
           addressPathToPrefix(path),
           path.addressIndex
         )
+
+        // return if the address by path was not found
+        if (scriptPubkeyFromPath == null) return
 
         const [address] = await tables.addressByScriptPubkey.query('', [
           scriptPubkeyFromPath

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -232,7 +232,7 @@ export async function makeUtxoEngine(
 
     async isAddressUsed(address: string): Promise<boolean> {
       const scriptPubkey = walletTools.addressToScriptPubkey(address)
-      const addressData = await processor.fetchAddresses(scriptPubkey)
+      const addressData = await processor.fetchAddress(scriptPubkey)
       if (addressData == null) return false
       return addressData.used
     },
@@ -251,7 +251,7 @@ export async function makeUtxoEngine(
         const scriptPubkey = walletTools.addressToScriptPubkey(
           target.publicAddress
         )
-        if (processor.fetchAddresses(scriptPubkey) != null) {
+        if (processor.fetchAddress(scriptPubkey) != null) {
           ourReceiveAddresses.push(target.publicAddress)
         }
 
@@ -323,7 +323,7 @@ export async function makeUtxoEngine(
       let nativeAmount = '0'
       for (const output of tx.outputs) {
         const scriptPubkey = output.script.toString('hex')
-        const own = await processor.fetchAddresses(scriptPubkey)
+        const own = await processor.fetchAddress(scriptPubkey)
         if (own != null) {
           nativeAmount = bs.sub(nativeAmount, output.value.toString())
         }
@@ -404,7 +404,7 @@ export async function makeUtxoEngine(
           })
           if (utxo == null) throw new Error('Invalid UTXO')
 
-          const address = await processor.fetchAddresses(utxo.scriptPubkey)
+          const address = await processor.fetchAddress(utxo.scriptPubkey)
           if (address?.path == null) throw new Error('Invalid script pubkey')
 
           return walletTools.getPrivateKey({ path: address.path, xprivKeys })

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -233,7 +233,8 @@ export async function makeUtxoEngine(
     async isAddressUsed(address: string): Promise<boolean> {
       const scriptPubkey = walletTools.addressToScriptPubkey(address)
       const addressData = await processor.fetchAddresses(scriptPubkey)
-      return addressData?.used
+      if (addressData == null) return false
+      return addressData.used
     },
 
     async makeSpend(

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -118,6 +118,9 @@ export function makeUtxoEngineState(
     })
     const percent = processedCount / totalCount
     if (percent - processedPercent > CACHE_THROTTLE || percent === 1) {
+      log(
+        `processed changed, percent: ${percent}, processedCount: ${processedCount}, totalCount: ${totalCount}`
+      )
       processedPercent = percent
       emitter.emit(EngineEvent.ADDRESSES_CHECKED, percent)
     }

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -464,7 +464,7 @@ const addToTransactionCache = async (
   // Fetch the networkQueryVal from the database
   const scriptPubkey = walletTools.addressToScriptPubkey(address)
   const { networkQueryVal = 0 } =
-    (await processor.fetchAddresses(scriptPubkey)) ?? {}
+    (await processor.fetchAddress(scriptPubkey)) ?? {}
   transactions[address] = {
     processing: false,
     path: {
@@ -838,7 +838,7 @@ const internalGetFreshAddress = async (
     addressIndex: Math.max(numAddresses - args.currencyInfo.gapLimit, 0)
   }
   const { scriptPubkey } =
-    (await processor.fetchAddresses(path)) ??
+    (await processor.fetchAddress(path)) ??
     (await walletTools.getScriptPubkey(path))
   if (scriptPubkey == null) {
     throw new Error('Unknown address path')
@@ -878,7 +878,7 @@ const processAddressTransactions = async (
   const transactionsCache = taskCache.transactionsCache
 
   const scriptPubkey = walletTools.addressToScriptPubkey(address)
-  const addressData = await processor.fetchAddresses(scriptPubkey)
+  const addressData = await processor.fetchAddress(scriptPubkey)
   if (addressData == null) {
     throw new Error(`could not find address with script pubkey ${scriptPubkey}`)
   }
@@ -1010,7 +1010,7 @@ const processAddressUtxos = async (
     .then(async (utxos: IAccountUTXO[]) => {
       serverStates.serverScoreUp(uri, Date.now() - queryTime)
       const scriptPubkey = walletTools.addressToScriptPubkey(address)
-      const addressData = await processor.fetchAddresses(scriptPubkey)
+      const addressData = await processor.fetchAddress(scriptPubkey)
       if (addressData == null || addressData.path == null) {
         return
       }
@@ -1073,7 +1073,7 @@ const processUtxoTransactions = async (
     )
 
     // Update balances for address that have this scriptPubkey
-    const address = await processor.fetchAddresses(scriptPubkey)
+    const address = await processor.fetchAddress(scriptPubkey)
 
     if (address == null) {
       throw new Error('address not found when processing UTXO transactions')

--- a/test/common/utxobased/db/Processor.spec.ts
+++ b/test/common/utxobased/db/Processor.spec.ts
@@ -77,9 +77,9 @@ describe('Processor address tests', () => {
     assertNumAddressesWithPaths(0)
     await assertLastUsedByFormatPath(undefined)
 
-    expect(await processor.fetchAddresses('doesnotexist')).to.be.undefined
+    expect(await processor.fetchAddress('doesnotexist')).to.be.undefined
     expect(
-      await processor.fetchAddresses({
+      await processor.fetchAddress({
         format: 'bip44',
         changeIndex: 0,
         addressIndex: 0
@@ -109,7 +109,7 @@ describe('Processor address tests', () => {
     assertNumAddressesWithPaths(0)
     await assertLastUsedByFormatPath(undefined)
     const processorAddress1 = assertProcessorObjectNotUndefined(
-      await processor.fetchAddresses(address1.scriptPubkey)
+      await processor.fetchAddress(address1.scriptPubkey)
     )
     expect(processorAddress1.scriptPubkey).to.eqls(address1.scriptPubkey)
 
@@ -128,7 +128,7 @@ describe('Processor address tests', () => {
     assertNumAddressesWithPaths(1)
     await assertLastUsedByFormatPath(undefined)
     const processorAddress2 = assertProcessorObjectNotUndefined(
-      await processor.fetchAddresses(address2.scriptPubkey)
+      await processor.fetchAddress(address2.scriptPubkey)
     )
     expect(processorAddress2.scriptPubkey).to.eqls(address2.scriptPubkey)
 
@@ -149,7 +149,7 @@ describe('Processor address tests', () => {
       )
     // Assertions
     assertNumAddressesWithPaths(1)
-    const processorAddress3 = await processor.fetchAddresses(
+    const processorAddress3 = await processor.fetchAddress(
       address3.scriptPubkey
     )
     expect(processorAddress3).to.be.undefined
@@ -168,15 +168,15 @@ describe('Processor address tests', () => {
     // Assertions
     assertNumAddressesWithPaths(2)
     const processorAddress4 = assertProcessorObjectNotUndefined(
-      await processor.fetchAddresses(address4.scriptPubkey)
+      await processor.fetchAddress(address4.scriptPubkey)
     )
     expect(processorAddress4.scriptPubkey).to.eqls(address4.scriptPubkey)
     await assertLastUsedByFormatPath(1)
 
     // check behavior of not found addresses in populated baselets:
-    expect(await processor.fetchAddresses('doesnotexist')).to.be.undefined
+    expect(await processor.fetchAddress('doesnotexist')).to.be.undefined
     expect(
-      await processor.fetchAddresses({
+      await processor.fetchAddress({
         format: 'bip32',
         changeIndex: 0,
         addressIndex: 0
@@ -206,7 +206,7 @@ describe('Processor address tests', () => {
     assertNumAddressesWithPaths(0)
     await assertLastUsedByFormatPath(undefined)
     const processorAddress1 = assertProcessorObjectNotUndefined(
-      await processor.fetchAddresses(address.scriptPubkey)
+      await processor.fetchAddress(address.scriptPubkey)
     )
     expect(processorAddress1.scriptPubkey).to.eqls(address.scriptPubkey)
 
@@ -224,7 +224,7 @@ describe('Processor address tests', () => {
     assertNumAddressesWithPaths(1)
     await assertLastUsedByFormatPath(undefined)
     const processorAddress2 = assertProcessorObjectNotUndefined(
-      await processor.fetchAddresses(address.scriptPubkey)
+      await processor.fetchAddress(address.scriptPubkey)
     )
     expect(processorAddress2.scriptPubkey).to.eqls(address.scriptPubkey)
 
@@ -234,7 +234,7 @@ describe('Processor address tests', () => {
     // Assertions
     assertNumAddressesWithPaths(1)
     const processorAddress3 = assertProcessorObjectNotUndefined(
-      await processor.fetchAddresses(address.scriptPubkey)
+      await processor.fetchAddress(address.scriptPubkey)
     )
     expect(processorAddress3.scriptPubkey).to.eqls(address.scriptPubkey)
     await assertLastUsedByFormatPath(0)
@@ -251,7 +251,7 @@ describe('Processor address tests', () => {
     // Assertions
     assertNumAddressesWithPaths(1)
     const processorAddress4 = assertProcessorObjectNotUndefined(
-      await processor.fetchAddresses(address.scriptPubkey)
+      await processor.fetchAddress(address.scriptPubkey)
     )
     expect(processorAddress4.scriptPubkey).to.eqls(address.scriptPubkey)
     expect(processorAddress4.networkQueryVal).to.eqls(1)


### PR DESCRIPTION
This PR renames `fetchAddresses` to `fetchAddress`.

Also introduces better type safety in the `fetchAddress` return arguments by extending the return type with an `undefined` that signals whether the address exists or not. The tests are extended as well to reflect this change and test for non-existing addresses.

This pull request originally contained more work to introduce similar safeguards in fetchUtxos and fetchTransactions. This was dropped however, since it requires more discussion in baselets error handling. 