### PR TITLE
Upgrade baselet

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "altcoin-js": "git://github.com/EdgeApp/altcoin-js.git#master",
     "async-mutex": "^0.2.6",
-    "baselet": "^0.1.0",
+    "baselet": "https://github.com/EdgeApp/baselet.git#sam/empty-queries-fix",
     "biggystring": "^4.0.0",
     "bip32": "^2.0.5",
     "bip32grs": "^2.0.5",

--- a/src/common/utxobased/db/Models/baselet.ts
+++ b/src/common/utxobased/db/Models/baselet.ts
@@ -1,170 +1,88 @@
-import { BaseType } from 'baselet'
+import {
+  CountBase,
+  CountBaseOptions,
+  HashBase,
+  HashBaseOptions,
+  RangeBase,
+  RangeBaseOptions
+} from 'baselet'
 
 import { AddressPath } from '../../../plugin/types'
-import { BaseletConfig, IAddress, IProcessorTransaction, IUTXO } from '../types'
-
-// deprecated
-export const RANGE_ID_KEY = 'idKey'
-// deprecated
-export const RANGE_KEY = 'rangeKey'
+import { IAddress, IProcessorTransaction, IUTXO } from '../types'
 
 export const addressPathToPrefix = (
   path: Omit<AddressPath, 'addressIndex'>
 ): string => `${path.format}_${path.changeIndex}`
 
-export type ScriptPubkeyByPath = string | undefined
-export const scriptPubkeyByPathConfig: BaseletConfig<BaseType.CountBase> = {
-  dbName: 'scriptPubkeyByPath',
-  type: BaseType.CountBase,
+export type ScriptPubkeyByPathBaselet = CountBase<string>
+export const scriptPubkeyByPathOptions: CountBaseOptions = {
+  name: 'scriptPubkeyByPath',
   bucketSize: 50
 }
 
-// deprecated
-export type UsedFlagByScriptPubkey = boolean
-export const usedFlagByScriptPubkeyConfig: BaseletConfig<BaseType.HashBase> = {
-  dbName: 'usedFlagByScriptPubkey',
-  type: BaseType.HashBase,
-  bucketSize: 50
+export type AddressByScriptPubkeyBaselet = HashBase<IAddress>
+export const addressByScriptPubkeyOptions: HashBaseOptions = {
+  name: 'addressByScriptPubkey',
+  prefixSize: 8
 }
 
-export type AddressByScriptPubkey = IAddress | undefined
-export const addressByScriptPubkeyConfig: BaseletConfig<BaseType.HashBase> = {
-  dbName: 'addressByScriptPubkey',
-  type: BaseType.HashBase,
-  bucketSize: 8
+export type LastUsedByFormatPathBaselet = HashBase<number>
+export const lastUsedByFormatPathOptions: HashBaseOptions = {
+  name: 'lastUsedByFormatPath',
+  prefixSize: 3
 }
 
-export type LastUsedByFormatPath = number | undefined
-export const lastUsedByFormatPathConfig: BaseletConfig<BaseType.HashBase> = {
-  dbName: 'lastUsedByFormatPath',
-  type: BaseType.HashBase,
-  bucketSize: 3
+export interface TxIdByBlockHeight {
+  txid: string
+  blockHeight: number
 }
-
-// deprectated
-export type AddressPathByMRU = string
-export const addressPathByMRUConfig: BaseletConfig<BaseType.CountBase> = {
-  dbName: 'addressPathByMRU',
-  type: BaseType.CountBase,
-  bucketSize: 100
-}
-
-export interface TxIdsByBlockHeight {
-  [RANGE_ID_KEY]: string
-  [RANGE_KEY]: string
-}
-export const txIdsByBlockHeightConfig: BaseletConfig<BaseType.RangeBase> = {
-  dbName: 'txIdByConfirmations',
-  type: BaseType.RangeBase,
+export type TxIdByBlockHeightBaselet = RangeBase<
+  TxIdByBlockHeight,
+  'blockHeight',
+  'txid'
+>
+export const txIdsByBlockHeightOptions: RangeBaseOptions<
+  'blockHeight',
+  'txid'
+> = {
+  name: 'TxIdByBlockHeight',
   bucketSize: 100000,
-  range: {
-    // deprecated - change to 'txIds'
-    id: RANGE_ID_KEY,
-    // deprecated - change to 'blockHeights'
-    key: RANGE_KEY
-  }
+  rangeKey: 'blockHeight',
+  idKey: 'txid'
 }
 
-// deprecated
-export interface ScriptPubkeysByBalance {
-  [RANGE_ID_KEY]: string
-  [RANGE_KEY]: string
-}
-export const scriptPubkeysByBalanceConfig: BaseletConfig<BaseType.RangeBase> = {
-  dbName: 'scriptPubkeysByBalance',
-  type: BaseType.RangeBase,
-  bucketSize: 100000
+export type TxByIdBaselet = HashBase<IProcessorTransaction>
+export const txByIdOptions: HashBaseOptions = {
+  name: 'txById',
+  prefixSize: 6
 }
 
-export type TxById = IProcessorTransaction | undefined
-export const txByIdConfig: BaseletConfig<BaseType.HashBase> = {
-  dbName: 'txById',
-  type: BaseType.HashBase,
-  bucketSize: 6
+export interface TxIdByDate {
+  txid: string
+  date: number
 }
-
-// deprecated
-export interface TxsByScriptPubkey {
-  [hash: string]: {
-    ins: { [index: number]: true }
-    outs: { [index: number]: true }
-  }
-}
-export const txsByScriptPubkeyConfig: BaseletConfig<BaseType.HashBase> = {
-  dbName: 'txsByScriptPubkey',
-  type: BaseType.HashBase,
-  bucketSize: 8
-}
-
-// deprecated - use TxIdsByDate instead
-export type TxsByDate = TxByDate[]
-interface TxByDate {
-  [RANGE_ID_KEY]: string
-  [RANGE_KEY]: string
-}
-export const txsByDateConfig: BaseletConfig<BaseType.RangeBase> = {
-  dbName: 'txsByDate',
-  type: BaseType.RangeBase,
-  bucketSize: 30 * 24 * 60 * 60 * 1000
-}
-
-export const txIdsByDateRangeKey = 'date'
-export const txIdsByDateRangeId = 'txId'
-export type TxIdsByDate = TxIdByDate[]
-interface TxIdByDate {
-  [txIdsByDateRangeKey]: string
-  [txIdsByDateRangeId]: string
-}
-export const txIdsByDateConfig: BaseletConfig<BaseType.RangeBase> = {
-  dbName: 'txIdsByDate',
-  type: BaseType.RangeBase,
+export type TxIdByDateBaselet = RangeBase<TxIdByDate, 'date', 'txid'>
+export const txIdsByDateOptions: RangeBaseOptions<'date', 'txid'> = {
+  name: 'txIdsByDate',
   bucketSize: 30 * 24 * 60 * 60 * 1000,
-  range: {
-    id: txIdsByDateRangeId,
-    key: txIdsByDateRangeKey
-  }
+  rangeKey: 'date',
+  idKey: 'txid'
 }
 
-export type UtxoById = IUTXO | undefined
-export const utxoByIdConfig: BaseletConfig<BaseType.HashBase> = {
-  dbName: 'utxoById',
-  type: BaseType.HashBase,
-  bucketSize: 6
+export type UtxoByIdBaselet = HashBase<IUTXO>
+export const utxoByIdOptions: HashBaseOptions = {
+  name: 'utxoById',
+  prefixSize: 6
 }
 
-export type BlockHashByBlockHeight = string
-export const blockHashByBlockHeightConfig: BaseletConfig<BaseType.HashBase> = {
-  dbName: 'blockHashByBlockHeight',
-  type: BaseType.HashBase,
-  bucketSize: 30 * 24 * 60 * 60 * 1000
+export type BlockHashByBlockHeightBaselet = HashBase<string>
+export const blockHashByBlockHeightOptions: HashBaseOptions = {
+  name: 'blockHashByBlockHeight',
+  prefixSize: 30 * 24 * 60 * 60 * 1000
 }
 
-// deprecated
-export type UtxosByScriptPubkey = Array<{
-  hash: string
-  vout: number
-}>
-export const utxoIdsByScriptPubkeyConfig: BaseletConfig<BaseType.HashBase> = {
-  dbName: 'utxoIdsByScriptPubkey',
-  type: BaseType.HashBase,
-  bucketSize: 8
-}
-
-// deprecated
-export interface UtxosBySize {
-  [RANGE_ID_KEY]: string
-  [RANGE_KEY]: string
-}
-export const utxoIdsBySizeConfig: BaseletConfig<BaseType.RangeBase> = {
-  dbName: 'utxoIdsBySize',
-  type: BaseType.RangeBase,
-  bucketSize: 100000
-}
-
-// deprecated
-export type SpentUtxoById = IUTXO | undefined
-export const spentUtxoByIdConfig: BaseletConfig<BaseType.HashBase> = {
-  dbName: 'spentUtxoById',
-  type: BaseType.HashBase,
-  bucketSize: 6
+export type UtxoIdsByScriptPubkeyBaselet = HashBase<string[]>
+export const utxoIdsByScriptPubkeyOptions: HashBaseOptions = {
+  name: 'utxoIdsByScriptPubkey',
+  prefixSize: 8
 }

--- a/src/common/utxobased/db/makeBaselets.ts
+++ b/src/common/utxobased/db/makeBaselets.ts
@@ -1,85 +1,66 @@
 import { Mutex } from 'async-mutex'
 import {
-  BaseType,
-  createCountBase,
-  createHashBase,
-  createRangeBase,
-  openBase
+  createOrOpenCountBase,
+  createOrOpenHashBase,
+  createOrOpenRangeBase
 } from 'baselet'
-import { CountBase } from 'baselet/src/CountBase'
-import { HashBase } from 'baselet/src/HashBase'
-import { RangeBase } from 'baselet/src/RangeBase'
 import { Disklet } from 'disklet'
 
 import {
-  addressByScriptPubkeyConfig,
-  addressPathByMRUConfig,
-  blockHashByBlockHeightConfig,
-  lastUsedByFormatPathConfig,
-  RANGE_ID_KEY,
-  RANGE_KEY,
-  scriptPubkeyByPathConfig,
-  scriptPubkeysByBalanceConfig,
-  spentUtxoByIdConfig,
-  txByIdConfig,
-  txIdsByBlockHeightConfig,
-  txIdsByDateConfig,
-  txsByDateConfig,
-  txsByScriptPubkeyConfig,
-  usedFlagByScriptPubkeyConfig,
-  utxoByIdConfig,
-  utxoIdsByScriptPubkeyConfig,
-  utxoIdsBySizeConfig
+  AddressByScriptPubkeyBaselet,
+  addressByScriptPubkeyOptions,
+  BlockHashByBlockHeightBaselet,
+  blockHashByBlockHeightOptions,
+  LastUsedByFormatPathBaselet,
+  lastUsedByFormatPathOptions,
+  ScriptPubkeyByPathBaselet,
+  scriptPubkeyByPathOptions,
+  TxByIdBaselet,
+  txByIdOptions,
+  TxIdByBlockHeightBaselet,
+  TxIdByDateBaselet,
+  txIdsByBlockHeightOptions,
+  txIdsByDateOptions,
+  UtxoByIdBaselet,
+  utxoByIdOptions,
+  UtxoIdsByScriptPubkeyBaselet,
+  utxoIdsByScriptPubkeyOptions
 } from './Models/baselet'
-import { Baselet, BaseletConfig } from './types'
-
-async function createOrOpen(
-  disklet: Disklet,
-  config: BaseletConfig<BaseType.HashBase>
-): Promise<HashBase>
-async function createOrOpen(
-  disklet: Disklet,
-  config: BaseletConfig<BaseType.CountBase>
-): Promise<CountBase>
-async function createOrOpen(
-  disklet: Disklet,
-  config: BaseletConfig<BaseType.RangeBase>
-): Promise<RangeBase>
-async function createOrOpen<T extends BaseType>(
-  disklet: Disklet,
-  config: BaseletConfig<T>
-): Promise<Baselet> {
-  try {
-    switch (config.type) {
-      case BaseType.HashBase:
-        return await createHashBase(disklet, config.dbName, config.bucketSize)
-      case BaseType.CountBase:
-        return await createCountBase(disklet, config.dbName, config.bucketSize)
-      case BaseType.RangeBase:
-        if (config.range == null) {
-          config.range = {
-            key: RANGE_KEY,
-            id: RANGE_ID_KEY
-          }
-        }
-        return await createRangeBase(
-          disklet,
-          config.dbName,
-          config.bucketSize,
-          config.range.key,
-          config.range.id
-        )
-    }
-  } catch (err) {
-    if (err instanceof Error && !err.message.includes('already exists')) {
-      throw err
-    }
-  }
-  return await openBase(disklet, config.dbName)
-}
 
 interface MakeBaseletsConfig {
   disklet: Disklet
+}
+
+type Executor<BaseletName extends keyof AllBaselets> = (
+  tables: AllBaselets[BaseletName]
+) => Promise<unknown>
+
+interface AllBaselets {
+  address: AddressBaselets
+  tx: TransactionBaselets
+  utxo: UtxoBaselets
+  block: BlockBaselets
+}
+
+interface AddressBaselets {
+  addressByScriptPubkey: AddressByScriptPubkeyBaselet
+  scriptPubkeyByPath: ScriptPubkeyByPathBaselet
+  lastUsedByFormatPath: LastUsedByFormatPathBaselet
+}
+
+interface TransactionBaselets {
+  txById: TxByIdBaselet
+  txIdsByBlockHeight: TxIdByBlockHeightBaselet
+  txIdsByDate: TxIdByDateBaselet
+}
+
+interface UtxoBaselets {
+  utxoById: UtxoByIdBaselet
+  utxoIdsByScriptPubkey: UtxoIdsByScriptPubkeyBaselet
+}
+
+interface BlockBaselets {
+  blockHashByBlockHeight: BlockHashByBlockHeightBaselet
 }
 
 export interface Baselets {
@@ -88,150 +69,47 @@ export interface Baselets {
   utxo: <E extends Executor<'utxo'>>(fn: E) => Promise<ReturnType<E>>
   block: <E extends Executor<'block'>>(fn: E) => Promise<ReturnType<E>>
 
-  all: AddressTables & TransactionTables & UTXOTables & SpentUTXOTables
-}
-
-type Executor<DatabaseName extends keyof Databases> = (
-  tables: Databases[DatabaseName]
-) => Promise<unknown>
-
-export interface Databases {
-  address: AddressTables
-  tx: TransactionTables
-  utxo: UTXOTables
-  block: BlockTables
-}
-
-export interface AddressTables {
-  addressByScriptPubkey: HashBase
-  // deprecated
-  addressPathByMRU: CountBase
-  scriptPubkeyByPath: CountBase
-  // deprecated
-  scriptPubkeysByBalance: RangeBase
-  // deprecated
-  usedFlagByScriptPubkey: HashBase
-  lastUsedByFormatPath: HashBase
-}
-
-export interface TransactionTables {
-  txById: HashBase
-  // deprecated
-  txsByScriptPubkey: HashBase
-  txIdsByBlockHeight: RangeBase
-  // deprecated - use txIdsByDate instead
-  txsByDate: RangeBase
-  txIdsByDate: RangeBase
-}
-
-export interface UTXOTables {
-  utxoById: HashBase
-  // deprecated
-  utxoIdsByScriptPubkey: HashBase
-  // deprecated
-  utxoIdsBySize: RangeBase
-}
-
-export interface BlockTables {
-  blockHashByBlockHeight: HashBase
-}
-
-// deprecated
-interface SpentUTXOTables {
-  spentUtxoById: HashBase
+  all: AddressBaselets & TransactionBaselets & UtxoBaselets
 }
 
 export const makeBaselets = async (
   config: MakeBaseletsConfig
 ): Promise<Baselets> => {
-  /* CountBases */
-  const scriptPubkeyByPath = await createOrOpen(
-    config.disklet,
-    scriptPubkeyByPathConfig
-  )
-  // deprecated
-  const addressPathByMRU = await createOrOpen(
-    config.disklet,
-    addressPathByMRUConfig
-  )
-
-  /* RangeBases */
-  // deprecated
-  const scriptPubkeysByBalance = await createOrOpen(
-    config.disklet,
-    scriptPubkeysByBalanceConfig
-  )
-  const txIdsByBlockHeight = await createOrOpen(
-    config.disklet,
-    txIdsByBlockHeightConfig
-  )
-  // deprecated - use txIdsByDate instead
-  const txsByDate = await createOrOpen(config.disklet, txsByDateConfig)
-  const txIdsByDate = await createOrOpen(config.disklet, txIdsByDateConfig)
-  // deprecated
-  const utxoIdsBySize = await createOrOpen(config.disklet, utxoIdsBySizeConfig)
-
-  /* HashBases */
-  const addressByScriptPubkey = await createOrOpen(
-    config.disklet,
-    addressByScriptPubkeyConfig
-  )
-  const txById = await createOrOpen(config.disklet, txByIdConfig)
-  const txsByScriptPubkey = await createOrOpen(
-    config.disklet,
-    txsByScriptPubkeyConfig
-  )
-  const utxoById = await createOrOpen(config.disklet, utxoByIdConfig)
-  // deprecated
-  const spentUtxoById = await createOrOpen(config.disklet, spentUtxoByIdConfig)
-  // deprecated
-  const utxoIdsByScriptPubkey = await createOrOpen(
-    config.disklet,
-    utxoIdsByScriptPubkeyConfig
-  )
-  // deprecated
-  const usedFlagByScriptPubkey = await createOrOpen(
-    config.disklet,
-    usedFlagByScriptPubkeyConfig
-  )
-  const blockHashByBlockHeight = await createOrOpen(
-    config.disklet,
-    blockHashByBlockHeightConfig
-  )
-  const lastUsedByFormatPath = await createOrOpen(
-    config.disklet,
-    lastUsedByFormatPathConfig
-  )
-
-  const addressBases: AddressTables = {
-    addressByScriptPubkey,
-    addressPathByMRU,
-    scriptPubkeyByPath,
-    scriptPubkeysByBalance,
-    usedFlagByScriptPubkey,
-    lastUsedByFormatPath
+  /* Tables */
+  const addressBases: AddressBaselets = {
+    addressByScriptPubkey: await createOrOpenHashBase(
+      config.disklet,
+      addressByScriptPubkeyOptions
+    ),
+    scriptPubkeyByPath: await createOrOpenCountBase(
+      config.disklet,
+      scriptPubkeyByPathOptions
+    ),
+    lastUsedByFormatPath: await createOrOpenHashBase(
+      config.disklet,
+      lastUsedByFormatPathOptions
+    )
   }
-
-  const txBases: TransactionTables = {
-    txById,
-    txsByScriptPubkey,
-    txIdsByBlockHeight,
-    txsByDate,
-    txIdsByDate
+  const txBases: TransactionBaselets = {
+    txById: await createOrOpenHashBase(config.disklet, txByIdOptions),
+    txIdsByBlockHeight: await createOrOpenRangeBase(
+      config.disklet,
+      txIdsByBlockHeightOptions
+    ),
+    txIdsByDate: await createOrOpenRangeBase(config.disklet, txIdsByDateOptions)
   }
-
-  const utxoBases: UTXOTables = {
-    utxoById,
-    utxoIdsByScriptPubkey,
-    utxoIdsBySize
+  const utxoBases: UtxoBaselets = {
+    utxoById: await createOrOpenHashBase(config.disklet, utxoByIdOptions),
+    utxoIdsByScriptPubkey: await createOrOpenHashBase(
+      config.disklet,
+      utxoIdsByScriptPubkeyOptions
+    )
   }
-
-  const spentUtxoBases: SpentUTXOTables = {
-    spentUtxoById
-  }
-
-  const blockHeightBases: BlockTables = {
-    blockHashByBlockHeight
+  const blockHeightBases: BlockBaselets = {
+    blockHashByBlockHeight: await createOrOpenHashBase(
+      config.disklet,
+      blockHashByBlockHeightOptions
+    )
   }
 
   const addressMutex = new Mutex()
@@ -259,8 +137,7 @@ export const makeBaselets = async (
       ...addressBases,
       ...txBases,
       ...utxoBases,
-      ...blockHeightBases,
-      ...spentUtxoBases
+      ...blockHeightBases
     }
   }
 }

--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -5,14 +5,7 @@ import { EdgeGetTransactionsOptions } from 'edge-core-js/types'
 
 import { AddressPath } from '../../plugin/types'
 import { makeBaselets } from './makeBaselets'
-import {
-  addressPathToPrefix,
-  RANGE_ID_KEY,
-  RANGE_KEY,
-  TxIdsByDate,
-  txIdsByDateRangeId,
-  txIdsByDateRangeKey
-} from './Models/baselet'
+import { addressPathToPrefix, TxIdByDate } from './Models/baselet'
 import {
   IAddress,
   IProcessorTransaction,
@@ -78,7 +71,7 @@ export interface Processor {
   removeUtxos: (utxoIds: string[]) => Promise<void>
   // fetch either all UTXOs if the array is empty or as selected from an array
   // of UTXO ids
-  fetchUtxos: (args: FetchUtxosArgs) => Promise<IUTXO[]>
+  fetchUtxos: (args: FetchUtxosArgs) => Promise<Array<IUTXO | undefined>>
 
   /* Transaction processing
   **********************
@@ -100,7 +93,7 @@ export interface Processor {
   removeTransaction: (txId: string) => Promise<void>
   fetchTransactions: (
     args: FetchTransactionArgs
-  ) => Promise<IProcessorTransaction[]>
+  ) => Promise<Array<IProcessorTransaction | undefined>>
 
   /* Address processing
   *********************
@@ -119,7 +112,7 @@ export interface Processor {
   // get the last used address index for a specific format
   lastUsedIndexByFormatPath: (
     path: Omit<AddressPath, 'addressIndex'>
-  ) => Promise<number | undefined>
+  ) => Promise<number>
   fetchAddress: (args: AddressPath | string) => Promise<IAddress | undefined>
 
   /* Block processing
@@ -134,7 +127,7 @@ export interface Processor {
   // insert a new block height / block hash pair. Evicts pairs further back in
   // history than the threshold blocks
   saveBlockHash: (args: BlockHeightArgs) => Promise<void>
-  fetchBlockHash: (height: number) => Promise<string[]>
+  fetchBlockHash: (height: number) => Promise<Array<string | undefined>>
 }
 
 export async function makeProcessor(
@@ -193,11 +186,17 @@ export async function makeProcessor(
 
     async saveUtxo(utxo: IUTXO): Promise<void> {
       return await baselets.utxo(async tables => {
-        await tables.utxoIdsByScriptPubkey.insert(
-          '',
-          utxo.scriptPubkey,
-          utxo.id
-        )
+        const [utxoIds = []] = await tables.utxoIdsByScriptPubkey.query('', [
+          utxo.scriptPubkey
+        ])
+        if (!utxoIds.includes(utxo.id)) {
+          utxoIds.push(utxo.id)
+          await tables.utxoIdsByScriptPubkey.insert(
+            '',
+            utxo.scriptPubkey,
+            utxoIds
+          )
+        }
 
         await tables.utxoById.insert('', utxo.id, utxo)
       })
@@ -205,35 +204,65 @@ export async function makeProcessor(
 
     async removeUtxos(utxoIds: string[]): Promise<void> {
       return await baselets.utxo(async tables => {
-        const utxos = await tables.utxoById.query('', utxoIds)
-        await tables.utxoIdsByScriptPubkey.delete(
-          '',
-          utxos.map(utxo => (utxo != null ? utxo.scriptPubkey : undefined))
-        )
+        if (utxoIds.length === 0) return
+
+        // To remove utxo from utxoIdsByScriptPubkey table:
+        // 1. Create a map of scriptPubkeys to utxoIds
+        // 2. Use the map to remove utxoIds from the utxoIdsByScriptPubkey table
+        const utxos = (await tables.utxoById.query('', utxoIds)).filter(
+          utxo => utxo != null
+        ) as IUTXO[]
+        const utxoIdsMap: { [scriptPubkey: string]: string[] } = {}
+        for (const utxo of utxos) {
+          utxoIdsMap[utxo.scriptPubkey] = [
+            ...(utxoIdsMap[utxo.scriptPubkey] ?? []),
+            utxo.id
+          ]
+        }
+        for (const scriptPubkey of Object.keys(utxoIdsMap)) {
+          const utxoIdsToRemove = utxoIdsMap[scriptPubkey]
+          const [utxoIds = []] = await tables.utxoIdsByScriptPubkey.query('', [
+            scriptPubkey
+          ])
+
+          for (const utxoIdToRemove of utxoIdsToRemove) {
+            utxoIds.splice(utxoIds.indexOf(utxoIdToRemove), 1)
+          }
+
+          // Update utxoIds for entry in table, otherwise delete entry
+          if (utxoIds.length > 0) {
+            await tables.utxoIdsByScriptPubkey.insert('', scriptPubkey, utxoIds)
+          } else {
+            await tables.utxoIdsByScriptPubkey.delete('', [scriptPubkey])
+          }
+        }
+
+        // Remove utxo utxoById table
         await tables.utxoById.delete('', utxoIds)
       })
     },
 
-    async fetchUtxos(args): Promise<IUTXO[]> {
+    async fetchUtxos(args): Promise<Array<IUTXO | undefined>> {
       const { scriptPubkey, utxoIds = [] } = args
       return await baselets.utxo(async tables => {
         if (scriptPubkey != null) {
-          const utxoIdsByScriptPubkey = (
-            await tables.utxoIdsByScriptPubkey.query('', [scriptPubkey])
-          ).filter(utxoId => utxoId != null)
+          const [
+            utxoIdsByScriptPubkey
+          ] = await tables.utxoIdsByScriptPubkey.query('', [scriptPubkey])
 
-          utxoIds.push(...utxoIdsByScriptPubkey)
+          if (utxoIdsByScriptPubkey != null)
+            utxoIds.push(...utxoIdsByScriptPubkey)
 
-          // Return undefined as the UTXO if no utxoIds are found by scriptPubkey
+          // Exit early if no utxoIds are found by scriptPubkey
           if (utxoIds.length === 0) {
-            return [undefined]
+            return []
           }
         }
 
         // Return all UTXOs if no UTXO ids are specified
         if (utxoIds.length === 0) {
-          const dump = await tables.utxoById.dumpData('')
-          return Object.values(dump.data)
+          const { data } = await tables.utxoById.dumpData('')
+          return Object.values(data[''])
         }
 
         return await tables.utxoById.query('', utxoIds)
@@ -244,16 +273,14 @@ export async function makeProcessor(
       const { scriptPubkey, tx } = args
       return await baselets.tx(async tables => {
         // Check if the transaction already exists
-        const processorTx:
-          | IProcessorTransaction
-          | undefined = await tables.txById
+        const processorTx = await tables.txById
           .query('', [tx.txid])
           .then(transactions => transactions[0])
           .catch(_ => undefined)
         if (processorTx == null) {
           await tables.txIdsByDate.insert('', {
-            [txIdsByDateRangeId]: tx.txid,
-            [txIdsByDateRangeKey]: tx.date
+            txid: tx.txid,
+            date: tx.date
           })
         }
         // Use the existing transaction if it does exist.
@@ -287,8 +314,8 @@ export async function makeProcessor(
           )
           transaction.blockHeight = tx.blockHeight
           await tables.txIdsByBlockHeight.insert('', {
-            [RANGE_ID_KEY]: transaction.txid,
-            [RANGE_KEY]: transaction.blockHeight
+            txid: transaction.txid,
+            blockHeight: transaction.blockHeight
           })
         } else {
           // Save tx by blockheight
@@ -296,11 +323,11 @@ export async function makeProcessor(
             await tables.txIdsByBlockHeight.query('', transaction.blockHeight)
           )
             .reverse()
-            .map(({ [RANGE_ID_KEY]: id }) => id)
+            .map(({ txid: id }) => id)
           if (!txIdsByTransactionBlockHeight.includes(transaction.txid)) {
             await tables.txIdsByBlockHeight.insert('', {
-              [RANGE_ID_KEY]: transaction.txid,
-              [RANGE_KEY]: transaction.blockHeight
+              txid: transaction.txid,
+              blockHeight: transaction.blockHeight
             })
           }
         }
@@ -320,17 +347,14 @@ export async function makeProcessor(
 
     async fetchTransactions(
       args: FetchTransactionArgs
-    ): Promise<IProcessorTransaction[]> {
+    ): Promise<Array<IProcessorTransaction | undefined>> {
       const { blockHeightMax, txId, options } = args
       let { blockHeight } = args
-      const txs: IProcessorTransaction[] = []
+      const txs: Array<IProcessorTransaction | undefined> = []
       await baselets.tx(async tables => {
         // Fetch transactions by id
         if (txId != null) {
-          const txById: IProcessorTransaction[] = await tables.txById.query(
-            '',
-            [txId]
-          )
+          const txById = await tables.txById.query('', [txId])
           txs.push(...txById)
         }
         // Fetch transactions by min block height
@@ -344,12 +368,9 @@ export async function makeProcessor(
             )
           )
             .reverse()
-            .map(({ [RANGE_ID_KEY]: id }) => id)
+            .map(({ txid: id }) => id)
 
-          const txsById: IProcessorTransaction[] = await tables.txById.query(
-            '',
-            txIdsByMinBlockHeight
-          )
+          const txsById = await tables.txById.query('', txIdsByMinBlockHeight)
           txs.push(...txsById)
         }
         if (options != null) {
@@ -361,7 +382,7 @@ export async function makeProcessor(
           } = options
 
           // Fetch transaction IDs ordered by date
-          let txData: TxIdsByDate
+          let txData: TxIdByDate[]
           if (startEntries != null && startIndex != null) {
             txData = await tables.txIdsByDate.queryByCount(
               '',
@@ -377,7 +398,7 @@ export async function makeProcessor(
           }
           const txIdsByOptions = await txData
             .reverse()
-            .map(({ [txIdsByDateRangeId]: id }) => id)
+            .map(({ txid: id }) => id)
 
           const txsByOptions = await tables.txById.query('', txIdsByOptions)
           // Make sure only existing transactions are included
@@ -389,9 +410,7 @@ export async function makeProcessor(
 
     async saveAddress(address: IAddress): Promise<void> {
       await baselets.address(async tables => {
-        const [
-          existingAddress
-        ]: IAddress[] = await tables.addressByScriptPubkey.query('', [
+        const [existingAddress] = await tables.addressByScriptPubkey.query('', [
           address.scriptPubkey
         ])
 
@@ -414,7 +433,7 @@ export async function makeProcessor(
           )
 
           // check if this address is used and if so, whether it has a higher last used index
-          if (address.used || existingAddress?.used) {
+          if (address.used || (existingAddress?.used ?? false)) {
             let [lastUsed] = await tables.lastUsedByFormatPath.query('', [
               addressPathToPrefix(address.path)
             ])
@@ -508,13 +527,13 @@ export async function makeProcessor(
 
     async lastUsedIndexByFormatPath(
       path: Omit<AddressPath, 'addressIndex'>
-    ): Promise<number | undefined> {
+    ): Promise<number> {
       const [addressIndex] = await baselets.address(async tables => {
         return await tables.lastUsedByFormatPath.query('', [
           addressPathToPrefix(path)
         ])
       })
-      return addressIndex
+      return addressIndex ?? -1
     },
 
     async fetchAddress(
@@ -564,7 +583,7 @@ export async function makeProcessor(
       })
     },
 
-    async fetchBlockHash(height: number): Promise<string[]> {
+    async fetchBlockHash(height: number): Promise<Array<string | undefined>> {
       return await baselets.block(
         async tables =>
           await tables.blockHashByBlockHeight.query('', [height.toString()])

--- a/src/common/utxobased/db/types.ts
+++ b/src/common/utxobased/db/types.ts
@@ -1,8 +1,3 @@
-import { BaseType } from 'baselet'
-import { CountBase } from 'baselet/src/CountBase'
-import { HashBase } from 'baselet/src/HashBase'
-import { RangeBase } from 'baselet/src/RangeBase'
-
 import { AddressPath } from '../../plugin/types'
 import { ScriptTypeEnum } from '../keymanager/keymanager'
 
@@ -52,15 +47,3 @@ export interface ITransactionInput extends ITransactionOutput {
   txId: string
   outputIndex: number
 }
-
-export interface BaseletConfig<T extends BaseType> {
-  dbName: string
-  type: T
-  bucketSize: number
-  range?: {
-    id: string
-    key: string
-  }
-}
-
-export type Baselet = HashBase | CountBase | RangeBase

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -187,6 +187,7 @@ export function makeUtxoEngineState(
         blockHeight: 0
       })
       for (const tx of txs) {
+        if (tx == null) continue
         taskCache.updateTransactionsCache[tx.txid] = { processing: false }
       }
     }
@@ -403,12 +404,10 @@ const setLookAhead = async (args: SetLookAheadArgs): Promise<void> => {
       changeIndex: branch
     }
 
-    const getLastUsed = async (): Promise<number> =>
-      (await processor.lastUsedIndexByFormatPath({ ...partialPath })) ?? -1
     const getAddressCount = (): number =>
       processor.numAddressesByFormatPath(partialPath)
 
-    let lastUsed = await getLastUsed()
+    let lastUsed = await processor.lastUsedIndexByFormatPath({ ...partialPath })
     let addressCount = getAddressCount()
     const addresses = new Set<string>()
 
@@ -431,7 +430,9 @@ const setLookAhead = async (args: SetLookAheadArgs): Promise<void> => {
       await saveAddress({ scriptPubkey, path, ...args })
       addresses.add(address)
 
-      lastUsed = await getLastUsed()
+      lastUsed = await processor.lastUsedIndexByFormatPath({
+        ...partialPath
+      })
       addressCount = getAddressCount()
     }
     addToAddressSubscribeCache(args, addresses, { format, branch })
@@ -1054,6 +1055,10 @@ const processUtxoTransactions = async (
   const currentUtxoIds: string[] = []
   let oldBalance = '0'
   for (const utxo of currentUtxos) {
+    if (utxo == null)
+      throw new Error(
+        'Unexpected undefined utxo when processing unspent transactions'
+      )
     oldBalance = add(utxo.value, oldBalance)
     currentUtxoIds.push(utxo.txid)
   }

--- a/src/util/filterUndefined.ts
+++ b/src/util/filterUndefined.ts
@@ -1,0 +1,4 @@
+// Accepts an array of values and returns a new array of values without undefined values.
+export const filterUndefined = <T>(values: Array<T | undefined>): T[] => {
+  return values.filter(value => value !== undefined) as T[]
+}

--- a/test/common/utxobased/db/Processor.spec.ts
+++ b/test/common/utxobased/db/Processor.spec.ts
@@ -20,7 +20,7 @@ chai.should()
 
 interface Fixtures {
   assertNumAddressesWithPaths: (expectedNum: number) => void
-  assertLastUsedByFormatPath: (toBe: number | undefined) => Promise<void>
+  assertLastUsedByFormatPath: (toBe: number) => Promise<void>
   assertNumTransactions: (expectedNum: number, processor: Processor) => void
   assertProcessorObjectNotUndefined: <T>(object: T | undefined) => T
   processor: Processor
@@ -75,7 +75,7 @@ describe('Processor address tests', () => {
     } = await makeFixtures()
 
     assertNumAddressesWithPaths(0)
-    await assertLastUsedByFormatPath(undefined)
+    await assertLastUsedByFormatPath(-1)
 
     expect(await processor.fetchAddress('doesnotexist')).to.be.undefined
     expect(
@@ -107,11 +107,11 @@ describe('Processor address tests', () => {
     await processor.saveAddress(address1)
     // Assertions
     assertNumAddressesWithPaths(0)
-    await assertLastUsedByFormatPath(undefined)
+    await assertLastUsedByFormatPath(-1)
     const processorAddress1 = assertProcessorObjectNotUndefined(
       await processor.fetchAddress(address1.scriptPubkey)
     )
-    expect(processorAddress1.scriptPubkey).to.eqls(address1.scriptPubkey)
+    expect(processorAddress1?.scriptPubkey).to.eqls(address1.scriptPubkey)
 
     // Insert an unused address with a path
     const address2: IAddress = {
@@ -126,11 +126,11 @@ describe('Processor address tests', () => {
     await processor.saveAddress(address2)
     // Assertions
     assertNumAddressesWithPaths(1)
-    await assertLastUsedByFormatPath(undefined)
+    await assertLastUsedByFormatPath(-1)
     const processorAddress2 = assertProcessorObjectNotUndefined(
       await processor.fetchAddress(address2.scriptPubkey)
     )
-    expect(processorAddress2.scriptPubkey).to.eqls(address2.scriptPubkey)
+    expect(processorAddress2?.scriptPubkey).to.eqls(address2.scriptPubkey)
 
     // Insert a used address with a conflicting path
     const address3: IAddress = {
@@ -170,7 +170,7 @@ describe('Processor address tests', () => {
     const processorAddress4 = assertProcessorObjectNotUndefined(
       await processor.fetchAddress(address4.scriptPubkey)
     )
-    expect(processorAddress4.scriptPubkey).to.eqls(address4.scriptPubkey)
+    expect(processorAddress4?.scriptPubkey).to.eqls(address4.scriptPubkey)
     await assertLastUsedByFormatPath(1)
 
     // check behavior of not found addresses in populated baselets:
@@ -204,11 +204,11 @@ describe('Processor address tests', () => {
     await processor.saveAddress(address)
     // Assertions
     assertNumAddressesWithPaths(0)
-    await assertLastUsedByFormatPath(undefined)
+    await assertLastUsedByFormatPath(-1)
     const processorAddress1 = assertProcessorObjectNotUndefined(
       await processor.fetchAddress(address.scriptPubkey)
     )
-    expect(processorAddress1.scriptPubkey).to.eqls(address.scriptPubkey)
+    expect(processorAddress1?.scriptPubkey).to.eqls(address.scriptPubkey)
 
     // Update the address with a path
     address = {
@@ -222,7 +222,7 @@ describe('Processor address tests', () => {
     await processor.saveAddress(address)
     // Assertions
     assertNumAddressesWithPaths(1)
-    await assertLastUsedByFormatPath(undefined)
+    await assertLastUsedByFormatPath(-1)
     const processorAddress2 = assertProcessorObjectNotUndefined(
       await processor.fetchAddress(address.scriptPubkey)
     )
@@ -417,7 +417,7 @@ describe('Processor utxo tests', () => {
     await processor
       .fetchUtxos({ scriptPubkey: utxo.scriptPubkey })
       .then(utxos => {
-        expect(utxos).to.eqls([undefined])
+        expect(utxos).to.eqls([])
       })
   })
 
@@ -559,12 +559,12 @@ describe('Processor transactions tests', () => {
 
     assertNumTransactions(1, processor)
     const [tx1] = await processor.fetchTransactions({ txId: transaction1.txid })
-    expect(tx1.ourOuts[0]).to.eqls('0')
-    expect(tx1.ourAmount).to.eqls('1')
+    expect(tx1?.ourOuts[0]).to.eqls('0')
+    expect(tx1?.ourAmount).to.eqls('1')
     const [txByBlockHeight1] = await processor.fetchTransactions({
       blockHeight: 1
     })
-    expect(txByBlockHeight1.blockHeight).to.eqls(1)
+    expect(txByBlockHeight1?.blockHeight).to.eqls(1)
 
     // insert the same transaction, but with a script pubkey referencing an input
     await processor.saveTransaction({
@@ -573,9 +573,9 @@ describe('Processor transactions tests', () => {
     })
 
     const [tx2] = await processor.fetchTransactions({ txId: transaction1.txid })
-    expect(tx2.ourOuts[0]).to.eqls('0')
-    expect(tx2.ourIns[0]).to.eqls('0')
-    expect(tx2.ourAmount).to.eqls('0')
+    expect(tx2?.ourOuts[0]).to.eqls('0')
+    expect(tx2?.ourIns[0]).to.eqls('0')
+    expect(tx2?.ourAmount).to.eqls('0')
 
     // insert the same transaction, but with a script pubkey referencing another output
     await processor.saveTransaction({
@@ -584,9 +584,9 @@ describe('Processor transactions tests', () => {
     })
 
     const [tx3] = await processor.fetchTransactions({ txId: transaction1.txid })
-    expect(tx3.ourOuts[1]).to.eqls('1')
-    expect(tx3.ourIns[0]).to.eqls('0')
-    expect(tx3.ourAmount).to.eqls('1')
+    expect(tx3?.ourOuts[1]).to.eqls('1')
+    expect(tx3?.ourIns[0]).to.eqls('0')
+    expect(tx3?.ourAmount).to.eqls('1')
 
     const [tx4] = await processor.fetchTransactions({ options: {} })
     expect(tx4).not.to.be.undefined
@@ -667,13 +667,13 @@ describe('Processor transactions tests', () => {
 
     assertNumTransactions(2, processor)
     const [tx1] = await processor.fetchTransactions({ txId: transaction1.txid })
-    expect(tx1.ourOuts[0]).to.eqls('0')
-    expect(tx1.ourAmount).to.eqls('1')
+    expect(tx1?.ourOuts[0]).to.eqls('0')
+    expect(tx1?.ourAmount).to.eqls('1')
     const txsByBlockHeight = await processor.fetchTransactions({
       blockHeight: 1
     })
-    expect(txsByBlockHeight[0].blockHeight).to.eqls(1)
-    expect(txsByBlockHeight[1].blockHeight).to.eqls(1)
+    expect(txsByBlockHeight[0]?.blockHeight).to.eqls(1)
+    expect(txsByBlockHeight[1]?.blockHeight).to.eqls(1)
 
     await processor.saveTransaction({
       tx: transaction1,
@@ -681,9 +681,9 @@ describe('Processor transactions tests', () => {
     })
 
     const [tx2] = await processor.fetchTransactions({ txId: transaction1.txid })
-    expect(tx2.ourOuts[0]).to.eqls('0')
-    expect(tx2.ourIns[0]).to.eqls('0')
-    expect(tx2.ourAmount).to.eqls('0')
+    expect(tx2?.ourOuts[0]).to.eqls('0')
+    expect(tx2?.ourIns[0]).to.eqls('0')
+    expect(tx2?.ourAmount).to.eqls('0')
 
     await processor.saveTransaction({
       tx: transaction1,
@@ -691,9 +691,9 @@ describe('Processor transactions tests', () => {
     })
 
     const [tx3] = await processor.fetchTransactions({ txId: transaction1.txid })
-    expect(tx3.ourOuts[1]).to.eqls('1')
-    expect(tx3.ourIns[0]).to.eqls('0')
-    expect(tx3.ourAmount).to.eqls('1')
+    expect(tx3?.ourOuts[1]).to.eqls('1')
+    expect(tx3?.ourIns[0]).to.eqls('0')
+    expect(tx3?.ourAmount).to.eqls('1')
 
     const [tx4] = await processor.fetchTransactions({ options: {} })
     expect(tx4).not.to.be.undefined
@@ -789,8 +789,8 @@ describe('Processor transactions tests', () => {
       blockHeight: 1
     })
     expect(txsByBlockHeight.length).to.be.eqls(2)
-    expect(txsByBlockHeight[0].blockHeight).to.eqls(1)
-    expect(txsByBlockHeight[1].blockHeight).to.eqls(1)
+    expect(txsByBlockHeight[0]?.blockHeight).to.eqls(1)
+    expect(txsByBlockHeight[1]?.blockHeight).to.eqls(1)
 
     await processor.saveTransaction({ tx: transaction2updated })
 
@@ -799,7 +799,7 @@ describe('Processor transactions tests', () => {
       blockHeight: 1
     })
     expect(txsByBlockHeight1.length).to.be.eqls(1)
-    expect(txsByBlockHeight1[0].blockHeight).to.eqls(1)
+    expect(txsByBlockHeight1[0]?.blockHeight).to.eqls(1)
 
     // should return between (including) a range of block heights
     const txsByBlockHeight2 = await processor.fetchTransactions({
@@ -813,6 +813,6 @@ describe('Processor transactions tests', () => {
       blockHeightMax: 10
     })
     expect(txsByBlockHeight3.length).to.be.equals(2)
-    expect(txsByBlockHeight3[0].blockHeight).to.be.equals(10)
+    expect(txsByBlockHeight3[0]?.blockHeight).to.be.equals(10)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1621,10 +1621,9 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-baselet@^0.1.0:
+"baselet@https://github.com/EdgeApp/baselet.git#sam/empty-queries-fix":
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/baselet/-/baselet-0.1.0.tgz#b89fc0222c78c99ed37189bd83c4e38cbdbd5fdc"
-  integrity sha512-bNMSXI7yEXw1KxgQ+p0d1svXMNQ8mFupGBZLHAeXOjtW+tbmBiN4rhGVtqRdcRvBnSM7nqQYODWPrSzyBMvjJQ==
+  resolved "https://github.com/EdgeApp/baselet.git#5be05f12c53274b26ddf7e62b20e6170c41cd536"
   dependencies:
     disklet "^0.4.5"
     memlet "^0.0.3"


### PR DESCRIPTION
This upgrades baselet to the new branch which includes type safety on all types of baselets. Includes necessary changes to the processor and engine with the added type safety/coverage.

Replaces: https://github.com/EdgeApp/edge-currency-plugins/pull/181