### PR TITLE
Server state fixes

### DIFF
--- a/src/common/plugin/pluginState.ts
+++ b/src/common/plugin/pluginState.ts
@@ -6,7 +6,7 @@ import { EdgeIo, EdgeLog } from 'edge-core-js/types'
 import { makeMemlet, Memlet } from 'memlet'
 
 import { UtxoEngineState } from '../utxobased/engine/makeUtxoEngineState'
-import { asServerInfo, ServerCache, ServerInfo } from './serverCache'
+import { asServerInfoCache, ServerCache, ServerInfoCache } from './serverCache'
 
 const InfoServerUrl = 'https://info1.edge.app/v1/blockBook/'
 
@@ -68,7 +68,7 @@ export class PluginState extends ServerCache {
   engines: UtxoEngineState[]
   memlet: Memlet
 
-  serverCacheJson: { [serverUrl: string]: ServerInfo }
+  serverCacheJson: ServerInfoCache
   pluginId: string
 
   constructor({
@@ -94,9 +94,9 @@ export class PluginState extends ServerCache {
 
   async load(): Promise<PluginState> {
     try {
-      const serverCacheText = await this.memlet.getJson('serverCache.json')
-      const cleaner = asObject(asServerInfo)
-      this.serverCacheJson = cleaner(JSON.parse(serverCacheText))
+      this.serverCacheJson = asServerInfoCache(
+        await this.memlet.getJson('serverCache.json')
+      )
     } catch (e) {
       this.log(
         `${this.pluginId}: Failed to load server cache: ${JSON.stringify(e)}`

--- a/src/common/plugin/pluginState.ts
+++ b/src/common/plugin/pluginState.ts
@@ -1,6 +1,6 @@
 // Typescript translation from original code in edge-currency-bitcoin
 
-import { asObject } from 'cleaners'
+import { asArray, asEither, asNull, asObject, asString } from 'cleaners'
 import { navigateDisklet } from 'disklet'
 import { EdgeIo, EdgeLog } from 'edge-core-js/types'
 import { makeMemlet, Memlet } from 'memlet'
@@ -8,7 +8,12 @@ import { makeMemlet, Memlet } from 'memlet'
 import { UtxoEngineState } from '../utxobased/engine/makeUtxoEngineState'
 import { asServerInfoCache, ServerCache, ServerInfoCache } from './serverCache'
 
-const InfoServerUrl = 'https://info1.edge.app/v1/blockBook/'
+const serverListInfoUrl = 'https://info1.edge.app/v1/blockBook/'
+const asWebsocketUrl = (raw: unknown): string => {
+  const url = new URL(asString(raw))
+  return `wss://${url.host}/websocket`
+}
+const asServerListInfo = asObject(asEither(asArray(asWebsocketUrl), asNull))
 
 /** A JSON object (as opposed to an array or primitive). */
 interface JsonObject {
@@ -150,32 +155,31 @@ export class PluginState extends ServerCache {
 
   async fetchServers(): Promise<void> {
     const { io } = this
-    let serverList = this.defaultServers
-    if (!this.disableFetchingServers) {
-      this.log(`${this.pluginId} - GET ${InfoServerUrl}`)
-      const serverListResponse = await io
-        .fetch(InfoServerUrl)
-        .then(async response => {
-          if (!response.ok) {
-            this.log(
-              `${this.pluginId} - Fetching ${InfoServerUrl} failed with ${response.status}`
-            )
-            return
-          }
-          return await response.json()
-        })
-        .catch(err => {
-          this.log(
-            `${this.pluginId} - Fetching ${InfoServerUrl} failed: ${err.message}`
-          )
-        })
-      const remoteServerList: string[] = serverListResponse[this.currencyCode]
 
-      serverList =
-        remoteServerList.map(
-          url => url.replace('https', 'wss') + '/websocket'
-        ) ?? this.defaultServers
-    }
+    if (this.disableFetchingServers) return
+
+    this.log(`${this.pluginId} - GET ${serverListInfoUrl}`)
+
+    const response = await io.fetch(serverListInfoUrl)
+    const responseBody = await (async () => {
+      try {
+        if (response.ok) {
+          return await response.json()
+        }
+        this.log(
+          `${this.pluginId} - Fetching ${serverListInfoUrl} failed with status ${response.status}`
+        )
+      } catch (err) {
+        this.log(
+          `${this.pluginId} - Fetching ${serverListInfoUrl} failed: ${err.message}`
+        )
+      }
+      return {}
+    })()
+
+    const serverListInfo = asServerListInfo(responseBody)
+    const serverList = serverListInfo[this.currencyCode] ?? this.defaultServers
+
     this.serverCacheLoad(this.serverCacheJson, serverList)
     await this.saveServerCache()
 

--- a/src/common/plugin/serverCache.ts
+++ b/src/common/plugin/serverCache.ts
@@ -10,6 +10,8 @@ export const asServerInfo = asObject({
   responseTime: asNumber,
   numResponseTimes: asNumber
 })
+export type ServerInfoCache = ReturnType<typeof asServerInfoCache>
+export const asServerInfoCache = asObject(asServerInfo)
 
 const RESPONSE_TIME_UNINITIALIZED = 999999999
 const MAX_SCORE = 500
@@ -19,7 +21,7 @@ const RE_ADDED_SERVER_SCORE = -10
 let lastScoreUpTime_: number = Date.now()
 
 export class ServerCache {
-  servers_: { [serverUrl: string]: ServerInfo } = {}
+  servers_: ServerInfoCache = {}
   serverCacheDirty = false
   cacheLastSave_ = 0
   log: EdgeLog
@@ -39,7 +41,7 @@ export class ServerCache {
    * @param newServers: Array<string> of new servers downloaded from the info server
    */
   serverCacheLoad(
-    oldServers: { [serverUrl: string]: ServerInfo },
+    oldServers: ServerInfoCache,
     newServers: string[] = []
   ): void {
     //


### PR DESCRIPTION
This fixes a few issues with the server state:

1. Memlet's return value was incorrectly assumed to be a JSON string; remove the extra JSON parsing.
2. Add cleaners for the serverCache.json file data object.
3. Add cleaners for the info server network responses for the server lists.