### PR TITLE
Server Score / Plugin State refactor

### DIFF
--- a/src/common/plugin/makeCurrencyPlugin.ts
+++ b/src/common/plugin/makeCurrencyPlugin.ts
@@ -10,7 +10,7 @@ import {
 import { makeUtxoEngine } from '../utxobased/engine/makeUtxoEngine'
 import { makeCurrencyTools } from './makeCurrencyTools'
 import { EngineEmitter, EngineEvent } from './makeEngineEmitter'
-import { PluginState } from './pluginState'
+import { makePluginState } from './pluginState'
 import { EngineConfig, NetworkEnum, PluginInfo } from './types'
 
 export function makeCurrencyPlugin(
@@ -26,7 +26,7 @@ export function makeCurrencyPlugin(
     blockBookServers,
     disableFetchingServers
   } = defaultSettings
-  const state = new PluginState({
+  const state = makePluginState({
     io,
     currencyCode,
     pluginId,

--- a/src/common/plugin/pluginState.ts
+++ b/src/common/plugin/pluginState.ts
@@ -82,13 +82,14 @@ export function makePluginState(settings: PluginStateSettings): PluginState {
     serverCacheDirty = true
     for (const engine of engines) {
       if (engine.processedPercent === 1) {
-        for (const uri of engine.getServerList()) {
-          if (uri === serverUrl) {
-            saveServerCache().catch(e => {
-              log(`${pluginId} - ${JSON.stringify(e.toString())}`)
-            })
-            return
-          }
+        const isFound = engine.getServerList().includes(serverUrl)
+        if (isFound) {
+          saveServerCache().catch(e => {
+            log(`${pluginId} - ${JSON.stringify(e.toString())}`)
+          })
+          // Early exit because the server cache is no longer dirty after
+          // calling saveServerCache
+          return
         }
       }
     }

--- a/src/common/utxobased/engine/makeServerStates.ts
+++ b/src/common/utxobased/engine/makeServerStates.ts
@@ -185,7 +185,7 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
   const doRefillServers = (): void => {
     const includePatterns = ['wss:']
     if (serverList.length === 0) {
-      serverList = pluginState.getServers(NEW_CONNECTIONS, includePatterns)
+      serverList = pluginState.getLocalServers(NEW_CONNECTIONS, includePatterns)
     }
     log(`refillServers: Top ${NEW_CONNECTIONS} servers:`, serverList)
     let chanceToBePicked = 1.25

--- a/test/common/plugin/serverScores.spec.ts
+++ b/test/common/plugin/serverScores.spec.ts
@@ -1,0 +1,278 @@
+// Typescript translation from original code in edge-currency-bitcoin
+
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+
+import { ServerScores } from '../../../src/common/plugin/serverScores'
+import { makeFakeLog } from '../../utils'
+
+describe(`ServerCache`, function () {
+  const testLog = makeFakeLog()
+  const callback = (_: string): void => {
+    return
+  }
+
+  it('Score only', function () {
+    const diskServerCache = {
+      server1: {
+        serverUrl: 'server1',
+        serverScore: 500,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server2: {
+        serverUrl: 'server2',
+        serverScore: 100,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server3: {
+        serverUrl: 'server3',
+        serverScore: 300,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server4: {
+        serverUrl: 'server4',
+        serverScore: 200,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server5: {
+        serverUrl: 'server5',
+        serverScore: -190,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server6: {
+        serverUrl: 'server6',
+        serverScore: 50,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server7: {
+        serverUrl: 'server7',
+        serverScore: 500,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server8: {
+        serverUrl: 'server8',
+        serverScore: -10,
+        responseTime: 10,
+        numResponseTimes: 20
+      }
+    }
+    const newServers = [
+      'newServer1',
+      'newServer2',
+      'newServer3',
+      'server1',
+      'server2',
+      'server3',
+      'server4',
+      'server5'
+    ]
+
+    // $FlowFixMe
+    const scores = new ServerScores(testLog)
+    const cache = {}
+
+    scores.serverScoresLoad(diskServerCache, cache, callback, newServers)
+    const result = scores.getServers(cache, 8)
+
+    console.log('\n\n process version:', process.version, '\n\n')
+    const expected =
+      // v8 switched to a stable sort in this version:
+      process.version > 'v11'
+        ? [
+            'newServer1',
+            'newServer2',
+            'newServer3',
+            'server1',
+            'server2',
+            'server3',
+            'server4',
+            'server5'
+          ]
+        : [
+            'server1',
+            'server3',
+            'server4',
+            'server2',
+            'newServer2',
+            'newServer3',
+            'newServer1',
+            'server5'
+          ]
+    assert.equal(JSON.stringify(result), JSON.stringify(expected))
+    // assert.equal(outBitcoinFees.highFee, '300')
+  })
+
+  it('Bump score', function () {
+    const diskServerCache = {
+      server1: {
+        serverUrl: 'server1',
+        serverScore: 500,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server2: {
+        serverUrl: 'server2',
+        serverScore: 400,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server3: {
+        serverUrl: 'server3',
+        serverScore: 380,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server4: {
+        serverUrl: 'server4',
+        serverScore: 370,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server5: {
+        serverUrl: 'server5',
+        serverScore: 360,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server6: {
+        serverUrl: 'server6',
+        serverScore: 350,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server7: {
+        serverUrl: 'server7',
+        serverScore: 340,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server8: {
+        serverUrl: 'server8',
+        serverScore: -1,
+        responseTime: 10,
+        numResponseTimes: 20
+      }
+    }
+    const newServers = [
+      'server8',
+      'server2',
+      'server3',
+      'server4',
+      'server5',
+      'server6',
+      'server7'
+    ]
+
+    // $FlowFixMe
+    const scores = new ServerScores(testLog)
+    const cache = {}
+
+    scores.serverScoresLoad(cache, diskServerCache, callback, newServers)
+    scores.serverScoreUp(cache, 'server8', 0, callback, 405)
+    const control = [
+      'server8',
+      'server2',
+      'server3',
+      'server4',
+      'server5',
+      'server6',
+      'server7',
+      'server1'
+    ]
+    const result = scores.getServers(cache, 8)
+    assert.equal(JSON.stringify(result), JSON.stringify(control))
+  })
+
+  it('No old servers', function () {
+    const diskServerCache = {
+      server1: {
+        serverUrl: 'server1',
+        serverScore: 300,
+        responseTime: 10,
+        numResponseTimes: 20
+      },
+      server2: {
+        serverUrl: 'server2',
+        serverScore: 310,
+        responseTime: 9,
+        numResponseTimes: 20
+      },
+      server3: {
+        serverUrl: 'server3',
+        serverScore: 500,
+        responseTime: 8,
+        numResponseTimes: 20
+      },
+      server4: {
+        serverUrl: 'server4',
+        serverScore: -10,
+        responseTime: 7,
+        numResponseTimes: 20
+      },
+      server5: {
+        serverUrl: 'server5',
+        serverScore: 190,
+        responseTime: 6,
+        numResponseTimes: 20
+      },
+      server6: {
+        serverUrl: 'server6',
+        serverScore: 310,
+        responseTime: 5,
+        numResponseTimes: 20
+      },
+      server7: {
+        serverUrl: 'server7',
+        serverScore: 500,
+        responseTime: 999999999,
+        numResponseTimes: 0
+      },
+      server8: {
+        serverUrl: 'server8',
+        serverScore: -10,
+        responseTime: 999999999,
+        numResponseTimes: 0
+      }
+    }
+    const newServers = ['newServer1', 'newServer2', 'newServer3']
+    const cache = {}
+
+    // $FlowFixMe
+    const scores = new ServerScores(testLog)
+
+    scores.serverScoresLoad(cache, diskServerCache, callback, newServers)
+    const result = scores.getServers(cache, 8)
+
+    const expected =
+      // v8 switched to a stable sort in this version:
+      process.version > 'v11'
+        ? [
+            'newServer1',
+            'newServer2',
+            'newServer3',
+            'server1',
+            'server2',
+            'server3',
+            'server4',
+            'server5'
+          ]
+        : [
+            'newServer3',
+            'newServer1',
+            'newServer2',
+            'server4',
+            'server5',
+            'server2',
+            'server7',
+            'server8'
+          ]
+    assert.equal(JSON.stringify(result), JSON.stringify(expected))
+  })
+})

--- a/test/common/plugin/serverScores.spec.ts
+++ b/test/common/plugin/serverScores.spec.ts
@@ -75,10 +75,10 @@ describe(`ServerCache`, function () {
     ]
 
     // $FlowFixMe
-    const scores = new ServerScores(testLog)
+    const scores = new ServerScores({ log: testLog, onDirtyServer: callback })
     const cache = {}
 
-    scores.serverScoresLoad(diskServerCache, cache, callback, newServers)
+    scores.serverScoresLoad(diskServerCache, cache, newServers)
     const result = scores.getServers(cache, 8)
 
     console.log('\n\n process version:', process.version, '\n\n')
@@ -171,11 +171,11 @@ describe(`ServerCache`, function () {
     ]
 
     // $FlowFixMe
-    const scores = new ServerScores(testLog)
+    const scores = new ServerScores({ log: testLog, onDirtyServer: callback })
     const cache = {}
 
-    scores.serverScoresLoad(cache, diskServerCache, callback, newServers)
-    scores.serverScoreUp(cache, 'server8', 0, callback, 405)
+    scores.serverScoresLoad(cache, diskServerCache, newServers)
+    scores.serverScoreUp(cache, 'server8', 0, 405)
     const control = [
       'server8',
       'server2',
@@ -245,9 +245,9 @@ describe(`ServerCache`, function () {
     const cache = {}
 
     // $FlowFixMe
-    const scores = new ServerScores(testLog)
+    const scores = new ServerScores({ log: testLog, onDirtyServer: callback })
 
-    scores.serverScoresLoad(cache, diskServerCache, callback, newServers)
+    scores.serverScoresLoad(cache, diskServerCache, newServers)
     const result = scores.getServers(cache, 8)
 
     const expected =


### PR DESCRIPTION
This removes the in-memory cache from the server state and re-implements the logic in the plugin state. The server state file is renamed to server scores. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1199373123392598