### PR TITLE
Refactor EngineCurrencyInfo

### DIFF
--- a/src/bch.ts
+++ b/src/bch.ts
@@ -8,7 +8,7 @@ const plugin = (options: EdgeCorePluginOptions): EdgeCurrencyPlugin =>
 
 if (typeof window !== 'undefined') {
   window.addEdgeCorePlugins?.({
-    [info.pluginId]: plugin
+    [info.currencyInfo.pluginId]: plugin
   })
 }
 

--- a/src/bsv.ts
+++ b/src/bsv.ts
@@ -8,7 +8,7 @@ const plugin = (options: EdgeCorePluginOptions): EdgeCurrencyPlugin =>
 
 if (typeof window !== 'undefined') {
   window.addEdgeCorePlugins?.({
-    [info.pluginId]: plugin
+    [info.currencyInfo.pluginId]: plugin
   })
 }
 

--- a/src/btc.ts
+++ b/src/btc.ts
@@ -8,7 +8,7 @@ const plugin = (options: EdgeCorePluginOptions): EdgeCurrencyPlugin =>
 
 if (typeof window !== 'undefined') {
   window.addEdgeCorePlugins?.({
-    [info.pluginId]: plugin
+    [info.currencyInfo.pluginId]: plugin
   })
 }
 

--- a/src/common/plugin/makeCurrencyPlugin.ts
+++ b/src/common/plugin/makeCurrencyPlugin.ts
@@ -13,17 +13,18 @@ import { EngineEmitter, EngineEvent } from './makeEngineEmitter'
 import { PluginState } from './pluginState'
 import {
   EngineConfig,
-  EngineCurrencyInfo,
   EngineCurrencyType,
-  NetworkEnum
+  NetworkEnum,
+  PluginInfo
 } from './types'
 
 export function makeCurrencyPlugin(
   pluginOptions: EdgeCorePluginOptions,
-  currencyInfo: EngineCurrencyInfo
+  pluginInfo: PluginInfo
 ): EdgeCurrencyPlugin {
+  const { currencyInfo, engineInfo } = pluginInfo
   const { io, log } = pluginOptions
-  const currencyTools = makeCurrencyTools(io, currencyInfo)
+  const currencyTools = makeCurrencyTools(io, pluginInfo)
   const { defaultSettings, pluginId, currencyCode } = currencyInfo
   const {
     customFeeSettings,
@@ -72,12 +73,12 @@ export function makeCurrencyPlugin(
         engineOptions.callbacks.onTxidsChanged
       )
 
-      const network = currencyInfo.networkType ?? NetworkEnum.Mainnet
+      const network = engineInfo.networkType ?? NetworkEnum.Mainnet
 
       const engineConfig: EngineConfig = {
         network,
         walletInfo,
-        currencyInfo,
+        pluginInfo,
         currencyTools,
         io,
         options: {
@@ -89,7 +90,7 @@ export function makeCurrencyPlugin(
       }
 
       let engine: EdgeCurrencyEngine
-      switch (currencyInfo.currencyType) {
+      switch (engineInfo.currencyType) {
         case EngineCurrencyType.UTXO:
           engine = await makeUtxoEngine(engineConfig)
           break

--- a/src/common/plugin/makeCurrencyPlugin.ts
+++ b/src/common/plugin/makeCurrencyPlugin.ts
@@ -11,12 +11,7 @@ import { makeUtxoEngine } from '../utxobased/engine/makeUtxoEngine'
 import { makeCurrencyTools } from './makeCurrencyTools'
 import { EngineEmitter, EngineEvent } from './makeEngineEmitter'
 import { PluginState } from './pluginState'
-import {
-  EngineConfig,
-  EngineCurrencyType,
-  NetworkEnum,
-  PluginInfo
-} from './types'
+import { EngineConfig, NetworkEnum, PluginInfo } from './types'
 
 export function makeCurrencyPlugin(
   pluginOptions: EdgeCorePluginOptions,
@@ -89,12 +84,7 @@ export function makeCurrencyPlugin(
         pluginState: state
       }
 
-      let engine: EdgeCurrencyEngine
-      switch (engineInfo.currencyType) {
-        case EngineCurrencyType.UTXO:
-          engine = await makeUtxoEngine(engineConfig)
-          break
-      }
+      const engine: EdgeCurrencyEngine = await makeUtxoEngine(engineConfig)
 
       return engine
     },

--- a/src/common/plugin/makeCurrencyTools.ts
+++ b/src/common/plugin/makeCurrencyTools.ts
@@ -15,7 +15,7 @@ import urlParse from 'url-parse'
 
 import * as utxoUtils from '../utxobased/engine/utils'
 import { CurrencyFormatKeys } from '../utxobased/engine/utils'
-import { EngineCurrencyType, NetworkEnum, PluginInfo } from './types'
+import { NetworkEnum, PluginInfo } from './types'
 import * as pluginUtils from './utils'
 import { getFormatsForNetwork } from './utils'
 
@@ -43,29 +43,21 @@ export function makeCurrencyTools(
         [mnemonicKey]: mnemonic
       }
 
-      switch (engineInfo.currencyType) {
-        case EngineCurrencyType.UTXO:
-          return {
-            ...keys,
-            format: opts?.format ?? engineInfo.formats?.[0] ?? 'bip44',
-            coinType: opts?.coinType ?? engineInfo.coinType ?? 0
-          }
+      return {
+        ...keys,
+        format: opts?.format ?? engineInfo.formats?.[0] ?? 'bip44',
+        coinType: opts?.coinType ?? engineInfo.coinType ?? 0
       }
     },
 
     async derivePublicKey(walletInfo: EdgeWalletInfo): Promise<JsonObject> {
-      let key = 'publicKey'
-      let publicKey: CurrencyFormatKeys
-      switch (engineInfo.currencyType) {
-        case EngineCurrencyType.UTXO:
-          key = utxoUtils.getXpubKey({ coin: engineInfo.network })
-          // TODO: which xpub should be saved? the root path (m) or hardened path with the wallet format path (m/{purpose}'/{coinType}'/{account}')?
-          publicKey = utxoUtils.deriveXpubsFromKeys({
-            keys: walletInfo.keys,
-            coin: engineInfo.network,
-            network: engineInfo.networkType ?? NetworkEnum.Mainnet
-          })
-      }
+      const key = utxoUtils.getXpubKey({ coin: engineInfo.network })
+      // TODO: which xpub should be saved? the root path (m) or hardened path with the wallet format path (m/{purpose}'/{coinType}'/{account}')?
+      const publicKey: CurrencyFormatKeys = utxoUtils.deriveXpubsFromKeys({
+        keys: walletInfo.keys,
+        coin: engineInfo.network,
+        network: engineInfo.networkType ?? NetworkEnum.Mainnet
+      })
       walletInfo.keys[key] = publicKey
       return walletInfo.keys
     },
@@ -93,16 +85,14 @@ export function makeCurrencyTools(
       const parsedUri: EdgeParsedUri = {}
       // Parse the pathname and add it to the result object
       if (pathname !== '') {
-        if (engineInfo.currencyType === EngineCurrencyType.UTXO) {
-          const parsedPath = utxoUtils.parsePathname({
-            pathname: uriObj.pathname,
-            coin: engineInfo.network,
-            network: engineInfo.networkType ?? NetworkEnum.Mainnet
-          })
-          if (parsedPath == null) throw new Error('InvalidUriError')
+        const parsedPath = utxoUtils.parsePathname({
+          pathname: uriObj.pathname,
+          coin: engineInfo.network,
+          network: engineInfo.networkType ?? NetworkEnum.Mainnet
+        })
+        if (parsedPath == null) throw new Error('InvalidUriError')
 
-          Object.assign(parsedUri, parsedPath)
-        }
+        Object.assign(parsedUri, parsedPath)
       }
 
       // Assign the query params to the parsedUri object

--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -36,7 +36,12 @@ export interface TxOptions {
   CPFP?: string
 }
 
-export interface EngineCurrencyInfo extends EdgeCurrencyInfo {
+export interface PluginInfo {
+  currencyInfo: EdgeCurrencyInfo
+  engineInfo: EngineInfo
+}
+
+export interface EngineInfo {
   formats?: CurrencyFormat[]
   forks?: string[]
   coinType: number
@@ -72,7 +77,7 @@ export const asSimpleFeeSettings = asObject({
 export interface EngineConfig {
   network: NetworkEnum
   walletInfo: EdgeWalletInfo
-  currencyInfo: EngineCurrencyInfo
+  pluginInfo: PluginInfo
   currencyTools: EdgeCurrencyTools
   options: EngineOptions
   io: EdgeIo

--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -25,10 +25,6 @@ export interface AddressPath {
   addressIndex: number
 }
 
-export enum EngineCurrencyType {
-  UTXO
-}
-
 export interface TxOptions {
   utxos?: IUTXO[]
   subtractFee?: boolean
@@ -45,7 +41,6 @@ export interface EngineInfo {
   formats?: CurrencyFormat[]
   forks?: string[]
   coinType: number
-  currencyType: EngineCurrencyType
   network: string // The offical network in lower case - Needs to match the Bitcoin Lib Network Type
   networkType?: NetworkEnum
   uriPrefix?: string

--- a/src/common/plugin/utils.ts
+++ b/src/common/plugin/utils.ts
@@ -1,5 +1,5 @@
 import { UtxoKeyFormat } from '../utxobased/engine/makeUtxoWalletTools'
-import { all as networks } from '../utxobased/info/all'
+import { all as plugins } from '../utxobased/info/all'
 
 export const getMnemonicKey = ({ coin }: { coin: string }): string =>
   `${coin}Key`
@@ -14,8 +14,9 @@ export const getMnemonic = (args: {
 }
 
 export const getFormatsForNetwork = (network: string): string[] => {
-  for (const coin of networks) {
-    if (coin.network === network) return coin.formats ?? []
+  for (const plugin of plugins) {
+    if (plugin.engineInfo.network === network)
+      return plugin.engineInfo.formats ?? []
   }
   return []
 }

--- a/src/common/utxobased/info/bitcoin.ts
+++ b/src/common/utxobased/info/bitcoin.ts
@@ -1,29 +1,13 @@
-import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyInfo, EngineCurrencyType } from '../../plugin/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-export const info: EngineCurrencyInfo = {
-  currencyType: EngineCurrencyType.UTXO,
-  coinType: 0,
-  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
-  forks: ['bitcoincash', 'bitcoingold'],
-  network: 'bitcoin',
+import { IMAGE_SERVER_URL } from '../../constants'
+import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'bitcoin',
   walletType: 'wallet:bitcoin',
   currencyCode: 'BTC',
   displayName: 'Bitcoin',
-  gapLimit: 25,
-  defaultFee: 1000,
-  feeUpdateInterval: 60000,
-  mempoolSpaceFeeInfoServer: 'https://mempool.space/api/v1/fees/recommended',
-  customFeeSettings: ['satPerByte'],
-  simpleFeeSettings: {
-    highFee: '150',
-    lowFee: '20',
-    standardFeeLow: '50',
-    standardFeeHigh: '100',
-    standardFeeLowAmount: '173200',
-    standardFeeHighAmount: '8670000'
-  },
   denominations: [
     { name: 'BTC', multiplier: '100000000', symbol: '₿' },
     { name: 'mBTC', multiplier: '100000', symbol: 'm₿' },
@@ -53,4 +37,30 @@ export const info: EngineCurrencyInfo = {
   // Images:
   symbolImage: `${IMAGE_SERVER_URL}/bitcoin-logo-solo-64.png`,
   symbolImageDarkMono: `${IMAGE_SERVER_URL}/bitcoin-logo-solo-64.png`
+}
+
+const engineInfo: EngineInfo = {
+  currencyType: EngineCurrencyType.UTXO,
+  coinType: 0,
+  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
+  forks: ['bitcoincash', 'bitcoingold'],
+  network: 'bitcoin',
+  gapLimit: 25,
+  defaultFee: 1000,
+  feeUpdateInterval: 60000,
+  mempoolSpaceFeeInfoServer: 'https://mempool.space/api/v1/fees/recommended',
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '150',
+    lowFee: '20',
+    standardFeeLow: '50',
+    standardFeeHigh: '100',
+    standardFeeLowAmount: '173200',
+    standardFeeHighAmount: '8670000'
+  }
+}
+
+export const info: PluginInfo = {
+  currencyInfo,
+  engineInfo
 }

--- a/src/common/utxobased/info/bitcoin.ts
+++ b/src/common/utxobased/info/bitcoin.ts
@@ -1,7 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+import { EngineInfo, PluginInfo } from '../../plugin/types'
 
 const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'bitcoin',
@@ -40,7 +40,6 @@ const currencyInfo: EdgeCurrencyInfo = {
 }
 
 const engineInfo: EngineInfo = {
-  currencyType: EngineCurrencyType.UTXO,
   coinType: 0,
   formats: ['bip49', 'bip84', 'bip44', 'bip32'],
   forks: ['bitcoincash', 'bitcoingold'],

--- a/src/common/utxobased/info/bitcoincash.ts
+++ b/src/common/utxobased/info/bitcoincash.ts
@@ -1,28 +1,13 @@
-import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyInfo, EngineCurrencyType } from '../../plugin/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-export const info: EngineCurrencyInfo = {
-  currencyType: EngineCurrencyType.UTXO,
-  coinType: 145,
-  formats: ['bip44', 'bip32'],
-  forks: ['bitcoincashsv'],
-  network: 'bitcoincash',
+import { IMAGE_SERVER_URL } from '../../constants'
+import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'bitcoincash',
   walletType: 'wallet:bitcoincash',
   currencyCode: 'BCH',
   displayName: 'Bitcoin Cash',
-  gapLimit: 10,
-  defaultFee: 10000,
-  feeUpdateInterval: 60000,
-  customFeeSettings: ['satPerByte'],
-  simpleFeeSettings: {
-    highFee: '20',
-    lowFee: '3',
-    standardFeeLow: '5',
-    standardFeeHigh: '10',
-    standardFeeLowAmount: '1000000',
-    standardFeeHighAmount: '65000000'
-  },
   denominations: [
     { name: 'BCH', multiplier: '100000000', symbol: '₿' },
     { name: 'mBCH', multiplier: '100000', symbol: 'm₿' },
@@ -53,3 +38,25 @@ export const info: EngineCurrencyInfo = {
   symbolImage: `${IMAGE_SERVER_URL}/bitcoincash-logo-solo-64.png`,
   symbolImageDarkMono: `${IMAGE_SERVER_URL}/bitcoincash-logo-solo-64.png`
 }
+
+const engineInfo: EngineInfo = {
+  currencyType: EngineCurrencyType.UTXO,
+  coinType: 145,
+  formats: ['bip44', 'bip32'],
+  forks: ['bitcoincashsv'],
+  network: 'bitcoincash',
+  gapLimit: 10,
+  defaultFee: 10000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '20',
+    lowFee: '3',
+    standardFeeLow: '5',
+    standardFeeHigh: '10',
+    standardFeeLowAmount: '1000000',
+    standardFeeHighAmount: '65000000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/bitcoincash.ts
+++ b/src/common/utxobased/info/bitcoincash.ts
@@ -1,7 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+import { EngineInfo, PluginInfo } from '../../plugin/types'
 
 const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'bitcoincash',
@@ -40,7 +40,6 @@ const currencyInfo: EdgeCurrencyInfo = {
 }
 
 const engineInfo: EngineInfo = {
-  currencyType: EngineCurrencyType.UTXO,
   coinType: 145,
   formats: ['bip44', 'bip32'],
   forks: ['bitcoincashsv'],

--- a/src/common/utxobased/info/bitcoinsv.ts
+++ b/src/common/utxobased/info/bitcoinsv.ts
@@ -1,28 +1,13 @@
-import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyInfo, EngineCurrencyType } from '../../plugin/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-export const info: EngineCurrencyInfo = {
-  currencyType: EngineCurrencyType.UTXO,
-  coinType: 236,
-  formats: ['bip44', 'bip32'],
-  network: 'bitcoinsv',
-  uriPrefix: 'bitcoin',
+import { IMAGE_SERVER_URL } from '../../constants'
+import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'bitcoinsv',
   walletType: 'wallet:bitcoinsv',
   currencyCode: 'BSV',
   displayName: 'Bitcoin SV',
-  gapLimit: 10,
-  defaultFee: 10000,
-  feeUpdateInterval: 60000,
-  customFeeSettings: ['satPerByte'],
-  simpleFeeSettings: {
-    highFee: '20',
-    lowFee: '3',
-    standardFeeLow: '5',
-    standardFeeHigh: '10',
-    standardFeeLowAmount: '1000000',
-    standardFeeHighAmount: '65000000'
-  },
   denominations: [
     { name: 'BSV', multiplier: '100000000', symbol: '₿' },
     { name: 'mBSV', multiplier: '100000', symbol: 'm₿' },
@@ -46,3 +31,25 @@ export const info: EngineCurrencyInfo = {
   symbolImage: `${IMAGE_SERVER_URL}/bitcoinsv-logo-solo-64.png`,
   symbolImageDarkMono: `${IMAGE_SERVER_URL}/bitcoinsv-logo-solo-64.png`
 }
+
+const engineInfo: EngineInfo = {
+  currencyType: EngineCurrencyType.UTXO,
+  coinType: 236,
+  formats: ['bip44', 'bip32'],
+  network: 'bitcoinsv',
+  uriPrefix: 'bitcoin',
+  gapLimit: 10,
+  defaultFee: 10000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '20',
+    lowFee: '3',
+    standardFeeLow: '5',
+    standardFeeHigh: '10',
+    standardFeeLowAmount: '1000000',
+    standardFeeHighAmount: '65000000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/bitcoinsv.ts
+++ b/src/common/utxobased/info/bitcoinsv.ts
@@ -1,7 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+import { EngineInfo, PluginInfo } from '../../plugin/types'
 
 const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'bitcoinsv',
@@ -33,7 +33,6 @@ const currencyInfo: EdgeCurrencyInfo = {
 }
 
 const engineInfo: EngineInfo = {
-  currencyType: EngineCurrencyType.UTXO,
   coinType: 236,
   formats: ['bip44', 'bip32'],
   network: 'bitcoinsv',

--- a/src/common/utxobased/info/bitcointestnet.ts
+++ b/src/common/utxobased/info/bitcointestnet.ts
@@ -1,7 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+import { EngineInfo, PluginInfo } from '../../plugin/types'
 
 export const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'bitcointestnet',
@@ -37,7 +37,6 @@ export const currencyInfo: EdgeCurrencyInfo = {
 }
 
 export const engineInfo: EngineInfo = {
-  currencyType: EngineCurrencyType.UTXO,
   coinType: 1,
   formats: ['bip49', 'bip84', 'bip44', 'bip32'],
   forks: ['bitcoincash', 'bitcoingold'],

--- a/src/common/utxobased/info/bitcointestnet.ts
+++ b/src/common/utxobased/info/bitcointestnet.ts
@@ -1,31 +1,13 @@
-import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyInfo, EngineCurrencyType } from '../../plugin/types'
-import { NetworkEnum } from '../keymanager/bitcoincashUtils/cashAddress'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-export const info: EngineCurrencyInfo = {
-  currencyType: EngineCurrencyType.UTXO,
-  coinType: 1,
-  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
-  forks: ['bitcoincash', 'bitcoingold'],
-  network: 'bitcointestnet',
+import { IMAGE_SERVER_URL } from '../../constants'
+import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+
+export const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'bitcointestnet',
   walletType: 'wallet:bitcointestnet',
   currencyCode: 'TESTBTC',
   displayName: 'Bitcoin Testnet',
-  networkType: NetworkEnum.Testnet,
-  gapLimit: 25,
-  defaultFee: 1000,
-  feeUpdateInterval: 60000,
-  mempoolSpaceFeeInfoServer: 'https://mempool.space/api/v1/fees/recommended',
-  customFeeSettings: ['satPerByte'],
-  simpleFeeSettings: {
-    highFee: '150',
-    lowFee: '20',
-    standardFeeLow: '50',
-    standardFeeHigh: '100',
-    standardFeeLowAmount: '173200',
-    standardFeeHighAmount: '8670000'
-  },
   denominations: [
     { name: 'TESTBTC', multiplier: '100000000', symbol: '₿' },
     { name: 'mTESTBTC', multiplier: '100000', symbol: 'm₿' },
@@ -53,3 +35,26 @@ export const info: EngineCurrencyInfo = {
   symbolImage: `${IMAGE_SERVER_URL}/bitcoin-logo-solo-64.png`,
   symbolImageDarkMono: `${IMAGE_SERVER_URL}/bitcoin-logo-solo-64.png`
 }
+
+export const engineInfo: EngineInfo = {
+  currencyType: EngineCurrencyType.UTXO,
+  coinType: 1,
+  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
+  forks: ['bitcoincash', 'bitcoingold'],
+  network: 'bitcointestnet',
+  gapLimit: 25,
+  defaultFee: 1000,
+  feeUpdateInterval: 60000,
+  mempoolSpaceFeeInfoServer: 'https://mempool.space/api/v1/fees/recommended',
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '150',
+    lowFee: '20',
+    standardFeeLow: '50',
+    standardFeeHigh: '100',
+    standardFeeLowAmount: '173200',
+    standardFeeHighAmount: '8670000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/feathercoin.ts
+++ b/src/common/utxobased/info/feathercoin.ts
@@ -1,7 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+import { EngineInfo, PluginInfo } from '../../plugin/types'
 
 export const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'feathercoin',
@@ -32,7 +32,6 @@ export const currencyInfo: EdgeCurrencyInfo = {
 }
 
 export const engineInfo: EngineInfo = {
-  currencyType: EngineCurrencyType.UTXO,
   coinType: 8,
   formats: ['bip49', 'bip84', 'bip44', 'bip32'],
   network: 'feathercoin',

--- a/src/common/utxobased/info/feathercoin.ts
+++ b/src/common/utxobased/info/feathercoin.ts
@@ -1,27 +1,13 @@
-import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyInfo, EngineCurrencyType } from '../../plugin/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-export const info: EngineCurrencyInfo = {
-  currencyType: EngineCurrencyType.UTXO,
-  coinType: 8,
-  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
-  network: 'feathercoin',
+import { IMAGE_SERVER_URL } from '../../constants'
+import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+
+export const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'feathercoin',
   walletType: 'wallet:feathercoin',
   displayName: 'Feathercoin',
   currencyCode: 'FTC',
-  gapLimit: 10,
-  defaultFee: 1000,
-  feeUpdateInterval: 60000,
-  customFeeSettings: ['satPerByte'],
-  simpleFeeSettings: {
-    highFee: '1200',
-    lowFee: '400',
-    standardFeeLow: '600',
-    standardFeeHigh: '800',
-    standardFeeLowAmount: '2000000000',
-    standardFeeHighAmount: '98100000000'
-  },
   denominations: [
     { name: 'FTC', multiplier: '100000000', symbol: 'F' },
     { name: 'mFTC', multiplier: '100000', symbol: 'mF' }
@@ -44,3 +30,24 @@ export const info: EngineCurrencyInfo = {
   symbolImage: `${IMAGE_SERVER_URL}/feathercoin-logo-solo-64.png`,
   symbolImageDarkMono: `${IMAGE_SERVER_URL}/feathercoin-logo-solo-64.png`
 }
+
+export const engineInfo: EngineInfo = {
+  currencyType: EngineCurrencyType.UTXO,
+  coinType: 8,
+  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
+  network: 'feathercoin',
+  gapLimit: 10,
+  defaultFee: 1000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '1200',
+    lowFee: '400',
+    standardFeeLow: '600',
+    standardFeeHigh: '800',
+    standardFeeLowAmount: '2000000000',
+    standardFeeHighAmount: '98100000000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/litecoin.ts
+++ b/src/common/utxobased/info/litecoin.ts
@@ -1,27 +1,13 @@
-import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyInfo, EngineCurrencyType } from '../../plugin/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-export const info: EngineCurrencyInfo = {
-  currencyType: EngineCurrencyType.UTXO,
-  coinType: 2,
-  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
-  network: 'litecoin',
+import { IMAGE_SERVER_URL } from '../../constants'
+import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+
+export const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'litecoin',
   walletType: 'wallet:litecoin',
   currencyCode: 'LTC',
   displayName: 'Litecoin',
-  gapLimit: 10,
-  defaultFee: 50000,
-  feeUpdateInterval: 60000,
-  customFeeSettings: ['satPerByte'],
-  simpleFeeSettings: {
-    highFee: '300',
-    lowFee: '100',
-    standardFeeLow: '150',
-    standardFeeHigh: '200',
-    standardFeeLowAmount: '20000000',
-    standardFeeHighAmount: '981000000'
-  },
   denominations: [
     { name: 'LTC', multiplier: '100000000', symbol: 'Ł' },
     { name: 'mLTC', multiplier: '100000', symbol: 'mŁ' }
@@ -50,3 +36,24 @@ export const info: EngineCurrencyInfo = {
   symbolImage: `${IMAGE_SERVER_URL}/litecoin-logo-solo-64.png`,
   symbolImageDarkMono: `${IMAGE_SERVER_URL}/litecoin-logo-solo-64.png`
 }
+
+export const engineInfo: EngineInfo = {
+  currencyType: EngineCurrencyType.UTXO,
+  coinType: 2,
+  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
+  network: 'litecoin',
+  gapLimit: 10,
+  defaultFee: 50000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '300',
+    lowFee: '100',
+    standardFeeLow: '150',
+    standardFeeHigh: '200',
+    standardFeeLowAmount: '20000000',
+    standardFeeHighAmount: '981000000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/litecoin.ts
+++ b/src/common/utxobased/info/litecoin.ts
@@ -1,7 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+import { EngineInfo, PluginInfo } from '../../plugin/types'
 
 export const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'litecoin',
@@ -38,7 +38,6 @@ export const currencyInfo: EdgeCurrencyInfo = {
 }
 
 export const engineInfo: EngineInfo = {
-  currencyType: EngineCurrencyType.UTXO,
   coinType: 2,
   formats: ['bip49', 'bip84', 'bip44', 'bip32'],
   network: 'litecoin',

--- a/src/common/utxobased/info/zcoin.ts
+++ b/src/common/utxobased/info/zcoin.ts
@@ -1,28 +1,13 @@
-import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyInfo, EngineCurrencyType } from '../../plugin/types'
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-export const info: EngineCurrencyInfo = {
-  currencyType: EngineCurrencyType.UTXO,
-  coinType: 136,
-  formats: ['bip44', 'bip32'],
-  network: 'zcoin',
+import { IMAGE_SERVER_URL } from '../../constants'
+import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+
+export const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'zcoin',
-  uriPrefix: 'firo',
   walletType: 'wallet:zcoin',
   displayName: 'Zcoin',
   currencyCode: 'FIRO',
-  gapLimit: 10,
-  defaultFee: 1000,
-  feeUpdateInterval: 60000,
-  customFeeSettings: ['satPerByte'],
-  simpleFeeSettings: {
-    highFee: '150',
-    lowFee: '20',
-    standardFeeLow: '50',
-    standardFeeHigh: '100',
-    standardFeeLowAmount: '173200',
-    standardFeeHighAmount: '8670000'
-  },
   denominations: [
     { name: 'FIRO', multiplier: '100000000', symbol: 'ƒ' },
     { name: 'mFIRO', multiplier: '100000', symbol: 'mƒ' }
@@ -45,3 +30,25 @@ export const info: EngineCurrencyInfo = {
   symbolImage: `${IMAGE_SERVER_URL}/zcoin-logo-solo-64.png`,
   symbolImageDarkMono: `${IMAGE_SERVER_URL}/zcoin-logo-solo-64.png`
 }
+
+export const engineInfo: EngineInfo = {
+  currencyType: EngineCurrencyType.UTXO,
+  coinType: 136,
+  formats: ['bip44', 'bip32'],
+  network: 'zcoin',
+  uriPrefix: 'firo',
+  gapLimit: 10,
+  defaultFee: 1000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '150',
+    lowFee: '20',
+    standardFeeLow: '50',
+    standardFeeHigh: '100',
+    standardFeeLowAmount: '173200',
+    standardFeeHighAmount: '8670000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/zcoin.ts
+++ b/src/common/utxobased/info/zcoin.ts
@@ -1,7 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { IMAGE_SERVER_URL } from '../../constants'
-import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+import { EngineInfo, PluginInfo } from '../../plugin/types'
 
 export const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'zcoin',
@@ -32,7 +32,6 @@ export const currencyInfo: EdgeCurrencyInfo = {
 }
 
 export const engineInfo: EngineInfo = {
-  currencyType: EngineCurrencyType.UTXO,
   coinType: 136,
   formats: ['bip44', 'bip32'],
   network: 'zcoin',

--- a/src/firo.ts
+++ b/src/firo.ts
@@ -8,7 +8,7 @@ const plugin = (options: EdgeCorePluginOptions): EdgeCurrencyPlugin =>
 
 if (typeof window !== 'undefined') {
   window.addEdgeCorePlugins?.({
-    [info.pluginId]: plugin
+    [info.currencyInfo.pluginId]: plugin
   })
 }
 

--- a/src/ftc.ts
+++ b/src/ftc.ts
@@ -8,7 +8,7 @@ const plugin = (options: EdgeCorePluginOptions): EdgeCurrencyPlugin =>
 
 if (typeof window !== 'undefined') {
   window.addEdgeCorePlugins?.({
-    [info.pluginId]: plugin
+    [info.currencyInfo.pluginId]: plugin
   })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { all } from './common/utxobased/info/all'
 const plugins: EdgeCorePlugins = {}
 
 for (const info of all) {
-  plugins[info.pluginId] = (options: EdgeCorePluginOptions) =>
+  plugins[info.currencyInfo.pluginId] = (options: EdgeCorePluginOptions) =>
     makeCurrencyPlugin(options, info)
 }
 

--- a/src/ltc.ts
+++ b/src/ltc.ts
@@ -8,7 +8,7 @@ const plugin = (options: EdgeCorePluginOptions): EdgeCurrencyPlugin =>
 
 if (typeof window !== 'undefined') {
   window.addEdgeCorePlugins?.({
-    [info.pluginId]: plugin
+    [info.currencyInfo.pluginId]: plugin
   })
 }
 

--- a/src/tbtc.ts
+++ b/src/tbtc.ts
@@ -8,7 +8,7 @@ const plugin = (options: EdgeCorePluginOptions): EdgeCurrencyPlugin =>
 
 if (typeof window !== 'undefined') {
   window.addEdgeCorePlugins?.({
-    [info.pluginId]: plugin
+    [info.currencyInfo.pluginId]: plugin
   })
 }
 

--- a/test/common/fees/fees.spec.ts
+++ b/test/common/fees/fees.spec.ts
@@ -6,7 +6,7 @@ import { MemoryStorage } from 'disklet/lib/src/backends/memory'
 import { FEES_PATH } from '../../../src/common/constants'
 import { Fees, makeFees } from '../../../src/common/fees/makeFees'
 import { SimpleFeeSettings } from '../../../src/common/plugin/types'
-import { makeFakeCurrencyInfo, makeFakeIo, makeFakeLog } from '../../utils'
+import { makeFakeIo, makeFakeLog, makeFakePluginInfo } from '../../utils'
 
 chai.should()
 chai.use(chaiAsPromised)
@@ -15,7 +15,7 @@ const { expect } = chai
 describe('fees', function () {
   const fakeIo = makeFakeIo()
   const fakeLog = makeFakeLog()
-  const fakeCurrencyInfo = makeFakeCurrencyInfo()
+  const fakeMakePluginInfo = makeFakePluginInfo()
   const memory: MemoryStorage = {}
   const disklet = makeMemoryDisklet(memory)
   let fees: Fees
@@ -34,12 +34,12 @@ describe('fees', function () {
     it('should load fees from the currency info file on wallet first load', async () => {
       fees = await makeFees({
         disklet,
-        currencyInfo: fakeCurrencyInfo,
+        pluginInfo: fakeMakePluginInfo,
         io: fakeIo,
         log: fakeLog
       })
 
-      fees.fees.should.eql(fakeCurrencyInfo.simpleFeeSettings)
+      fees.fees.should.eql(fakeMakePluginInfo.engineInfo.simpleFeeSettings)
 
       testJson()
     })
@@ -47,7 +47,7 @@ describe('fees', function () {
     it('should cache fees after started', async () => {
       await fees.start()
 
-      testJson(fakeCurrencyInfo.simpleFeeSettings)
+      testJson(fakeMakePluginInfo.engineInfo.simpleFeeSettings)
 
       // be sure to stop after start, test will hang otherwise
       fees.stop()

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -7,11 +7,9 @@ import {
   EdgeLog
 } from 'edge-core-js/types'
 
-import { EngineCurrencyType, PluginInfo } from '../src/common/plugin/types'
+import { PluginInfo } from '../src/common/plugin/types'
 
-export const makeFakePluginInfo = (
-  currencyType = EngineCurrencyType.UTXO
-): PluginInfo => {
+export const makeFakePluginInfo = (): PluginInfo => {
   return {
     currencyInfo: {
       addressExplorer: '',
@@ -26,7 +24,6 @@ export const makeFakePluginInfo = (
     },
     engineInfo: {
       coinType: 0,
-      currencyType,
       customFeeSettings: [],
       defaultFee: 0,
       feeUpdateInterval: 0,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -7,39 +7,40 @@ import {
   EdgeLog
 } from 'edge-core-js/types'
 
-import {
-  EngineCurrencyInfo,
-  EngineCurrencyType
-} from '../src/common/plugin/types'
+import { EngineCurrencyType, PluginInfo } from '../src/common/plugin/types'
 
-export const makeFakeCurrencyInfo = (
+export const makeFakePluginInfo = (
   currencyType = EngineCurrencyType.UTXO
-): EngineCurrencyInfo => {
+): PluginInfo => {
   return {
-    addressExplorer: '',
-    coinType: 0,
-    currencyCode: '',
-    currencyType,
-    customFeeSettings: [],
-    defaultFee: 0,
-    defaultSettings: {},
-    denominations: [],
-    displayName: '',
-    feeUpdateInterval: 0,
-    gapLimit: 0,
-    metaTokens: [],
-    network: '',
-    pluginId: '',
-    simpleFeeSettings: {
-      highFee: '1',
-      lowFee: '2',
-      standardFeeHigh: '3',
-      standardFeeHighAmount: '4',
-      standardFeeLow: '5',
-      standardFeeLowAmount: '6'
+    currencyInfo: {
+      addressExplorer: '',
+      currencyCode: '',
+      defaultSettings: {},
+      denominations: [],
+      displayName: '',
+      metaTokens: [],
+      pluginId: '',
+      transactionExplorer: '',
+      walletType: ''
     },
-    transactionExplorer: '',
-    walletType: ''
+    engineInfo: {
+      coinType: 0,
+      currencyType,
+      customFeeSettings: [],
+      defaultFee: 0,
+      feeUpdateInterval: 0,
+      gapLimit: 0,
+      network: '',
+      simpleFeeSettings: {
+        highFee: '1',
+        lowFee: '2',
+        standardFeeHigh: '3',
+        standardFeeHighAmount: '4',
+        standardFeeLow: '5',
+        standardFeeLowAmount: '6'
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Refactor EngineCurrencyInfo for each wallet to no longer extend EdgeCurrencyInfo. Rather, have EngineInfo and EdgeCurrencyInfo be sibling fields in a PluginInfo object which is passed to makeCurrencyPlugin.