### PR TITLE
Sort package.json to fix browser field location

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "repository": "https://github.app/EdgeApp/edge-currency-plugins",
   "license": "MIT",
   "author": "Airbitz, Inc.",
-  "browser": {
-    "ws": false
-  },
   "exports": {
     ".": {
       "import": "./lib/index.mjs",
@@ -45,6 +42,9 @@
   },
   "main": "./lib/index.js",
   "module": "./lib/edge-currency-plugins.js",
+  "browser": {
+    "ws": false
+  },
   "types": "./lib/index.d.ts",
   "files": [
     "lib/*",


### PR DESCRIPTION
Runs `npx sort-package-json` to follow the sorting rules according to this package.