### PR TITLE
Fix intermittent zero-balance

### DIFF
--- a/src/common/plugin/makeMetadata.ts
+++ b/src/common/plugin/makeMetadata.ts
@@ -75,6 +75,7 @@ export const makeMetadata = async (
       const metadata = await memlet.getJson(metadataPath)
       return asLocalWalletMetadata(metadata)
     } catch (err) {
+      log.error(err)
       return await resetMetadata()
     }
   }


### PR DESCRIPTION
Despite the method name `setJson`, memlet expects an object and takes
care of JSON serialization and de-serialization.
This confusion lead to an inconsistency in storing and retrieving
the metadata object.