### PR TITLE
Add Currency Info

### DIFF
--- a/fixtures/currencyPlugins.json
+++ b/fixtures/currencyPlugins.json
@@ -132,10 +132,10 @@
       }]
     },
     "getSplittableTypes": {
-      "bip32": ["wallet:bitcoincash"],
-      "bip44": ["wallet:bitcoincash"],
-      "bip49": [],
-      "bip84": []
+      "bip32": ["wallet:bitcoincash", "wallet:bitcoingold"],
+      "bip44": ["wallet:bitcoincash", "wallet:bitcoingold"],
+      "bip49": ["wallet:bitcoingold"],
+      "bip84": ["wallet:bitcoingold"]
     }
   },
   {

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -7,6 +7,7 @@ import { info as bitcointestnet } from './bitcointestnet'
 import { info as dash } from './dash'
 import { info as digibyte } from './digibyte'
 import { info as dogecoin } from './dogecoin'
+import { info as eboost } from './eboost'
 import { info as feathercoin } from './feathercoin'
 import { info as litecoin } from './litecoin'
 import { info as zcoin } from './zcoin'
@@ -20,6 +21,7 @@ export { info as bitcointestnet } from './bitcointestnet'
 export { info as dash } from './dash'
 export { info as digibyte } from './digibyte'
 export { info as dogecoin } from './dogecoin'
+export { info as eboost } from './eboost'
 export { info as feathercoin } from './feathercoin'
 export { info as litecoin } from './litecoin'
 export { info as zcoin } from './zcoin'
@@ -34,6 +36,7 @@ export const all = [
   dash,
   digibyte,
   dogecoin,
+  eboost,
   feathercoin,
   litecoin,
   zcoin

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -4,6 +4,7 @@ import { info as bitcoincash } from './bitcoincash'
 import { info as bitcoingold } from './bitcoingold'
 import { info as bitcoinsv } from './bitcoinsv'
 import { info as bitcointestnet } from './bitcointestnet'
+import { info as dash } from './dash'
 import { info as feathercoin } from './feathercoin'
 import { info as litecoin } from './litecoin'
 import { info as zcoin } from './zcoin'
@@ -14,6 +15,7 @@ export { info as bitcoincash } from './bitcoincash'
 export { info as bitcoingold } from './bitcoingold'
 export { info as bitcoinsv } from './bitcoinsv'
 export { info as bitcointestnet } from './bitcointestnet'
+export { info as dash } from './dash'
 export { info as feathercoin } from './feathercoin'
 export { info as litecoin } from './litecoin'
 export { info as zcoin } from './zcoin'
@@ -25,6 +27,7 @@ export const all = [
   bitcoingold,
   bitcoinsv,
   bitcointestnet,
+  dash,
   feathercoin,
   litecoin,
   zcoin

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -1,6 +1,7 @@
 import { info as badcoin } from './badcoin'
 import { info as bitcoin } from './bitcoin'
 import { info as bitcoincash } from './bitcoincash'
+import { info as bitcoingold } from './bitcoingold'
 import { info as bitcoinsv } from './bitcoinsv'
 import { info as bitcointestnet } from './bitcointestnet'
 import { info as feathercoin } from './feathercoin'
@@ -9,9 +10,10 @@ import { info as zcoin } from './zcoin'
 
 export { info as badcoin } from './badcoin'
 export { info as bitcoin } from './bitcoin'
-export { info as bitcointestnet } from './bitcointestnet'
 export { info as bitcoincash } from './bitcoincash'
+export { info as bitcoingold } from './bitcoingold'
 export { info as bitcoinsv } from './bitcoinsv'
+export { info as bitcointestnet } from './bitcointestnet'
 export { info as feathercoin } from './feathercoin'
 export { info as litecoin } from './litecoin'
 export { info as zcoin } from './zcoin'
@@ -20,6 +22,7 @@ export const all = [
   badcoin,
   bitcoin,
   bitcoincash,
+  bitcoingold,
   bitcoinsv,
   bitcointestnet,
   feathercoin,

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -5,6 +5,7 @@ import { info as bitcoingold } from './bitcoingold'
 import { info as bitcoinsv } from './bitcoinsv'
 import { info as bitcointestnet } from './bitcointestnet'
 import { info as dash } from './dash'
+import { info as digibyte } from './digibyte'
 import { info as feathercoin } from './feathercoin'
 import { info as litecoin } from './litecoin'
 import { info as zcoin } from './zcoin'
@@ -16,6 +17,7 @@ export { info as bitcoingold } from './bitcoingold'
 export { info as bitcoinsv } from './bitcoinsv'
 export { info as bitcointestnet } from './bitcointestnet'
 export { info as dash } from './dash'
+export { info as digibyte } from './digibyte'
 export { info as feathercoin } from './feathercoin'
 export { info as litecoin } from './litecoin'
 export { info as zcoin } from './zcoin'
@@ -28,6 +30,7 @@ export const all = [
   bitcoinsv,
   bitcointestnet,
   dash,
+  digibyte,
   feathercoin,
   litecoin,
   zcoin

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -11,6 +11,7 @@ import { info as eboost } from './eboost'
 import { info as feathercoin } from './feathercoin'
 import { info as groestlcoin } from './groestlcoin'
 import { info as litecoin } from './litecoin'
+import { info as qtum } from './qtum'
 import { info as zcoin } from './zcoin'
 
 export { info as badcoin } from './badcoin'
@@ -26,6 +27,7 @@ export { info as eboost } from './eboost'
 export { info as feathercoin } from './feathercoin'
 export { info as groestlcoin } from './groestlcoin'
 export { info as litecoin } from './litecoin'
+export { info as qtum } from './qtum'
 export { info as zcoin } from './zcoin'
 
 export const all = [
@@ -42,5 +44,6 @@ export const all = [
   feathercoin,
   groestlcoin,
   litecoin,
+  qtum,
   zcoin
 ]

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -1,3 +1,4 @@
+import { info as badcoin } from './badcoin'
 import { info as bitcoin } from './bitcoin'
 import { info as bitcoincash } from './bitcoincash'
 import { info as bitcoinsv } from './bitcoinsv'
@@ -6,6 +7,7 @@ import { info as feathercoin } from './feathercoin'
 import { info as litecoin } from './litecoin'
 import { info as zcoin } from './zcoin'
 
+export { info as badcoin } from './badcoin'
 export { info as bitcoin } from './bitcoin'
 export { info as bitcointestnet } from './bitcointestnet'
 export { info as bitcoincash } from './bitcoincash'
@@ -15,6 +17,7 @@ export { info as litecoin } from './litecoin'
 export { info as zcoin } from './zcoin'
 
 export const all = [
+  badcoin,
   bitcoin,
   bitcoincash,
   bitcoinsv,

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -12,6 +12,7 @@ import { info as feathercoin } from './feathercoin'
 import { info as groestlcoin } from './groestlcoin'
 import { info as litecoin } from './litecoin'
 import { info as qtum } from './qtum'
+import { info as ravencoin } from './ravencoin'
 import { info as zcoin } from './zcoin'
 
 export { info as badcoin } from './badcoin'
@@ -28,6 +29,7 @@ export { info as feathercoin } from './feathercoin'
 export { info as groestlcoin } from './groestlcoin'
 export { info as litecoin } from './litecoin'
 export { info as qtum } from './qtum'
+export { info as ravencoin } from './ravencoin'
 export { info as zcoin } from './zcoin'
 
 export const all = [
@@ -45,5 +47,6 @@ export const all = [
   groestlcoin,
   litecoin,
   qtum,
+  ravencoin,
   zcoin
 ]

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -9,6 +9,7 @@ import { info as digibyte } from './digibyte'
 import { info as dogecoin } from './dogecoin'
 import { info as eboost } from './eboost'
 import { info as feathercoin } from './feathercoin'
+import { info as groestlcoin } from './groestlcoin'
 import { info as litecoin } from './litecoin'
 import { info as zcoin } from './zcoin'
 
@@ -23,6 +24,7 @@ export { info as digibyte } from './digibyte'
 export { info as dogecoin } from './dogecoin'
 export { info as eboost } from './eboost'
 export { info as feathercoin } from './feathercoin'
+export { info as groestlcoin } from './groestlcoin'
 export { info as litecoin } from './litecoin'
 export { info as zcoin } from './zcoin'
 
@@ -38,6 +40,7 @@ export const all = [
   dogecoin,
   eboost,
   feathercoin,
+  groestlcoin,
   litecoin,
   zcoin
 ]

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -6,6 +6,7 @@ import { info as bitcoinsv } from './bitcoinsv'
 import { info as bitcointestnet } from './bitcointestnet'
 import { info as dash } from './dash'
 import { info as digibyte } from './digibyte'
+import { info as dogecoin } from './dogecoin'
 import { info as feathercoin } from './feathercoin'
 import { info as litecoin } from './litecoin'
 import { info as zcoin } from './zcoin'
@@ -18,6 +19,7 @@ export { info as bitcoinsv } from './bitcoinsv'
 export { info as bitcointestnet } from './bitcointestnet'
 export { info as dash } from './dash'
 export { info as digibyte } from './digibyte'
+export { info as dogecoin } from './dogecoin'
 export { info as feathercoin } from './feathercoin'
 export { info as litecoin } from './litecoin'
 export { info as zcoin } from './zcoin'
@@ -31,6 +33,7 @@ export const all = [
   bitcointestnet,
   dash,
   digibyte,
+  dogecoin,
   feathercoin,
   litecoin,
   zcoin

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -14,6 +14,7 @@ import { info as litecoin } from './litecoin'
 import { info as qtum } from './qtum'
 import { info as ravencoin } from './ravencoin'
 import { info as smartcash } from './smartcash'
+import { info as ufo } from './ufo'
 import { info as zcoin } from './zcoin'
 
 export { info as badcoin } from './badcoin'
@@ -32,6 +33,7 @@ export { info as litecoin } from './litecoin'
 export { info as qtum } from './qtum'
 export { info as ravencoin } from './ravencoin'
 export { info as smartcash } from './smartcash'
+export { info as ufo } from './ufo'
 export { info as zcoin } from './zcoin'
 
 export const all = [
@@ -51,5 +53,6 @@ export const all = [
   qtum,
   ravencoin,
   smartcash,
+  ufo,
   zcoin
 ]

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -15,6 +15,7 @@ import { info as qtum } from './qtum'
 import { info as ravencoin } from './ravencoin'
 import { info as smartcash } from './smartcash'
 import { info as ufo } from './ufo'
+import { info as vertcoin } from './vertcoin'
 import { info as zcoin } from './zcoin'
 
 export { info as badcoin } from './badcoin'
@@ -34,6 +35,7 @@ export { info as qtum } from './qtum'
 export { info as ravencoin } from './ravencoin'
 export { info as smartcash } from './smartcash'
 export { info as ufo } from './ufo'
+export { info as vertcoin } from './vertcoin'
 export { info as zcoin } from './zcoin'
 
 export const all = [
@@ -54,5 +56,6 @@ export const all = [
   ravencoin,
   smartcash,
   ufo,
+  vertcoin,
   zcoin
 ]

--- a/src/common/utxobased/info/all.ts
+++ b/src/common/utxobased/info/all.ts
@@ -13,6 +13,7 @@ import { info as groestlcoin } from './groestlcoin'
 import { info as litecoin } from './litecoin'
 import { info as qtum } from './qtum'
 import { info as ravencoin } from './ravencoin'
+import { info as smartcash } from './smartcash'
 import { info as zcoin } from './zcoin'
 
 export { info as badcoin } from './badcoin'
@@ -30,6 +31,7 @@ export { info as groestlcoin } from './groestlcoin'
 export { info as litecoin } from './litecoin'
 export { info as qtum } from './qtum'
 export { info as ravencoin } from './ravencoin'
+export { info as smartcash } from './smartcash'
 export { info as zcoin } from './zcoin'
 
 export const all = [
@@ -48,5 +50,6 @@ export const all = [
   litecoin,
   qtum,
   ravencoin,
+  smartcash,
   zcoin
 ]

--- a/src/common/utxobased/info/badcoin.ts
+++ b/src/common/utxobased/info/badcoin.ts
@@ -1,0 +1,48 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'badcoin',
+  walletType: 'wallet:badcoin',
+  currencyCode: 'BAD',
+  displayName: 'Badcoin',
+  denominations: [
+    { name: 'BAD', multiplier: '100000000', symbol: 'BAD' },
+    { name: 'mBAD', multiplier: '100000', symbol: 'mBAD' }
+  ],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: [],
+    disableFetchingServers: true
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://www.blockingbad.com/address/%s',
+  blockExplorer: 'https://www.blockingbad.com/block/%s',
+  transactionExplorer: 'https://www.blockingbad.com/tx/%s'
+}
+
+const engineInfo: EngineInfo = {
+  currencyType: EngineCurrencyType.UTXO,
+  coinType: 324,
+  formats: ['bip49', 'bip44', 'bip32'],
+  network: 'badcoin',
+  gapLimit: 10,
+  defaultFee: 500000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '300',
+    lowFee: '100',
+    standardFeeLow: '150',
+    standardFeeHigh: '200',
+    standardFeeLowAmount: '20000000',
+    standardFeeHighAmount: '981000000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/badcoin.ts
+++ b/src/common/utxobased/info/badcoin.ts
@@ -1,6 +1,6 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
-import { EngineCurrencyType, EngineInfo, PluginInfo } from '../../plugin/types'
+import { EngineInfo, PluginInfo } from '../../plugin/types'
 
 const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'badcoin',
@@ -27,7 +27,6 @@ const currencyInfo: EdgeCurrencyInfo = {
 }
 
 const engineInfo: EngineInfo = {
-  currencyType: EngineCurrencyType.UTXO,
   coinType: 324,
   formats: ['bip49', 'bip44', 'bip32'],
   network: 'badcoin',

--- a/src/common/utxobased/info/bitcoingold.ts
+++ b/src/common/utxobased/info/bitcoingold.ts
@@ -1,0 +1,54 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'bitcoingold',
+  walletType: 'wallet:bitcoingold',
+  currencyCode: 'BTG',
+  displayName: 'Bitcoin Gold',
+  denominations: [
+    { name: 'BTG', multiplier: '100000000', symbol: '₿' },
+    { name: 'mBTG', multiplier: '100000', symbol: 'm₿' },
+    { name: 'bits', multiplier: '100', symbol: 'ƀ' }
+  ],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: [
+      'wss://btg1.trezor.io',
+      'wss://btg2.trezor.io',
+      'wss://btg3.trezor.io',
+      'wss://btg4.trezor.io',
+      'wss://btg5.trezor.io'
+    ],
+    disableFetchingServers: false
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://explorer.bitcoingold.org/insight/address/%s',
+  blockExplorer: 'https://explorer.bitcoingold.org/insight/block/%s',
+  transactionExplorer: 'https://explorer.bitcoingold.org/insight/tx/%s'
+}
+
+const engineInfo: EngineInfo = {
+  coinType: 156,
+  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
+  network: 'bitcoingold',
+  gapLimit: 10,
+  defaultFee: 1000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '200',
+    lowFee: '10',
+    standardFeeLow: '15',
+    standardFeeHigh: '140',
+    standardFeeLowAmount: '17320',
+    standardFeeHighAmount: '86700000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/dash.ts
+++ b/src/common/utxobased/info/dash.ts
@@ -1,0 +1,53 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'dash',
+  walletType: 'wallet:dash',
+  currencyCode: 'DASH',
+  displayName: 'Dash',
+  denominations: [
+    { name: 'DASH', multiplier: '100000000', symbol: 'Ð' },
+    { name: 'mDASH', multiplier: '100000', symbol: 'mÐ' }
+  ],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: [
+      'wss://dash1.trezor.io',
+      'wss://dash2.trezor.io',
+      'wss://dash3.trezor.io',
+      'wss://dash4.trezor.io',
+      'wss://dash5.trezor.io'
+    ],
+    disableFetchingServers: false
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://blockchair.com/dash/address/%s?from=edgeapp',
+  blockExplorer: 'https://blockchair.com/dash/block/%s?from=edgeapp',
+  transactionExplorer: 'https://blockchair.com/dash/transaction/%s?from=edgeapp'
+}
+
+const engineInfo: EngineInfo = {
+  coinType: 5,
+  formats: ['bip44', 'bip32'],
+  network: 'dash',
+  gapLimit: 10,
+  defaultFee: 10000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '300',
+    lowFee: '100',
+    standardFeeLow: '150',
+    standardFeeHigh: '200',
+    standardFeeLowAmount: '20000000',
+    standardFeeHighAmount: '981000000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/digibyte.ts
+++ b/src/common/utxobased/info/digibyte.ts
@@ -1,0 +1,48 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'digibyte',
+  walletType: 'wallet:digibyte',
+  currencyCode: 'DGB',
+  displayName: 'DigiByte',
+  denominations: [
+    { name: 'DGB', multiplier: '100000000', symbol: 'Ɗ' },
+    { name: 'mDGB', multiplier: '100000', symbol: 'mƊ' }
+  ],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: ['wss://dgb1.trezor.io', 'wss://dgb2.trezor.io'],
+    disableFetchingServers: false
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://digiexplorer.info/address/%s',
+  blockExplorer: 'https://digiexplorer.info/block/%s',
+  transactionExplorer: 'https://digiexplorer.info/tx/%s'
+}
+
+const engineInfo: EngineInfo = {
+  coinType: 20,
+  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
+  forks: [],
+  network: 'digibyte',
+  gapLimit: 10,
+  defaultFee: 1000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '150',
+    lowFee: '20',
+    standardFeeLow: '50',
+    standardFeeHigh: '100',
+    standardFeeLowAmount: '173200',
+    standardFeeHighAmount: '8670000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/dogecoin.ts
+++ b/src/common/utxobased/info/dogecoin.ts
@@ -1,0 +1,52 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'dogecoin',
+  walletType: 'wallet:dogecoin',
+  currencyCode: 'DOGE',
+  displayName: 'Dogecoin',
+  denominations: [{ name: 'DOGE', multiplier: '100000000', symbol: 'Ð' }],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: [
+      'wss://doge1.trezor.io',
+      'wss://doge2.trezor.io',
+      'wss://doge3.trezor.io',
+      'wss://doge4.trezor.io',
+      'wss://doge5.trezor.io'
+    ],
+    disableFetchingServers: false
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://blockchair.com/dogecoin/address/%s?from=edgeapp',
+  blockExplorer: 'https://blockchair.com/dogecoin/block/%s?from=edgeapp',
+  transactionExplorer:
+    'https://blockchair.com/dogecoin/transaction/%s?from=edgeapp'
+}
+
+const engineInfo: EngineInfo = {
+  coinType: 3,
+  formats: ['bip44', 'bip32'],
+  network: 'dogecoin',
+  gapLimit: 10,
+  defaultFee: 1000,
+  feeUpdateInterval: 10000,
+  // minRelay: '???',
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '526316',
+    lowFee: '526316',
+    standardFeeLow: '526316',
+    standardFeeHigh: '526316',
+    standardFeeLowAmount: '2000000000',
+    standardFeeHighAmount: '98100000000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/eboost.ts
+++ b/src/common/utxobased/info/eboost.ts
@@ -1,0 +1,47 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'eboost',
+  walletType: 'wallet:eboost',
+  currencyCode: 'EBST',
+  displayName: 'eBoost',
+  denominations: [
+    { name: 'EBST', multiplier: '100000000', symbol: 'EBST' },
+    { name: 'mEBST', multiplier: '100000', symbol: 'mEBST' }
+  ],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: [],
+    disableFetchingServers: true
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://www.blockexperts.com/ebst/address/%s',
+  blockExplorer: 'https://www.blockexperts.com/ebst/hash/%s',
+  transactionExplorer: 'https://www.blockexperts.com/ebst/tx/%s'
+}
+
+const engineInfo: EngineInfo = {
+  coinType: 324,
+  formats: ['bip44', 'bip32'],
+  network: 'eboost',
+  gapLimit: 10,
+  defaultFee: 500000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '300',
+    lowFee: '100',
+    standardFeeLow: '150',
+    standardFeeHigh: '200',
+    standardFeeLowAmount: '20000000',
+    standardFeeHighAmount: '981000000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/groestlcoin.ts
+++ b/src/common/utxobased/info/groestlcoin.ts
@@ -1,0 +1,49 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'groestlcoin',
+  walletType: 'wallet:groestlcoin',
+  currencyCode: 'GRS',
+  displayName: 'Groestlcoin',
+  denominations: [
+    { name: 'GRS', multiplier: '100000000', symbol: 'G' },
+    { name: 'mGRS', multiplier: '100000', symbol: 'mG' }
+  ],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: ['wss://blockbook.groestlcoin.org'],
+    disableFetchingServers: true
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer:
+    'https://blockchair.com/groestlcoin/address/%s?from=edgeapp?from=edgeapp',
+  blockExplorer: 'https://blockchair.com/groestlcoin/block/%s?from=edgeapp',
+  transactionExplorer:
+    'https://blockchair.com/groestlcoin/transaction/%s?from=edgeapp'
+}
+
+const engineInfo: EngineInfo = {
+  coinType: 17,
+  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
+  network: 'groestlcoin',
+  gapLimit: 10,
+  defaultFee: 100000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '150',
+    lowFee: '20',
+    standardFeeLow: '50',
+    standardFeeHigh: '100',
+    standardFeeLowAmount: '173200',
+    standardFeeHighAmount: '8670000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/qtum.ts
+++ b/src/common/utxobased/info/qtum.ts
@@ -1,0 +1,44 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'qtum',
+  walletType: 'wallet:qtum',
+  currencyCode: 'QTUM',
+  displayName: 'Qtum',
+  denominations: [{ name: 'QTUM', multiplier: '100000000', symbol: 'Q' }],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: [],
+    disableFetchingServers: false
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://explorer.qtum.org/address/%s',
+  blockExplorer: 'https://explorer.qtum.org/block/%s',
+  transactionExplorer: 'https://explorer.qtum.org/tx/%s'
+}
+
+const engineInfo: EngineInfo = {
+  coinType: 2301,
+  formats: ['bip44', 'bip32'],
+  network: 'qtum',
+  gapLimit: 10,
+  defaultFee: 1000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '1000',
+    lowFee: '400',
+    standardFeeLow: '450',
+    standardFeeHigh: '700',
+    standardFeeLowAmount: '20000000',
+    standardFeeHighAmount: '981000000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/ravencoin.ts
+++ b/src/common/utxobased/info/ravencoin.ts
@@ -1,0 +1,44 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'ravencoin',
+  walletType: 'wallet:ravencoin',
+  currencyCode: 'RVN',
+  displayName: 'Ravencoin',
+  denominations: [{ name: 'RVN', multiplier: '100000000', symbol: 'R' }],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: ['wss://blockbook.ravencoin.org'],
+    disableFetchingServers: false
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://ravencoin.network/address/%s',
+  blockExplorer: 'https://ravencoin.network/block/%s',
+  transactionExplorer: 'https://ravencoin.network/tx/%s'
+}
+
+const engineInfo: EngineInfo = {
+  coinType: 175,
+  formats: ['bip44', 'bip32'],
+  network: 'ravencoin',
+  gapLimit: 10,
+  defaultFee: 1000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '150',
+    lowFee: '20',
+    standardFeeLow: '50',
+    standardFeeHigh: '100',
+    standardFeeLowAmount: '173200',
+    standardFeeHighAmount: '8670000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/smartcash.ts
+++ b/src/common/utxobased/info/smartcash.ts
@@ -1,0 +1,47 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'smartcash',
+  walletType: 'wallet:smartcash',
+  currencyCode: 'SMART',
+  displayName: 'SmartCash',
+  denominations: [
+    { name: 'SMART', multiplier: '100000000', symbol: 'S' },
+    { name: 'mSMART', multiplier: '100000', symbol: 'mS' }
+  ],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: [],
+    disableFetchingServers: true
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://insight.smartcash.cc/address/%s',
+  blockExplorer: 'https://insight.smartcash.cc/block/%s',
+  transactionExplorer: 'https://insight.smartcash.cc/tx/%s'
+}
+
+const engineInfo: EngineInfo = {
+  coinType: 224,
+  formats: ['bip44', 'bip32'],
+  network: 'smartcash',
+  gapLimit: 10,
+  defaultFee: 100000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '1500',
+    lowFee: '200',
+    standardFeeLow: '500',
+    standardFeeHigh: '1000',
+    standardFeeLowAmount: '1732000',
+    standardFeeHighAmount: '86700000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/ufo.ts
+++ b/src/common/utxobased/info/ufo.ts
@@ -1,0 +1,47 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'ufo',
+  walletType: 'wallet:ufo',
+  currencyCode: 'UFO',
+  displayName: 'UFO',
+  denominations: [
+    { name: 'UFO', multiplier: '100000000', symbol: 'Ʉ' },
+    { name: 'kUFO', multiplier: '100000000000', symbol: 'kɄ' }
+  ],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: [],
+    disableFetchingServers: false
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://explorer.ufobject.com/address/%s',
+  blockExplorer: 'https://explorer.ufobject.com/block/%s',
+  transactionExplorer: 'https://explorer.ufobject.com/tx/%s'
+}
+
+const engineInfo: EngineInfo = {
+  coinType: 202,
+  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
+  network: 'uniformfiscalobject',
+  gapLimit: 10,
+  defaultFee: 50000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '2250',
+    lowFee: '1000',
+    standardFeeLow: '1100',
+    standardFeeHigh: '2000',
+    standardFeeLowAmount: '51282051282051',
+    standardFeeHighAmount: '5128205128205100'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }

--- a/src/common/utxobased/info/vertcoin.ts
+++ b/src/common/utxobased/info/vertcoin.ts
@@ -1,0 +1,54 @@
+import { EdgeCurrencyInfo } from 'edge-core-js/types'
+
+import { EngineInfo, PluginInfo } from '../../plugin/types'
+
+const currencyInfo: EdgeCurrencyInfo = {
+  pluginId: 'vertcoin',
+  walletType: 'wallet:vertcoin',
+  currencyCode: 'VTC',
+  displayName: 'Vertcoin',
+  denominations: [
+    { name: 'VTC', multiplier: '100000000', symbol: 'V' },
+    { name: 'mVTC', multiplier: '100000', symbol: 'mV' }
+  ],
+
+  // Configuration options:
+  defaultSettings: {
+    customFeeSettings: ['satPerByte'],
+    blockBookServers: [
+      'wss://vtc1.trezor.io',
+      'wss://vtc2.trezor.io',
+      'wss://vtc3.trezor.io',
+      'wss://vtc4.trezor.io',
+      'wss://vtc5.trezor.io'
+    ],
+    disableFetchingServers: false
+  },
+  metaTokens: [],
+
+  // Explorers:
+  addressExplorer: 'https://insight.vertcoin.org/address/%s',
+  blockExplorer: 'https://insight.vertcoin.org/block/%s',
+  transactionExplorer: 'https://insight.vertcoin.org/tx/%s'
+}
+
+const engineInfo: EngineInfo = {
+  coinType: 28,
+  formats: ['bip49', 'bip84', 'bip44', 'bip32'],
+  forks: [],
+  network: 'vertcoin',
+  gapLimit: 10,
+  defaultFee: 1000,
+  feeUpdateInterval: 60000,
+  customFeeSettings: ['satPerByte'],
+  simpleFeeSettings: {
+    highFee: '150',
+    lowFee: '20',
+    standardFeeLow: '50',
+    standardFeeHigh: '100',
+    standardFeeLowAmount: '173200',
+    standardFeeHighAmount: '8670000'
+  }
+}
+
+export const info: PluginInfo = { currencyInfo, engineInfo }


### PR DESCRIPTION
This adds the remaining missing currency info files from edge-currency-bitcoin. The info for for the following currencies have been added:

* badcoin BAD
* bitcoingold BTG
* dash DASH
* digibyte DGB
* dogecoin DOGE
* eboost EBST
* groestlcoin GRS
* qtum QTUM
* ravencoin RVN
* smartcash SMART
* ufo UFO
* vertcoin VTC