### PR TITLE
Sam/Fix/Numb Keys

### DIFF
--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -1,5 +1,5 @@
 import { bip32 } from 'altcoin-js'
-import { asNumber, asObject, asString } from 'cleaners'
+import { asNumber, asObject, asString, asValue } from 'cleaners'
 import { Disklet } from 'disklet'
 import {
   EdgeCurrencyEngineOptions,
@@ -20,7 +20,8 @@ export enum NetworkEnum {
   Testnet = 'testnet'
 }
 
-export type CurrencyFormat = 'bip32' | 'bip44' | 'bip49' | 'bip84'
+export type CurrencyFormat = ReturnType<typeof asCurrencyFormat>
+export const asCurrencyFormat = asValue('bip32', 'bip44', 'bip49', 'bip84')
 
 export interface AddressPath {
   format: CurrencyFormat

--- a/src/common/plugin/utils.ts
+++ b/src/common/plugin/utils.ts
@@ -1,17 +1,4 @@
-import { UtxoKeyFormat } from '../utxobased/engine/makeUtxoWalletTools'
 import { all as plugins } from '../utxobased/info/all'
-
-export const getMnemonicKey = ({ coin }: { coin: string }): string =>
-  `${coin}Key`
-
-export const getMnemonic = (args: {
-  keys: UtxoKeyFormat
-  coin: string
-}): string => {
-  const key = args.keys[getMnemonicKey(args)]
-  if (key == null) throw new Error('Cannot derive key from watch-only wallet')
-  return key
-}
 
 export const getFormatsForNetwork = (coinName: string): string[] => {
   for (const plugin of plugins) {

--- a/src/common/utxobased/engine/makeServerStates.ts
+++ b/src/common/utxobased/engine/makeServerStates.ts
@@ -1,9 +1,10 @@
-import { EdgeLog, EdgeTransaction, EdgeWalletInfo } from 'edge-core-js/types'
+import { EdgeLog, EdgeTransaction } from 'edge-core-js/types'
 import { parse } from 'uri-js'
 
 import { EngineEmitter, EngineEvent } from '../../plugin/makeEngineEmitter'
 import { PluginState } from '../../plugin/pluginState'
 import { removeItem } from '../../plugin/utils'
+import { NumbWalletInfo } from '../keymanager/cleaners'
 import { BlockBook, makeBlockBook } from '../network/BlockBook'
 import { INewTransactionResponse } from '../network/BlockBookAPI'
 import Deferred from '../network/Deferred'
@@ -21,7 +22,7 @@ interface ServerState {
 
 interface ServerStateConfig {
   engineStarted: boolean
-  walletInfo: EdgeWalletInfo
+  walletInfo: NumbWalletInfo
   pluginState: PluginState
   engineEmitter: EngineEmitter
   log: EdgeLog

--- a/src/common/utxobased/keymanager/cleaners.ts
+++ b/src/common/utxobased/keymanager/cleaners.ts
@@ -1,0 +1,189 @@
+import {
+  asCodec,
+  asMaybe,
+  asNumber,
+  asObject,
+  asOptional,
+  asString,
+  asValue,
+  Cleaner
+} from 'cleaners'
+import { EdgeWalletInfo } from 'edge-core-js/types'
+
+import {
+  asCurrencyFormat,
+  CurrencyFormat,
+  NetworkEnum,
+  PluginInfo
+} from '../../plugin/types'
+import { deriveXpubsFromKeys } from '../engine/utils'
+
+// Private key format are a strict subset of all currency formats
+const asPrivateKeyFormat = asValue('bip32', 'bip44', 'bip49')
+// Default to bip32 always for legacy reasons
+const asOptionalPrivateKeyFormat = asOptional(asPrivateKeyFormat, 'bip32')
+
+/**
+ * A cleaner for the private key format following the key-formats specification.
+ *
+ * (spec: https://github.com/EdgeApp/edge-core-js/blob/master/docs/key-formats.md)
+ */
+export interface PrivateKey {
+  coinType: number
+  format: CurrencyFormat
+  seed: string
+}
+export function asPrivateKey(
+  coinName: string,
+  coinType: number = 0
+): Cleaner<PrivateKey> {
+  return asCodec(
+    raw => {
+      if (raw == null || typeof raw !== 'object') {
+        throw new TypeError('Private keys must be objects')
+      }
+      const asCoinType = asOptional(asNumber, coinType)
+      return {
+        coinType: asCoinType(raw.coinType),
+        format: asOptionalPrivateKeyFormat(raw.format),
+        seed: asString(raw[`${coinName}Key`])
+      }
+    },
+    clean => {
+      const { coinType, format, seed } = clean
+      return {
+        coinType,
+        format,
+        [`${coinName}Key`]: seed
+      }
+    }
+  )
+}
+
+/**
+ * A cleaner for the public key format following the key-formats specification.
+ *
+ * (spec: https://github.com/EdgeApp/edge-core-js/blob/master/docs/key-formats.md)
+ */
+export interface PublicKey {
+  publicKeys: {
+    [format in CurrencyFormat]?: string
+  }
+}
+export const asPublicKey: Cleaner<PublicKey> = asObject({
+  publicKeys: asObject({
+    bip32: asOptional(asString),
+    bip44: asOptional(asString),
+    bip49: asOptional(asString),
+    bip84: asOptional(asString)
+  })
+})
+
+/**
+ * This utility returns a wallet's supported formats as specified in the
+ * key-formats specification.
+ */
+export const getSupportedFormats = (
+  format: CurrencyFormat
+): CurrencyFormat[] => {
+  switch (format) {
+    case 'bip32':
+      return ['bip32']
+    case 'bip44':
+      return ['bip44']
+    case 'bip49':
+      return ['bip49', 'bip84']
+    case 'bip84':
+      return ['bip49', 'bip84']
+    default:
+      throw new Error(`Unsupported format ${format}`)
+  }
+}
+
+/**
+ * A cleaner that desensitizes the walletInfo object, excluding sensitive
+ * keys (seed/mnemonic, sync key, data key, etc). By using this object type
+ * internally within the plugin, we can minimize risk.
+ *
+ * It also includes internal derived data (publicKey, format, supportedFormats, etc).
+ * This derived data is to be used internally within the plugin and saved to disk (publicKey).
+ */
+export interface NumbWalletInfo {
+  id: string
+  type: string
+  keys: {
+    format: CurrencyFormat
+    supportedFormats: CurrencyFormat[]
+    publicKey: PublicKey
+  }
+}
+export const asNumbWalletInfo = (
+  pluginInfo: PluginInfo
+): Cleaner<NumbWalletInfo> => {
+  return (walletInfo: EdgeWalletInfo): NumbWalletInfo => {
+    const { engineInfo, coinInfo } = pluginInfo
+    const { id, type } = walletInfo
+
+    const asCurrencyPrivateKey = asPrivateKey(coinInfo.name, coinInfo.coinType)
+
+    const publicKey = asMaybe(asPublicKey)(walletInfo.keys)
+    if (publicKey != null) {
+      const formats = Object.entries(publicKey.publicKeys)
+        // Filter out undefined values in the entries because cleaners allow
+        // undefined values for optional fields.
+        .filter(([, value]) => value != null)
+        // Map to the entry's key as a currency format
+        .map(([format]) => asMaybe(asCurrencyFormat)(format))
+        // Filter out any formats that didn't pass the cleaner assertion
+        .filter(
+          (format?: CurrencyFormat): format is CurrencyFormat => format != null
+        )
+
+      if (formats.length === 0) {
+        throw new Error('Missing wallet public keys')
+      }
+
+      // Search the engineInfo's formats array for the first format that exists
+      // in the publicKey data.
+      // If there is not defined formats in the engineInfo, fallback to the first
+      // format in the publicKey after sorting alphabetically.
+      const format =
+        (engineInfo.formats != null && engineInfo.formats.length > 0
+          ? engineInfo.formats.find(format => formats.includes(format))
+          : undefined) ??
+        formats.sort((a, b) => (a === b ? 0 : a > b ? 1 : -1))[0]
+
+      return {
+        id,
+        type,
+        keys: {
+          format,
+          supportedFormats: formats,
+          publicKey
+        }
+      }
+    }
+
+    const privateKey = asMaybe(asCurrencyPrivateKey)(walletInfo.keys)
+    if (privateKey != null) {
+      const publicKey = deriveXpubsFromKeys({
+        privateKey,
+        coin: coinInfo.name,
+        network: engineInfo.networkType ?? NetworkEnum.Mainnet
+      })
+
+      return {
+        id,
+        type,
+        keys: {
+          format: privateKey.format,
+          supportedFormats: getSupportedFormats(privateKey.format),
+          publicKey: { publicKeys: publicKey }
+        }
+      }
+    }
+
+    // If we get here, nothing matched:
+    throw new Error('Either a public or private key are required')
+  }
+}

--- a/test/common/utxobased/engine/UtxoWalletTools.spec.ts
+++ b/test/common/utxobased/engine/UtxoWalletTools.spec.ts
@@ -5,20 +5,12 @@ import { makeUtxoWalletTools } from '../../../../src/common/utxobased/engine/mak
 
 describe('wallet tools tests', () => {
   const walletTools = makeUtxoWalletTools({
-    keys: {
-      format: 'bip49',
-      bitcoinKey:
-        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
-      coinType: 0,
-      dataKey: 'uU0scsGxX1IWo4D4v8oB0T+caUrYibGwBjHrR5xeoK0=',
-      syncKey: 'PFzlVyzztuA/QoSS/m9jHkvPv1s=',
-      bitcoinXpub: {
+    publicKey: {
+      publicKeys: {
         bip49:
-          'ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP'
-      },
-      bitcoinXpriv: {
-        bip49:
-          'yprvAHwhK6RbpuS3dgCYHM5jc2ZvEKd7Bi61u9FVhYMpgMSuZS613T1xxQeKTffhrHY79hZ5PsskBjcc6C2V7DrnsMsNaGDaWev3GLRQRgV7hxF'
+          'ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP',
+        bip84:
+          'zpub6qmK2GdQoxXphTU8DjQNBFc9xKc3XnoNBUhKHKfKchMmVLENqeVn8GcwL9ThKYme2Qqnvq8RSrJh2PkpPGhy5rXmizkRBZ7naCd33hHSpaN'
       }
     },
     coin: 'bitcoin',
@@ -47,9 +39,8 @@ describe('wallet tools tests', () => {
 
 describe('wallet tools wif test', () => {
   const walletTools = makeUtxoWalletTools({
-    keys: {
-      wifKeys: ['L2uPYXe17xSTqbCjZvL2DsyXPCbXspvcu5mHLDYUgzdUbZGSKrSr']
-    },
+    publicKey: {} as any,
+    wifKeys: ['L2uPYXe17xSTqbCjZvL2DsyXPCbXspvcu5mHLDYUgzdUbZGSKrSr'],
     coin: 'bitcoin',
     network: NetworkEnum.Mainnet
   })


### PR DESCRIPTION
Re-implement `derivePublicKey` to follow `edge-core-js` key-formats spec

- Add PrivateKey and PublicKey types and asPrivateKey and asPublicKey
cleaners for internal use and documentation.
- Desensitize public keys returned by derivePublicKey using the cleaners.
- Modify util functions to always include segwit and wrapped-segwit
formats together, following the spec.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201256727099457