### PR TITLE
Sam/Fix/Hasty Refill Servers

### DIFF
--- a/src/common/utxobased/engine/makeServerStates.ts
+++ b/src/common/utxobased/engine/makeServerStates.ts
@@ -377,8 +377,6 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
     return serverStates[uri].blockHeight
   }
 
-  refillServers()
-
   return {
     setPickNextTaskCB,
     stop,


### PR DESCRIPTION
This hasty invocation side-steps the proper invocation flow beginning
with the `startEngine` method.