### PR TITLE
Use yarn to invoke precommit hook script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run precommit"
+      "pre-commit": "yarn precommit"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
This is a necessary change to avoid an error caused after changing
yarn config --ignore-scripts=true. Apparently using NPM for the hook
after making this change causing some weird conflicts between which
version of node yarn is using over NPM.