### PR TITLE
Dogecoin: Add min relay fee rate

### DIFF
--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -11,6 +11,7 @@ import {
 
 import { IUTXO } from '../utxobased/db/types'
 import { ScriptTemplates } from '../utxobased/info/scriptTemplates/types'
+import { UtxoPicker } from '../utxobased/keymanager/utxopicker'
 import { EngineEmitter } from './makeEngineEmitter'
 import { PluginState } from './pluginState'
 
@@ -74,6 +75,7 @@ export interface CoinInfo {
     network: BitcoinJSNetwork
   ) => bip32.BIP32Interface
   bip32FromSeedFunc?: (seed: Buffer) => bip32.BIP32Interface
+  utxoPicker?: UtxoPicker
   mainnetConstants: CoinPrefixes
   // by default should contain the bitcoin mainnet constants, useful for networks were multiple constants were in use.
   legacyConstants?: CoinPrefixes

--- a/src/common/utxobased/info/dogecoin.ts
+++ b/src/common/utxobased/info/dogecoin.ts
@@ -1,6 +1,7 @@
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { CoinInfo, EngineInfo, PluginInfo } from '../../plugin/types'
+import { makeDogeUtxoPicker } from './utxoPickers/dogeUtxoPicker'
 
 const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'dogecoin',
@@ -43,7 +44,6 @@ const engineInfo: EngineInfo = {
   gapLimit: 10,
   defaultFee: 1000,
   feeUpdateInterval: 10000,
-  // minRelay: '???',
   simpleFeeSettings: {
     highFee: '526316',
     lowFee: '526316',
@@ -58,6 +58,7 @@ export const coinInfo: CoinInfo = {
   name: 'dogecoin',
   segwit: false,
   coinType: 3,
+  utxoPicker: makeDogeUtxoPicker(),
   mainnetConstants: {
     messagePrefix: '\x18Dogecoin Signed Message:\n',
     wif: 0x9e,

--- a/src/common/utxobased/info/utxoPickers/dogeUtxoPicker.ts
+++ b/src/common/utxobased/info/utxoPickers/dogeUtxoPicker.ts
@@ -1,0 +1,34 @@
+import {
+  UtxoPicker,
+  UtxoPickerArgs,
+  UtxoPickerResult
+} from '../../keymanager/utxopicker'
+import { accumulative } from '../../keymanager/utxopicker/accumulative'
+import { forceUseUtxo } from '../../keymanager/utxopicker/forceUseUtxo'
+import { subtractFee } from '../../keymanager/utxopicker/subtractFee'
+
+export function makeDogeUtxoPicker(): UtxoPicker {
+  // According to https://github.com/dogecoin/dogecoin/discussions/2347 the min fee rate is now 0.001 Doge per Kilobyte
+  const minRelayFeeRate = 0.001 / 1000
+
+  return {
+    forceUseUtxo: (args: UtxoPickerArgs): UtxoPickerResult => {
+      if (args.feeRate < minRelayFeeRate) {
+        args.feeRate = minRelayFeeRate
+      }
+      return forceUseUtxo(args)
+    },
+    subtractFee: (args: UtxoPickerArgs): UtxoPickerResult => {
+      if (args.feeRate < minRelayFeeRate) {
+        args.feeRate = minRelayFeeRate
+      }
+      return subtractFee(args)
+    },
+    accumulative: (args: UtxoPickerArgs): UtxoPickerResult => {
+      if (args.feeRate < minRelayFeeRate) {
+        args.feeRate = minRelayFeeRate
+      }
+      return accumulative(args)
+    }
+  }
+}

--- a/src/common/utxobased/keymanager/keymanager.ts
+++ b/src/common/utxobased/keymanager/keymanager.ts
@@ -215,7 +215,7 @@ export interface MakeTxTarget {
   value: number
 }
 
-interface MakeTxReturn extends Required<utxopicker.Result> {
+interface MakeTxReturn extends Required<utxopicker.UtxoPickerResult> {
   psbtBase64: string
 }
 
@@ -949,12 +949,15 @@ export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
     coin: coin.name,
     network: args.network
   })
+
+  const utxoPicker = coin.utxoPicker ?? utxopicker.utxoPicker
+
   const utxopicking =
     args.forceUseUtxo != null ?? false
-      ? utxopicker.forceUseUtxo
+      ? utxoPicker.forceUseUtxo
       : args.subtractFee ?? false
-      ? utxopicker.subtractFee
-      : utxopicker.accumulative
+      ? utxoPicker.subtractFee
+      : utxoPicker.accumulative
   const result = utxopicking({
     utxos: mappedUtxos,
     useUtxos,

--- a/src/common/utxobased/keymanager/utxopicker.ts
+++ b/src/common/utxobased/keymanager/utxopicker.ts
@@ -1,4 +1,17 @@
+import { accumulative } from './utxopicker/accumulative'
+import { forceUseUtxo } from './utxopicker/forceUseUtxo'
+import { subtractFee } from './utxopicker/subtractFee'
+import { UtxoPickingFunc } from './utxopicker/types'
 export * from './utxopicker/types'
-export * from './utxopicker/accumulative'
-export * from './utxopicker/subtractFee'
-export * from './utxopicker/forceUseUtxo'
+
+export interface UtxoPicker {
+  forceUseUtxo: UtxoPickingFunc
+  subtractFee: UtxoPickingFunc
+  accumulative: UtxoPickingFunc
+}
+
+export const utxoPicker: UtxoPicker = {
+  forceUseUtxo,
+  subtractFee,
+  accumulative
+}

--- a/src/common/utxobased/keymanager/utxopicker/accumulative.ts
+++ b/src/common/utxobased/keymanager/utxopicker/accumulative.ts
@@ -1,9 +1,9 @@
-import { Output, Result, UTXO, UtxoPickerArgs } from './types'
+import { Output, UTXO, UtxoPickerArgs, UtxoPickerResult } from './types'
 import * as utils from './utils'
 // add inputs until we reach or surpass the target value (or deplete)
 // worst-case: O(n)
 
-export function accumulative(args: UtxoPickerArgs): Result {
+export function accumulative(args: UtxoPickerArgs): UtxoPickerResult {
   const { utxos, targets, feeRate, changeScript } = args
 
   if (!isFinite(utils.uintOrNaN(feeRate))) {

--- a/src/common/utxobased/keymanager/utxopicker/forceUseUtxo.ts
+++ b/src/common/utxobased/keymanager/utxopicker/forceUseUtxo.ts
@@ -1,10 +1,10 @@
-import { Output, Result, UTXO, UtxoPickerArgs } from './types'
+import { Output, UTXO, UtxoPickerArgs, UtxoPickerResult } from './types'
 import * as utils from './utils'
 // implementation very similar to accumulative strategy
 // add inputs until we reach or surpass the target value (or deplete)
 // worst-case: O(n)
 
-export function forceUseUtxo(args: UtxoPickerArgs): Result {
+export function forceUseUtxo(args: UtxoPickerArgs): UtxoPickerResult {
   const { utxos, useUtxos, targets, feeRate, changeScript } = args
 
   if (!isFinite(utils.uintOrNaN(feeRate))) {

--- a/src/common/utxobased/keymanager/utxopicker/subtractFee.ts
+++ b/src/common/utxobased/keymanager/utxopicker/subtractFee.ts
@@ -1,7 +1,7 @@
-import { Output, Result, UtxoPickerArgs } from './types'
+import { Output, UtxoPickerArgs, UtxoPickerResult } from './types'
 import * as utils from './utils'
 
-export function subtractFee(args: UtxoPickerArgs): Result {
+export function subtractFee(args: UtxoPickerArgs): UtxoPickerResult {
   const { utxos, targets, feeRate } = args
 
   const outputs: Output[] = targets.map(target => ({

--- a/src/common/utxobased/keymanager/utxopicker/types.ts
+++ b/src/common/utxobased/keymanager/utxopicker/types.ts
@@ -31,9 +31,11 @@ export interface UtxoPickerArgs {
   changeScript: string
 }
 
-export interface Result {
+export interface UtxoPickerResult {
   inputs?: Input[]
   outputs?: Output[]
   changeUsed: boolean
   fee: number
 }
+
+export type UtxoPickingFunc = (args: UtxoPickerArgs) => UtxoPickerResult

--- a/src/common/utxobased/keymanager/utxopicker/utils.ts
+++ b/src/common/utxobased/keymanager/utxopicker/utils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-fallthrough */
 /* eslint-disable no-duplicate-case */
 import { ScriptTypeEnum } from '../keymanager'
-import { Input, Output, Result, UTXO } from './types'
+import { Input, Output, UTXO, UtxoPickerResult } from './types'
 
 const WITNESS_SCALE = 4
 const OP_CODE_VSIZE = WITNESS_SCALE - 1
@@ -123,7 +123,7 @@ export function finalize(
   outputs: Output[],
   feeRate: number,
   changeScript: string
-): Result {
+): UtxoPickerResult {
   const inValue = sumOrNaN(inputs)
   const outValue = sumOrNaN(outputs)
   let fee = feeRate * transactionBytes(inputs, outputs)


### PR DESCRIPTION
Dogecoin has a min relay fee of 0.001 Doge / KByte according to their newest fee scheme described in
https://github.com/dogecoin/dogecoin/discussions/2347 . Enforce this by adding a fee checker function to the CoiInfo.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201274042339100