### PR TITLE
Fix broken reconnect for makeServerStates

### DIFF
--- a/src/common/utxobased/engine/makeServerStates.ts
+++ b/src/common/utxobased/engine/makeServerStates.ts
@@ -166,12 +166,12 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
 
   const reconnect = (): void => {
     if (isEngineOn) {
-      if (reconnectCounter < 5) reconnectCounter++
       log(`attempting server reconnect number ${reconnectCounter}`)
+      const reconnectionDelay = Math.max(5, reconnectCounter++) * 1000
       reconnectTimer = setTimeout(() => {
         clearTimeout(reconnectTimer)
         refillServers()
-      }, reconnectCounter * 1000)
+      }, reconnectionDelay)
     }
   }
 

--- a/src/common/utxobased/engine/makeServerStates.ts
+++ b/src/common/utxobased/engine/makeServerStates.ts
@@ -23,7 +23,6 @@ interface ServerState {
 
 interface ServerStateConfig {
   engineEmitter: EngineEmitter
-  engineStarted: boolean
   log: EdgeLog
   pluginInfo: PluginInfo
   pluginState: PluginState
@@ -61,18 +60,11 @@ interface Connections {
 }
 
 export function makeServerStates(config: ServerStateConfig): ServerStates {
-  const {
-    engineEmitter,
-    engineStarted,
-    log,
-    pluginInfo,
-    pluginState,
-    walletInfo
-  } = config
+  const { engineEmitter, log, pluginInfo, pluginState, walletInfo } = config
   log('Making server states')
 
   let serverStates: ServerStateCache = {}
-
+  let isEngineOn: boolean = true
   let connections: Connections = {}
   let serverList: string[] = []
   let reconnectCounter = 0
@@ -159,6 +151,7 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
   }
 
   const stop = async (): Promise<void> => {
+    isEngineOn = false
     log(`stopping server states`)
     removeIdFromQueue(walletInfo.id)
     clearTimeout(reconnectTimer)
@@ -172,7 +165,7 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
   }
 
   const reconnect = (): void => {
-    if (engineStarted) {
+    if (isEngineOn) {
       if (reconnectCounter < 5) reconnectCounter++
       log(`attempting server reconnect number ${reconnectCounter}`)
       reconnectTimer = setTimeout(() => {

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -149,19 +149,16 @@ export function makeUtxoEngineState(
     }
   }
 
-  const engineStarted = false
   const lock = new AwaitLock()
 
   const serverStates = makeServerStates({
-    pluginInfo,
-    engineStarted,
-    walletInfo,
-    pluginState,
     engineEmitter: emitter,
-    log
+    log,
+    pluginInfo,
+    pluginState,
+    walletInfo
   })
   const commonArgs: CommonArgs = {
-    engineStarted,
     pluginInfo,
     walletInfo,
     walletTools,
@@ -439,7 +436,6 @@ export function makeUtxoEngineState(
 }
 
 interface CommonArgs {
-  engineStarted: boolean
   pluginInfo: PluginInfo
   walletInfo: NumbWalletInfo
   walletTools: UTXOPluginWalletTools


### PR DESCRIPTION
Remove an unused `engineStarted` flag to fix the reconnect
implementation.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201681616582368