### PR TITLE
Fix `importPrivateKey` error cases and change spec

### DIFF
--- a/src/common/plugin/makeCurrencyTools.ts
+++ b/src/common/plugin/makeCurrencyTools.ts
@@ -54,27 +54,25 @@ export function makeCurrencyTools(
     },
 
     async importPrivateKey(
-      seedOrMnemonic: string,
+      entropy: string,
       opts?: JsonObject
     ): Promise<JsonObject> {
-      const isMnemonic = bip39.validateMnemonic(seedOrMnemonic)
-      // An Airbitz seed is a 256 bit base64 encoded string. Convert the string
-      // to a buffer and then count the bytes (32 bytes is 256 bits).
-      const isAirbitzSeed = Buffer.from(seedOrMnemonic, 'base64').length === 32
-      // An Airbitz seed is a 256 bit base64 encoded string. Convert the string
-      // to a buffer and then count the bytes (32 bytes is 256 bits).
-      const isHexSeed = Buffer.from(seedOrMnemonic, 'hex').length === 32
+      const isMnemonic = bip39.validateMnemonic(entropy)
 
-      if (isAirbitzSeed) {
-        throw new Error('Import for Airbitz seeds is unsupported.')
-      }
-      if (!isMnemonic && !isHexSeed) {
-        throw new Error('Invalid seed or mnemonic')
+      // Handle error case(s) if not a valid form of entropy
+      if (!isMnemonic) {
+        // An Airbitz seed is a 256 bit base64 encoded string. Convert the string
+        // to a buffer and then count the bytes (32 bytes is 256 bits).
+        const isAirbitzSeed = Buffer.from(entropy, 'base64').length === 32
+        if (isAirbitzSeed) {
+          throw new Error('Import for Airbitz seeds is unsupported.')
+        }
+        throw new Error('Invalid mnemonic')
       }
 
       const privateKey: PrivateKey = {
         imported: true,
-        seed: seedOrMnemonic,
+        seed: entropy,
         format: opts?.format ?? engineInfo.formats?.[0] ?? 'bip44',
         coinType: opts?.coinType ?? coinInfo.coinType ?? 0
       }

--- a/test/common/plugin/currencyPlugin.fixtures/common.ts
+++ b/test/common/plugin/currencyPlugin.fixtures/common.ts
@@ -71,6 +71,3 @@ export const key = [
 ]
 export const mnemonics = [mnemonic]
 export const airbitzSeeds = ['AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=']
-export const hexSeeds = [
-  '24ffe175a5644da63141b420ff7dcd079f226a333bee5780a8c7e37901adb771'
-]

--- a/test/common/plugin/currencyPlugin.fixtures/currencies/bitcoin.ts
+++ b/test/common/plugin/currencyPlugin.fixtures/currencies/bitcoin.ts
@@ -1,4 +1,4 @@
-import { airbitzSeeds, FixtureType, hexSeeds, key, mnemonics } from '../common'
+import { airbitzSeeds, FixtureType, key, mnemonics } from '../common'
 
 export const bitcoin: FixtureType = {
   pluginId: 'bitcoin',
@@ -19,10 +19,9 @@ export const bitcoin: FixtureType = {
     keys: { bitcoinKeyz: '12345678abcd' }
   },
   importKey: {
-    validKeys: [...mnemonics, ...hexSeeds],
+    validKeys: [...mnemonics],
     invalidKeys: [
       ...airbitzSeeds.map(seed => seed.slice(1)),
-      ...hexSeeds.map(seed => seed.slice(1)),
       ...mnemonics.map(mnemonic => mnemonic.split(' ').slice(1).join(' ')),
       'bunch of garbly gook !@#$%^&*()'
     ],

--- a/test/common/plugin/currencyPlugin.fixtures/currencies/bitcoincash.ts
+++ b/test/common/plugin/currencyPlugin.fixtures/currencies/bitcoincash.ts
@@ -1,4 +1,4 @@
-import { airbitzSeeds, FixtureType, hexSeeds, key, mnemonics } from '../common'
+import { airbitzSeeds, FixtureType, key, mnemonics } from '../common'
 
 export const bitcoincash: FixtureType = {
   pluginId: 'bitcoincash',
@@ -22,10 +22,9 @@ export const bitcoincash: FixtureType = {
     keys: { bitcoincashKeyz: '12345678abcd' }
   },
   importKey: {
-    validKeys: [...mnemonics, ...hexSeeds],
+    validKeys: [...mnemonics],
     invalidKeys: [
       ...airbitzSeeds.map(seed => seed.slice(1)),
-      ...hexSeeds.map(seed => seed.slice(1)),
       ...mnemonics.map(mnemonic => mnemonic.split(' ').slice(1).join(' ')),
       'bunch of garbly gook !@#$%^&*()'
     ],

--- a/test/common/plugin/currencyPlugin.fixtures/currencies/bitcoinsv.ts
+++ b/test/common/plugin/currencyPlugin.fixtures/currencies/bitcoinsv.ts
@@ -1,4 +1,4 @@
-import { airbitzSeeds, FixtureType, hexSeeds, key, mnemonics } from '../common'
+import { airbitzSeeds, FixtureType, key, mnemonics } from '../common'
 
 export const bitcoinsv: FixtureType = {
   pluginId: 'bitcoinsv',
@@ -22,10 +22,9 @@ export const bitcoinsv: FixtureType = {
     keys: { bitcoincashKeyz: '12345678abcd' }
   },
   importKey: {
-    validKeys: [...mnemonics, ...hexSeeds],
+    validKeys: [...mnemonics],
     invalidKeys: [
       ...airbitzSeeds.map(seed => seed.slice(1)),
-      ...hexSeeds.map(seed => seed.slice(1)),
       ...mnemonics.map(mnemonic => mnemonic.split(' ').slice(1).join(' ')),
       'bunch of garbly gook !@#$%^&*()'
     ],

--- a/test/common/plugin/currencyPlugin.fixtures/currencies/digibyte.ts
+++ b/test/common/plugin/currencyPlugin.fixtures/currencies/digibyte.ts
@@ -1,4 +1,4 @@
-import { airbitzSeeds, FixtureType, hexSeeds, key, mnemonics } from '../common'
+import { airbitzSeeds, FixtureType, key, mnemonics } from '../common'
 
 export const digibyte: FixtureType = {
   pluginId: 'digibyte',
@@ -22,10 +22,9 @@ export const digibyte: FixtureType = {
     keys: { digibyteKeyz: '12345678abcd' }
   },
   importKey: {
-    validKeys: [...mnemonics, ...hexSeeds],
+    validKeys: [...mnemonics],
     invalidKeys: [
       ...airbitzSeeds.map(seed => seed.slice(1)),
-      ...hexSeeds.map(seed => seed.slice(1)),
       ...mnemonics.map(mnemonic => mnemonic.split(' ').slice(1).join(' ')),
       'bunch of garbly gook !@#$%^&*()'
     ],

--- a/test/common/plugin/currencyPlugin.fixtures/currencies/feathercoin.ts
+++ b/test/common/plugin/currencyPlugin.fixtures/currencies/feathercoin.ts
@@ -1,4 +1,4 @@
-import { airbitzSeeds, FixtureType, hexSeeds, key, mnemonics } from '../common'
+import { airbitzSeeds, FixtureType, key, mnemonics } from '../common'
 
 export const feathercoin: FixtureType = {
   pluginId: 'feathercoin',
@@ -24,10 +24,9 @@ export const feathercoin: FixtureType = {
     keys: { feathercoinKeyz: '12345678abcd' }
   },
   importKey: {
-    validKeys: [...mnemonics, ...hexSeeds],
+    validKeys: [...mnemonics],
     invalidKeys: [
       ...airbitzSeeds.map(seed => seed.slice(1)),
-      ...hexSeeds.map(seed => seed.slice(1)),
       ...mnemonics.map(mnemonic => mnemonic.split(' ').slice(1).join(' ')),
       'bunch of garbly gook !@#$%^&*()'
     ],

--- a/test/common/plugin/currencyPlugin.fixtures/currencies/groestlcoin.ts
+++ b/test/common/plugin/currencyPlugin.fixtures/currencies/groestlcoin.ts
@@ -1,4 +1,4 @@
-import { airbitzSeeds, FixtureType, hexSeeds, key, mnemonics } from '../common'
+import { airbitzSeeds, FixtureType, key, mnemonics } from '../common'
 
 export const groestlcoin: FixtureType = {
   pluginId: 'groestlcoin',
@@ -22,10 +22,9 @@ export const groestlcoin: FixtureType = {
     keys: { groestlcoinKeyz: '12345678abcd' }
   },
   importKey: {
-    validKeys: [...mnemonics, ...hexSeeds],
+    validKeys: [...mnemonics],
     invalidKeys: [
       ...airbitzSeeds.map(seed => seed.slice(1)),
-      ...hexSeeds.map(seed => seed.slice(1)),
       ...mnemonics.map(mnemonic => mnemonic.split(' ').slice(1).join(' ')),
       'bunch of garbly gook !@#$%^&*()'
     ],

--- a/test/common/plugin/currencyPlugin.fixtures/currencies/litecoin.ts
+++ b/test/common/plugin/currencyPlugin.fixtures/currencies/litecoin.ts
@@ -1,4 +1,4 @@
-import { airbitzSeeds, FixtureType, hexSeeds, key, mnemonics } from '../common'
+import { airbitzSeeds, FixtureType, key, mnemonics } from '../common'
 
 export const litecoin: FixtureType = {
   pluginId: 'litecoin',
@@ -22,10 +22,9 @@ export const litecoin: FixtureType = {
     keys: { litecoinKeyz: '12345678abcd' }
   },
   importKey: {
-    validKeys: [...mnemonics, ...hexSeeds],
+    validKeys: [...mnemonics],
     invalidKeys: [
       ...airbitzSeeds.map(seed => seed.slice(1)),
-      ...hexSeeds.map(seed => seed.slice(1)),
       ...mnemonics.map(mnemonic => mnemonic.split(' ').slice(1).join(' ')),
       'bunch of garbly gook !@#$%^&*()'
     ],

--- a/test/common/plugin/currencyPlugin.fixtures/currencies/smartcash.ts
+++ b/test/common/plugin/currencyPlugin.fixtures/currencies/smartcash.ts
@@ -1,4 +1,4 @@
-import { airbitzSeeds, FixtureType, hexSeeds, key, mnemonics } from '../common'
+import { airbitzSeeds, FixtureType, key, mnemonics } from '../common'
 
 export const smartcash: FixtureType = {
   pluginId: 'smartcash',
@@ -22,10 +22,9 @@ export const smartcash: FixtureType = {
     keys: { smartcashKeyz: '12345678abcd' }
   },
   importKey: {
-    validKeys: [...mnemonics, ...hexSeeds],
+    validKeys: [...mnemonics],
     invalidKeys: [
       ...airbitzSeeds.map(seed => seed.slice(1)),
-      ...hexSeeds.map(seed => seed.slice(1)),
       ...mnemonics.map(mnemonic => mnemonic.split(' ').slice(1).join(' ')),
       'bunch of garbly gook !@#$%^&*()'
     ],

--- a/test/common/plugin/currencyPlugin.fixtures/currencies/zcoin.ts
+++ b/test/common/plugin/currencyPlugin.fixtures/currencies/zcoin.ts
@@ -1,4 +1,4 @@
-import { airbitzSeeds, FixtureType, hexSeeds, key, mnemonics } from '../common'
+import { airbitzSeeds, FixtureType, key, mnemonics } from '../common'
 
 export const zcoin: FixtureType = {
   pluginId: 'zcoin',
@@ -22,10 +22,9 @@ export const zcoin: FixtureType = {
     keys: { zcoinKeyz: '12345678abcd' }
   },
   importKey: {
-    validKeys: [...mnemonics, ...hexSeeds],
+    validKeys: [...mnemonics],
     invalidKeys: [
       ...airbitzSeeds.map(seed => seed.slice(1)),
-      ...hexSeeds.map(seed => seed.slice(1)),
       ...mnemonics.map(mnemonic => mnemonic.split(' ').slice(1).join(' ')),
       'bunch of garbly gook !@#$%^&*()'
     ],


### PR DESCRIPTION
Only support mnemonic phrases for imports and change the error
handling flow to make the business logic more obvious; remove support
for "hex seeds".