### PR TITLE
Export `setMemletConfig`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,5 @@ if (typeof window !== 'undefined') {
 }
 
 export default plugins
+
+export { setMemletConfig } from 'memlet'


### PR DESCRIPTION
This allows for the GUI to use the `setMemletConfig` for the correct
module.
This is a problem if the GUI happens to use a different memlet
dependency than what the plugins use.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201914705276091