### PR TITLE
Index transaction data after the transaction is saved

### DIFF
--- a/src/common/utxobased/db/makeProcessor.ts
+++ b/src/common/utxobased/db/makeProcessor.ts
@@ -256,12 +256,7 @@ export async function makeProcessor(
           .query('', [tx.txid])
           .then(transactions => transactions[0])
           .catch(_ => undefined)
-        if (processorTx == null) {
-          await tables.txIdsByDate.insert('', {
-            txid: tx.txid,
-            date: tx.date
-          })
-        }
+
         // Use the existing transaction if it does exist.
         const transaction = processorTx ?? tx
 
@@ -313,6 +308,14 @@ export async function makeProcessor(
 
         // Save transaction
         await tables.txById.insert('', transaction.txid, transaction)
+
+        // Save index entry only for first transaction insert
+        if (processorTx == null) {
+          await tables.txIdsByDate.insert('', {
+            txid: tx.txid,
+            date: tx.date
+          })
+        }
 
         return transaction
       })


### PR DESCRIPTION
This remove the requirement for `saveTransaction` to be atomic; it can
safely be interrupted.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201924982952951