### PR TITLE
Build feeRateUsed for frontend consumption

### DIFF
--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -253,10 +253,9 @@ export async function makeUtxoEngine(
           async (tx: IProcessorTransaction) =>
             await toEdgeTransaction({
               tx,
-              currencyCode: currencyInfo.currencyCode,
               walletTools,
               processor,
-              engineInfo
+              pluginInfo
             })
         )
       )

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -647,20 +647,13 @@ interface TransactionChangedArgs {
 export const transactionChanged = async (
   args: TransactionChangedArgs
 ): Promise<void> => {
-  const {
-    emitter,
-    walletTools,
-    processor,
-    pluginInfo: { currencyInfo, engineInfo },
-    tx
-  } = args
+  const { emitter, walletTools, processor, pluginInfo, tx } = args
   emitter.emit(EngineEvent.TRANSACTIONS_CHANGED, [
     await toEdgeTransaction({
       tx,
-      currencyCode: currencyInfo.currencyCode,
       walletTools,
       processor,
-      engineInfo
+      pluginInfo
     })
   ])
 }


### PR DESCRIPTION
Computes the sat/vByte used for a given transaction, and adds
`feeRateUsed` object to the `EdgeTransaction` output.

The frontend should be able to render the transaction fee information
for received transactions. However, it only works for new transactions.
To make existing transactions also display the UTXO fees, changes need
to be made in the `edge-core-js` repository to modify the cache fetching
and merging logics.

See associated branch: https://github.com/EdgeApp/edge-core-js/tree/xipu/btc-receive-fee

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1200681747993915
![Simulator Screen Shot - iPhone 12 - 2022-06-28 at 13 54 00](https://user-images.githubusercontent.com/23110002/176306653-ba9b2e5c-4741-48c7-84c3-d21d257dd588.png)