### PR TITLE
Add OP_RETURN to outputs

### DIFF
--- a/src/common/plugin/makeCurrencyTools.ts
+++ b/src/common/plugin/makeCurrencyTools.ts
@@ -5,6 +5,7 @@ import {
   EdgeCurrencyTools,
   EdgeEncodeUri,
   EdgeIo,
+  EdgeMemoRules,
   EdgeMetaToken,
   EdgeWalletInfo,
   JsonObject
@@ -12,7 +13,7 @@ import {
 import * as uri from 'uri-js'
 import urlParse from 'url-parse'
 
-import { parsePathname } from '../utxobased/engine/utils'
+import { parsePathname, validateMemo } from '../utxobased/engine/utils'
 import {
   asNumbWalletInfo,
   asPrivateKey,
@@ -78,6 +79,10 @@ export function makeCurrencyTools(
       }
 
       return wasCurrencyPrivateKey(privateKey)
+    },
+
+    async validateMemo(memo: string): Promise<EdgeMemoRules> {
+      return validateMemo(memo)
     },
 
     async derivePublicKey(walletInfo: EdgeWalletInfo): Promise<JsonObject> {

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -311,7 +311,8 @@ export async function makeUtxoEngine(
             )
             targets.push({
               address: publicAddress,
-              value: parseInt(target.nativeAmount)
+              value: parseInt(target.nativeAmount),
+              memo: target.memo
             })
           }
         } else {
@@ -323,7 +324,8 @@ export async function makeUtxoEngine(
           }
           targets.push({
             address: target.publicAddress,
-            value: parseInt(target.nativeAmount)
+            value: parseInt(target.nativeAmount),
+            memo: target.memo
           })
         }
       }

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -376,7 +376,7 @@ export async function makeUtxoEngine(
       log.warn(`spend: Using fee rate ${feeRate} sat/B`)
       const subtractFee =
         options?.subtractFee != null ? options.subtractFee : false
-      const tx = await makeTx({
+      const tx = makeTx({
         utxos,
         forceUseUtxo: maxUtxo != null ? [maxUtxo] : [],
         targets,

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -297,7 +297,10 @@ export async function makeUtxoEngine(
       let targets: MakeTxTarget[] = []
       const ourReceiveAddresses: string[] = []
       for (const target of spendTargets) {
-        if (target.publicAddress == null || target.nativeAmount == null) {
+        if (
+          target.memo == null &&
+          (target.publicAddress == null || target.nativeAmount == null)
+        ) {
           throw new Error('Invalid spend target')
         }
 
@@ -311,20 +314,28 @@ export async function makeUtxoEngine(
             )
             targets.push({
               address: publicAddress,
-              value: parseInt(target.nativeAmount),
+              value:
+                target.nativeAmount == null
+                  ? undefined
+                  : parseInt(target.nativeAmount),
               memo: target.memo
             })
           }
         } else {
-          const scriptPubkey = walletTools.addressToScriptPubkey(
-            target.publicAddress
-          )
-          if (processor.fetchAddress(scriptPubkey) != null) {
-            ourReceiveAddresses.push(target.publicAddress)
+          if (target.publicAddress != null) {
+            const scriptPubkey = walletTools.addressToScriptPubkey(
+              target.publicAddress
+            )
+            if (processor.fetchAddress(scriptPubkey) != null) {
+              ourReceiveAddresses.push(target.publicAddress)
+            }
           }
           targets.push({
             address: target.publicAddress,
-            value: parseInt(target.nativeAmount),
+            value:
+              target.nativeAmount == null
+                ? undefined
+                : parseInt(target.nativeAmount),
             memo: target.memo
           })
         }

--- a/src/common/utxobased/engine/utils.ts
+++ b/src/common/utxobased/engine/utils.ts
@@ -1,6 +1,6 @@
 import * as bs from 'biggystring'
 import { Disklet } from 'disklet'
-import { EdgeParsedUri } from 'edge-core-js/types'
+import { EdgeMemoRules, EdgeParsedUri } from 'edge-core-js/types'
 
 import { CurrencyFormat } from '../../plugin/types'
 import { IUTXO } from '../db/types'
@@ -33,6 +33,19 @@ export const getCurrencyFormatFromPurposeType = (
     case BIP43PurposeTypeEnum.Segwit:
       return 'bip84'
   }
+}
+
+// Expect memo to be a hex string
+export const validateMemo = (memo: string): EdgeMemoRules => {
+  const result: EdgeMemoRules = {
+    passed: true,
+    tooLarge: false
+  }
+  if (Math.ceil(memo.length / 2) > 80) {
+    result.passed = false
+    result.tooLarge = true
+  }
+  return result
 }
 
 export const getAddressTypeFromKeys = (

--- a/src/common/utxobased/keymanager/keymanager.ts
+++ b/src/common/utxobased/keymanager/keymanager.ts
@@ -827,7 +827,7 @@ export function signMessageBase64(message: string, privateKey: string): string {
     .toString('base64')
 }
 
-export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
+export function makeTx(args: MakeTxArgs): MakeTxReturn {
   let sequence = 0xffffffff
   if (args.setRBF) {
     sequence -= 2
@@ -921,7 +921,7 @@ export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
     if (target.memo != null) {
       const memoHex = Buffer.from(target.memo, 'utf8').toString('hex')
       // check if hex string is within 80 bytes
-      const validatedMemo = await validateMemo(memoHex)
+      const validatedMemo = validateMemo(memoHex)
       if (!validatedMemo.passed) {
         throw new Error('Memo size exceeds 80 bytes')
       }

--- a/src/common/utxobased/keymanager/keymanager.ts
+++ b/src/common/utxobased/keymanager/keymanager.ts
@@ -10,6 +10,7 @@ import { indexAtProtected } from '../../../util/indexAtProtected'
 import { undefinedIfEmptyString } from '../../../util/undefinedIfEmptyString'
 import { AddressPath, CoinInfo, CoinPrefixes } from '../../plugin/types'
 import { IUTXO } from '../db/types'
+import { validateMemo } from '../engine/utils'
 import { ScriptTemplate } from '../info/scriptTemplates/types'
 import { sortInputs, sortOutputs } from './bip69'
 import {
@@ -191,6 +192,7 @@ export interface MakeTxArgs {
 export interface MakeTxTarget {
   address: string
   value: number
+  memo?: string | null
 }
 
 interface MakeTxReturn extends Required<utxopicker.UtxoPickerResult> {
@@ -903,16 +905,36 @@ export async function makeTx(args: MakeTxArgs): Promise<MakeTxReturn> {
     if (!forceUsage) mappedUtxos.push(input)
   }
 
-  const targets: utxopicker.Target[] = args.targets.map(target => {
-    const script = addressToScriptPubkey({
-      address: target.address,
-      coin: coin.name
-    })
-    return {
-      script,
-      value: target.value
+  const targets: utxopicker.Target[] = []
+  for (const target of args.targets) {
+    if (target.address != null && target.value != null) {
+      const script = addressToScriptPubkey({
+        address: target.address,
+        coin: coin.name
+      })
+      targets.push({
+        script,
+        value: target.value
+      })
     }
-  })
+
+    if (target.memo != null) {
+      const memoHex = Buffer.from(target.memo, 'utf8').toString('hex')
+      // check if hex string is within 80 bytes
+      const validatedMemo = await validateMemo(memoHex)
+      if (!validatedMemo.passed) {
+        throw new Error('Memo size exceeds 80 bytes')
+      }
+      const script = bitcoin.script
+        .compile([bitcoin.opcodes.OP_RETURN, Buffer.from(target.memo, 'utf8')])
+        .toString('hex')
+      targets.push({
+        script,
+        value: 0
+      })
+    }
+  }
+
   const changeScript = addressToScriptPubkey({
     address: args.freshChangeAddress,
     coin: coin.name

--- a/src/common/utxobased/keymanager/keymanager.ts
+++ b/src/common/utxobased/keymanager/keymanager.ts
@@ -190,8 +190,8 @@ export interface MakeTxArgs {
 }
 
 export interface MakeTxTarget {
-  address: string
-  value: number
+  address?: string
+  value?: number
   memo?: string | null
 }
 

--- a/test/common/utxobased/keymanager/coins/bitcoincashtransactiontest.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcoincashtransactiontest.spec.ts
@@ -38,7 +38,7 @@ describe('bitcoincash transaction creation and signing test', () => {
       This deserialization is not required in the usual form from the caller.
       It is enough to pass the full previous rawtransaction.
     */
-    const { psbtBase64 } = await makeTx({
+    const { psbtBase64 } = makeTx({
       forceUseUtxo: [],
       coin: 'bitcoincash',
       currencyCode: 'BCH',
@@ -119,7 +119,7 @@ describe('bitcoincash replay protection transaction creation and signing test', 
       This deserialization is not required in the usual form from the caller.
       It is enough to pass the full previous rawtransaction.
     */
-    const { psbtBase64 } = await makeTx({
+    const { psbtBase64 } = makeTx({
       forceUseUtxo: [],
       coin: 'bitcoincash',
       currencyCode: 'BCH',

--- a/test/common/utxobased/keymanager/coins/bitcointransactiontest.spec.ts
+++ b/test/common/utxobased/keymanager/coins/bitcointransactiontest.spec.ts
@@ -150,7 +150,7 @@ describe('bitcoin transaction creation and signing test', function () {
       This deserialization is not required in the usual form from the caller.
       It is enough to pass the full previous rawtransaction.
     */
-    const { psbtBase64 } = await makeTx({
+    const { psbtBase64 } = makeTx({
       forceUseUtxo: [],
       coin: 'bitcoin',
       currencyCode: 'BTC',
@@ -204,7 +204,7 @@ describe('bitcoin transaction creation and signing test', function () {
   })
 
   it('create a legacy tx with segwit outputs, then create another tx consuming these outputs', async () => {
-    const { psbtBase64 } = await makeTx({
+    const { psbtBase64 } = makeTx({
       forceUseUtxo: [],
       coin: 'bitcoin',
       currencyCode: 'BTC',
@@ -269,7 +269,7 @@ describe('bitcoin transaction creation and signing test', function () {
       script: segwitScriptPubkey,
       vout: i
     })
-    const { psbtBase64 } = await makeTx({
+    const { psbtBase64 } = makeTx({
       forceUseUtxo: [getUtxo(0), getUtxo(1), getUtxo(2, '0')],
       coin: 'bitcoin',
       currencyCode: 'BTC',
@@ -343,7 +343,7 @@ describe('bitcoin transaction creation and signing test', function () {
       value: 200
     }
 
-    const { psbtBase64 } = await makeTx({
+    const { psbtBase64 } = makeTx({
       forceUseUtxo: [utxoLegacy, utxoSegwit, utxoWrappedSegwit],
       coin: 'bitcoin',
       currencyCode: 'BTC',
@@ -394,7 +394,7 @@ describe('bitcoin transaction creation and signing test', function () {
 
     const target: MakeTxTarget = { address, value: 200 }
 
-    const { psbtBase64 } = await makeTx({
+    const { psbtBase64 } = makeTx({
       forceUseUtxo: [],
       coin: 'bitcoin',
       currencyCode: 'BTC',
@@ -427,7 +427,7 @@ describe('bitcoin transaction creation and signing test', function () {
         vout: i
       }))
 
-    const { psbtBase64: psbtBase64Multi } = await makeTx({
+    const { psbtBase64: psbtBase64Multi } = makeTx({
       forceUseUtxo: [],
       coin: 'bitcoin',
       currencyCode: 'BTC',

--- a/test/common/utxobased/keymanager/coins/groestlcointransactiontest.spec.ts
+++ b/test/common/utxobased/keymanager/coins/groestlcointransactiontest.spec.ts
@@ -32,7 +32,7 @@ describe('groestlcoin transaction creation and signing test', function () {
       This deserialization is not required in the usual form from the caller.
       It is enough to pass the full previous rawtransaction.
     */
-    const { psbtBase64 } = await makeTx({
+    const { psbtBase64 } = makeTx({
       forceUseUtxo: [],
       coin: 'groestlcoin',
       currencyCode: 'GRS',


### PR DESCRIPTION
The added logics check if the `target` has memo, if so, we know it's 
an `OP_RETURN` script. Then, we use the altcoin.js lib to construct
an `OP_RETURN` script value.

However, if the memo (in hex string) exceeds the 80 bytes limitation
for `OP_RETURN` script, we throw.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201934696774649