### PR TITLE
Filter for empty strings in SpendTarget memo

### DIFF
--- a/src/common/utxobased/keymanager/keymanager.ts
+++ b/src/common/utxobased/keymanager/keymanager.ts
@@ -920,7 +920,7 @@ export function makeTx(args: MakeTxArgs): MakeTxReturn {
       })
     }
 
-    if (target.memo != null) {
+    if (target.memo != null && target.memo !== '') {
       const memoHex = Buffer.from(target.memo, 'utf8').toString('hex')
       // check if hex string is within 80 bytes
       const validatedMemo = validateMemo(memoHex)


### PR DESCRIPTION
We include strings with only space characters as "empty strings".

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202829098136863