### PR TITLE
Add getTransactionSpecific endpoint support

### DIFF
--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -10,7 +10,7 @@ import {
   EdgeWalletInfo
 } from 'edge-core-js/types'
 
-import { IUTXO } from '../utxobased/db/types'
+import { IProcessorTransaction, IUTXO } from '../utxobased/db/types'
 import { ScriptTemplates } from '../utxobased/info/scriptTemplates/types'
 import { UtxoPicker } from '../utxobased/keymanager/utxopicker'
 import { EngineEmitter } from './makeEngineEmitter'
@@ -56,6 +56,11 @@ export interface EngineInfo {
   scriptTemplates?: ScriptTemplates
   // Codec Cleaners
   asBlockbookAddress?: Cleaner<string>
+  // Coin specific transaction handling
+  txSpecificHandling?: (
+    tx: IProcessorTransaction,
+    specialTx: unknown
+  ) => IProcessorTransaction
 }
 
 /**

--- a/src/common/utxobased/db/Models/ProcessorTransaction.ts
+++ b/src/common/utxobased/db/Models/ProcessorTransaction.ts
@@ -117,6 +117,7 @@ export const toEdgeTransaction = async (
     currencyCode: currencyInfo.currencyCode,
     txid: tx.txid,
     blockHeight: tx.blockHeight,
+    confirmations: tx.confirmations,
     date: tx.date,
     nativeAmount: tx.ourAmount,
     networkFee: tx.fees,

--- a/src/common/utxobased/db/types.ts
+++ b/src/common/utxobased/db/types.ts
@@ -46,6 +46,7 @@ export interface IProcessorTransaction {
   txid: string
   hex: string
   blockHeight: number
+  confirmations?: 'confirmed' | 'unconfirmed' | 'dropped' | number
   date: number
   fees: string
   inputs: ITransactionInput[]

--- a/src/common/utxobased/info/dash.ts
+++ b/src/common/utxobased/info/dash.ts
@@ -1,6 +1,8 @@
+import { asBoolean, asMaybe, asObject, asOptional } from 'cleaners'
 import { EdgeCurrencyInfo } from 'edge-core-js/types'
 
 import { CoinInfo, EngineInfo, PluginInfo } from '../../plugin/types'
+import { IProcessorTransaction } from '../db/types'
 
 const currencyInfo: EdgeCurrencyInfo = {
   pluginId: 'dash',
@@ -52,6 +54,21 @@ const engineInfo: EngineInfo = {
     standardFeeHigh: '200',
     standardFeeLowAmount: '20000000',
     standardFeeHighAmount: '981000000'
+  },
+  txSpecificHandling: (
+    tx: IProcessorTransaction,
+    txSpecific: unknown
+  ): IProcessorTransaction => {
+    const asDashTransactionSpecific = asObject({
+      instantlock: asOptional(asBoolean)
+    })
+    const cleanedTxSpecific = asMaybe(asDashTransactionSpecific)(txSpecific)
+
+    if (cleanedTxSpecific?.instantlock === true) {
+      tx.confirmations = 'confirmed'
+    }
+
+    return tx
   }
 }
 

--- a/src/common/utxobased/network/BlockBookAPI.ts
+++ b/src/common/utxobased/network/BlockBookAPI.ts
@@ -6,6 +6,7 @@ import {
   asObject,
   asOptional,
   asString,
+  asUnknown,
   Cleaner,
   uncleaner
 } from 'cleaners'
@@ -210,6 +211,17 @@ export const transactionMessage = (
 })
 export type TransactionResponse = BlockbookTransaction
 export const asTransactionResponse = asBlockbookTransaction
+
+/**
+ * Get Transaction Specific
+ */
+export const transactionMessageSpecific = (
+  hash: string
+): BlockbookTask<unknown> => ({
+  method: 'getTransactionSpecific',
+  params: { txid: hash },
+  cleaner: asBlockbookResponse(asUnknown)
+})
 
 /**
  * Send Transaction


### PR DESCRIPTION
The "transaction specific" blockbook functionality include additional data that is unique to the network the transaction is on. For example, this is where Dash's InstantSend boolean is returned since that wouldn't be appropriate in the general transaction endpoint. 

This PR adds the following:
1) Add transaction specific functionality
2) Use new endpoint and the core's confirmation API to update pending InstantSend transactions as confirmed
3) Add logic to avoid the extra query and engine callback if the plugin doesn't require the new method

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201425242712367