### PR TITLE
Reduce the KEEP_ALIVE_MS blockbook server heartbeat time

### DIFF
--- a/src/common/utxobased/network/Socket.ts
+++ b/src/common/utxobased/network/Socket.ts
@@ -10,7 +10,7 @@ import { InnerSocket, InnerSocketCallbacks, ReadyState } from './types'
 import { setupBrowser } from './windowWS'
 
 const TIMER_SLACK = 500
-const KEEP_ALIVE_MS = 60000 // interval at which we keep the connection alive
+const KEEP_ALIVE_MS = 50000 // interval at which we keep the connection alive
 const WAKE_UP_MS = 5000 // interval at which we wakeUp and potentially onQueueSpace
 
 export type OnFailHandler = (error: Error) => void


### PR DESCRIPTION
This is to prevent a race condition where the timeout for some blockbook
server connection is the same as the heartbeat; our heartbeat time must
be lower than the server timeout.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203495785463912