### PR TITLE
Only handle private keys within privileged functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "bs58smartcheck": "^2.0.4",
     "cleaners": "^0.3.12",
     "disklet": "^0.4.5",
-    "edge-core-js": "^0.19.37",
+    "edge-core-js": "^0.19.48",
     "edge-sync-client": "^0.2.7",
     "memlet": "^0.1.7",
     "uri-js": "^4.4.0",

--- a/src/common/plugin/makeCurrencyTools.ts
+++ b/src/common/plugin/makeCurrencyTools.ts
@@ -105,6 +105,8 @@ export function makeCurrencyTools(
     async derivePublicKey(
       unsafeWalletInfo: EdgeWalletInfo
     ): Promise<JsonObject> {
+      // Use the safety cleaner to derive the public keys from the
+      // unsafeWalletInfo which contains the private key.
       const safeWalletInfo = asCurrencySafeWalletInfo(unsafeWalletInfo)
       return safeWalletInfo.keys.publicKey
     },

--- a/src/common/plugin/makeCurrencyTools.ts
+++ b/src/common/plugin/makeCurrencyTools.ts
@@ -15,9 +15,9 @@ import urlParse from 'url-parse'
 
 import { parsePathname, validateMemo } from '../utxobased/engine/utils'
 import {
-  asNumbWalletInfo,
   asPrivateKey,
   asPublicKey,
+  asSafeWalletInfo,
   getSupportedFormats,
   inferPrivateKeyFormat,
   PrivateKey
@@ -38,7 +38,7 @@ export function makeCurrencyTools(
 
   const asCurrencyPrivateKey = asPrivateKey(coinInfo.name, coinInfo.coinType)
   const wasCurrencyPrivateKey = uncleaner(asCurrencyPrivateKey)
-  const asCurrencyNumbWalletInfo = asNumbWalletInfo(pluginInfo)
+  const asCurrencySafeWalletInfo = asSafeWalletInfo(pluginInfo)
 
   const fns: EdgeCurrencyTools = {
     async checkPublicKey(publicKeyData: JsonObject): Promise<boolean> {
@@ -102,9 +102,11 @@ export function makeCurrencyTools(
       return validateMemo(memo)
     },
 
-    async derivePublicKey(walletInfo: EdgeWalletInfo): Promise<JsonObject> {
-      const numbWalletInfo = asCurrencyNumbWalletInfo(walletInfo)
-      return numbWalletInfo.keys.publicKey
+    async derivePublicKey(
+      unsafeWalletInfo: EdgeWalletInfo
+    ): Promise<JsonObject> {
+      const safeWalletInfo = asCurrencySafeWalletInfo(unsafeWalletInfo)
+      return safeWalletInfo.keys.publicKey
     },
 
     async parseUri(uri: string): Promise<ExtendedParseUri> {

--- a/src/common/utxobased/engine/makeServerStates.ts
+++ b/src/common/utxobased/engine/makeServerStates.ts
@@ -5,7 +5,7 @@ import { EngineEmitter, EngineEvent } from '../../plugin/makeEngineEmitter'
 import { PluginState } from '../../plugin/pluginState'
 import { PluginInfo } from '../../plugin/types'
 import { removeItem } from '../../plugin/utils'
-import { NumbWalletInfo } from '../keymanager/cleaners'
+import { SafeWalletInfo } from '../keymanager/cleaners'
 import { BlockBook, makeBlockBook } from '../network/BlockBook'
 import { SubscribeAddressResponse } from '../network/BlockBookAPI'
 import Deferred from '../network/Deferred'
@@ -27,7 +27,7 @@ interface ServerStateConfig {
   log: EdgeLog
   pluginInfo: PluginInfo
   pluginState: PluginState
-  walletInfo: NumbWalletInfo
+  walletInfo: SafeWalletInfo
 }
 
 export interface ServerStates {

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -77,9 +77,11 @@ export async function makeUtxoEngine(
   })
 
   const asCurrencyPrivateKey = asPrivateKey(coinInfo.name, coinInfo.coinType)
-  // Private key may be missing for watch-only wallets
+  // Private key may be missing for read-only wallets
   const asMaybeCurrencyPrivateKey = asMaybe(asCurrencyPrivateKey)
-  // This walletInfo is desensitized and can be passed around over the original walletInfo
+
+  // This walletInfo will not contain private keys and should only contain the
+  // public keys and so can be passed around the plugin safely.
   const walletInfo = asSafeWalletInfo(pluginInfo)(config.walletInfo)
   const { privateKeyFormat, publicKey, walletFormats } = walletInfo.keys
 

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -122,7 +122,7 @@ export async function makeUtxoEngine(
     pluginState
   })
 
-  const fns: EdgeCurrencyEngine = {
+  const engine = {
     async startEngine(): Promise<void> {
       emitter.emit(
         EngineEvent.WALLET_BALANCE_CHANGED,
@@ -481,7 +481,7 @@ export async function makeUtxoEngine(
 
     async resyncBlockchain(): Promise<void> {
       // Stops the engine
-      await fns.killEngine()
+      await engine.killEngine()
 
       // Clear cache and state
       await processor.clearAll()
@@ -493,7 +493,7 @@ export async function makeUtxoEngine(
       await pluginState.refreshServers()
 
       // Restart the engine
-      await fns.startEngine()
+      await engine.startEngine()
     },
 
     async saveTx(edgeTx: EdgeTransaction): Promise<void> {
@@ -751,5 +751,5 @@ export async function makeUtxoEngine(
     }
   }
 
-  return fns
+  return engine
 }

--- a/src/common/utxobased/engine/makeUtxoEngineState.ts
+++ b/src/common/utxobased/engine/makeUtxoEngineState.ts
@@ -26,7 +26,7 @@ import {
   IUTXO,
   makeIAddress
 } from '../db/types'
-import { getSupportedFormats, NumbWalletInfo } from '../keymanager/cleaners'
+import { getSupportedFormats, SafeWalletInfo } from '../keymanager/cleaners'
 import {
   BIP43PurposeTypeEnum,
   derivationLevelScriptHash,
@@ -87,7 +87,7 @@ export interface UtxoEngineState {
 
 export interface UtxoEngineStateConfig extends EngineConfig {
   walletTools: UTXOPluginWalletTools
-  walletInfo: NumbWalletInfo
+  walletInfo: SafeWalletInfo
   processor: Processor
 }
 
@@ -512,7 +512,7 @@ export function makeUtxoEngineState(
 
 interface CommonArgs {
   pluginInfo: PluginInfo
-  walletInfo: NumbWalletInfo
+  walletInfo: SafeWalletInfo
   walletTools: UTXOPluginWalletTools
   processor: Processor
   emitter: EngineEmitter

--- a/src/common/utxobased/engine/types.ts
+++ b/src/common/utxobased/engine/types.ts
@@ -19,3 +19,10 @@ export interface UtxoTxOtherParams {
   edgeSpendInfo?: EdgeSpendInfo
   ourScriptPubkeys: string[]
 }
+
+export type UtxoSignMessageOtherParams = ReturnType<
+  typeof asUtxoSignMessageOtherParams
+>
+export const asUtxoSignMessageOtherParams = asObject({
+  publicAddress: asString
+})

--- a/src/common/utxobased/engine/utils.ts
+++ b/src/common/utxobased/engine/utils.ts
@@ -52,14 +52,6 @@ export const validateMemo = (memo: string): EdgeMemoRules => {
   return result
 }
 
-export const getAddressTypeFromKeys = (
-  privateKey: PrivateKey
-): AddressTypeEnum => {
-  return getAddressTypeFromPurposeType(
-    currencyFormatToPurposeType(privateKey.format)
-  )
-}
-
 export const getAddressTypeFromPurposeType = (
   purpose: BIP43PurposeTypeEnum
 ): AddressTypeEnum => {

--- a/src/common/utxobased/engine/utils.ts
+++ b/src/common/utxobased/engine/utils.ts
@@ -231,30 +231,20 @@ export const deriveXpubsFromKeys = (args: {
 }): CurrencyFormatKeys => {
   const { engineInfo, privateKey, coin } = args
   const xpubs: CurrencyFormatKeys = {}
-  for (const format of getSupportedFormats(
-    engineInfo,
-    args.privateKey.format
-  )) {
-    xpubs[format] = deriveXpub({
-      privateKey,
+  for (const format of getSupportedFormats(engineInfo, privateKey.format)) {
+    const xpriv = deriveXprivFromKeys({
       coin,
-      type: currencyFormatToPurposeType(format)
+      privateKey
+    })[format]
+    if (xpriv == null)
+      throw new Error('Cannot derive xpub: no private key exists')
+    xpubs[format] = xprivToXPub({
+      coin,
+      type: currencyFormatToPurposeType(format),
+      xpriv
     })
   }
   return xpubs
-}
-
-export const deriveXpub = (args: {
-  privateKey: PrivateKey
-  coin: string
-  type: BIP43PurposeTypeEnum
-}): string => {
-  const xpriv = deriveXprivFromKeys(args)[
-    getCurrencyFormatFromPurposeType(args.type)
-  ]
-  if (xpriv == null)
-    throw new Error('Cannot derive xpub: no private key exists')
-  return xprivToXPub({ ...args, xpriv })
 }
 
 export const parsePathname = (args: {

--- a/src/common/utxobased/keymanager/cleaners.ts
+++ b/src/common/utxobased/keymanager/cleaners.ts
@@ -127,9 +127,12 @@ export const inferPrivateKeyFormat = (
 }
 
 /**
- * A cleaner that desensitizes the walletInfo object, excluding sensitive
+ * A cleaner that desensitizes an unsafeWalletInfo object, excluding sensitive
  * keys (seed/mnemonic, sync key, data key, etc). By using this object type
- * internally within the plugin, we can minimize risk of leaking sensitive data.
+ * internally within the plugin, we can minimize risk of leaking sensitive data
+ * when deriving public keys from walletInfo which only contains private keys.
+ * It may also be used on a safeWalletInfo object which only contains the
+ * wallet's public keys.
  *
  * It also includes internal derived data (publicKey, format, walletFormats, etc).
  * This derived data is to be used internally within the plugin and saved to disk (publicKey).

--- a/src/common/utxobased/keymanager/cleaners.ts
+++ b/src/common/utxobased/keymanager/cleaners.ts
@@ -141,7 +141,7 @@ export const inferPrivateKeyFormat = (
  * useful for determining the "kind of wallet", or more precisely how the public
  * key (xpubs) formats were derived.
  */
-export interface NumbWalletInfo {
+export interface SafeWalletInfo {
   id: string
   type: string
   keys: {
@@ -151,10 +151,10 @@ export interface NumbWalletInfo {
     walletFormats: CurrencyFormat[]
   }
 }
-export const asNumbWalletInfo = (
+export const asSafeWalletInfo = (
   pluginInfo: PluginInfo
-): Cleaner<NumbWalletInfo> => {
-  return (walletInfo: EdgeWalletInfo): NumbWalletInfo => {
+): Cleaner<SafeWalletInfo> => {
+  return (walletInfo: EdgeWalletInfo): SafeWalletInfo => {
     const { coinInfo, engineInfo } = pluginInfo
     const { id, type } = walletInfo
 

--- a/src/common/utxobased/keymanager/cleaners.ts
+++ b/src/common/utxobased/keymanager/cleaners.ts
@@ -27,6 +27,10 @@ const asOptionalPrivateKeyFormat = asOptional(asPrivateKeyFormat, 'bip32')
 
 /**
  * A cleaner for the private key format following the key-formats specification.
+ * It _includes_ the private key.
+ *
+ * **It is not considered safe memory, and it should be deallocated
+ * (thrown away) after use**.
  *
  * (spec: https://github.com/EdgeApp/edge-core-js/blob/master/docs/key-formats.md)
  */
@@ -34,7 +38,7 @@ export interface PrivateKey {
   coinType: number
   format: PrivateKeyFormat
   imported?: boolean
-  seed: string
+  seed: string // rename of seed/mnemonic (i.e. bitcoinKey, litecoinKey, etc)
 }
 export function asPrivateKey(
   coinName: string,

--- a/test/common/utxobased/engine/engine.spec.ts
+++ b/test/common/utxobased/engine/engine.spec.ts
@@ -89,6 +89,7 @@ describe('engine.spec', function () {
         emitter.emit('onTransactionsChanged', transactionList)
       },
       onTxidsChanged() {},
+      onUnactivatedTokenIdsChanged() {},
       onWcNewContractCall() {}
     }
 
@@ -359,7 +360,7 @@ describe('engine.spec', function () {
 
     describe(`Get Wallet Keys for Wallet type ${WALLET_TYPE}`, function () {
       it('get private key', function (done) {
-        engine.getDisplayPrivateSeed()
+        engine.getDisplayPrivateSeed(keys)
         done()
       })
       it('get public key', function (done) {
@@ -429,7 +430,7 @@ describe('engine.spec', function () {
           return await engine
             .makeSpend(templateSpend)
             .then(async a => {
-              return await engine.signTx(a)
+              return await engine.signTx(a, keys)
             })
             .then(a => {
               fakeLogger.info('sign', a)
@@ -458,7 +459,7 @@ describe('engine.spec', function () {
             throw new Error('No sweepPrivateKeys')
           }
           return await engine.sweepPrivateKeys(templateSpend).then(async a => {
-            return await engine.signTx(a)
+            return await engine.signTx(a, keys)
           })
           // .then(a => {
           // console.warn('sign', a)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3063,10 +3063,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-edge-core-js@^0.19.37:
-  version "0.19.37"
-  resolved "https://registry.yarnpkg.com/edge-core-js/-/edge-core-js-0.19.37.tgz#f10ed23353458f9acda1b831d74c6a7cb24b88ed"
-  integrity sha512-zGfuL+b+C7qXAO1K3jL8czMoM/8D8Otd4fnFMjI8a2cbKY3OsmJWqciAPTER6HH9smwR5zCr7WRv0vTyB1fVmQ==
+edge-core-js@^0.19.48:
+  version "0.19.48"
+  resolved "https://registry.yarnpkg.com/edge-core-js/-/edge-core-js-0.19.48.tgz#cfc0ed5ab176e723007ebfd4845a4027fc6a9506"
+  integrity sha512-hP8sB8JR0f11/a0Bd4uEp+4HCfYQjh9IgU+1Lj5TVbqJwKvduFFdH4TlCiwSXIqTxt+aCjvcEL+jrqNpPgtZEQ==
   dependencies:
     aes-js "^3.1.0"
     base-x "^1.0.4"
@@ -3087,7 +3087,7 @@ edge-core-js@^0.19.37:
     rfc4648 "^1.4.0"
     scrypt-js "^2.0.3"
     serverlet "^0.1.0"
-    yaob "^0.3.8"
+    yaob "^0.3.9"
     yavent "^0.1.3"
 
 edge-sync-client@^0.2.7:
@@ -8752,10 +8752,10 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yaob@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/yaob/-/yaob-0.3.8.tgz#a359fd092dbf42d07f82eb2fb0b00bdb87f1c4cc"
-  integrity sha512-6ocTmk7fVAB7TOc8ot7sdt5o+UK3d8qtDtd61IBIVe++V1xGmhP3Y8FYOCrzmo6ywzGJPaDS66orZIwnw5NwEw==
+yaob@^0.3.9:
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/yaob/-/yaob-0.3.10.tgz#fb86d54d564ff6014f6f52fafc4219b6c068f613"
+  integrity sha512-QU+03xtNssGOw01Tten5zlfNcrsMPQjy0Nr/gueVEbXYsXHgYeDKXNLgPNMdYdTY7qkvLj8IGLOk/MKtsUh+Fg==
   dependencies:
     rfc4648 "^1.1.0"
 


### PR DESCRIPTION
### CHANGELOG

- changed: Upgrade security access to private keys in EdgeWalletInfo
- changed: Add signMessage API to replace signMessageBase64 in otherMethods

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204056629741203