### PR TITLE
Fix otherParams for signMessage

### DIFF
--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -527,10 +527,8 @@ export async function makeUtxoEngine(
       privateKeys: JsonObject,
       opts: EdgeSignMessageOptions
     ): Promise<string> {
-      const otherParams = asUtxoSignMessageOtherParams(opts)
+      const otherParams = asUtxoSignMessageOtherParams(opts.otherParams)
       const { publicAddress } = otherParams
-      if (publicAddress == null)
-        throw new Error('Missing publicAddress in EdgeSignMessageOptions')
       const scriptPubkey = walletTools.addressToScriptPubkey(publicAddress)
       const processorAddress = await processor.fetchAddress(scriptPubkey)
       if (processorAddress?.path == null) {


### PR DESCRIPTION
### CHANGELOG

- fixed: Bug with signMessage cleaning of `EdgeSignMessageOptions['otherParams']`

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
