### PR TITLE
Detect and throw DustSpendError

### DIFF
--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -2,6 +2,7 @@ import * as bs from 'biggystring'
 import { asMaybe } from 'cleaners'
 import { makeMemoryDisklet } from 'disklet'
 import {
+  DustSpendError,
   EdgeCurrencyCodeOptions,
   EdgeCurrencyEngine,
   EdgeDataDump,
@@ -178,7 +179,12 @@ export async function makeUtxoEngine(
           )
         }
       }
-      const id = await engineState.broadcastTx(transaction)
+      const id = await engineState.broadcastTx(transaction).catch(err => {
+        if (String(err).includes('Error: Blockbook Error: -26: dust')) {
+          throw new DustSpendError()
+        }
+        throw err
+      })
       if (id !== transaction.txid) {
         throw new Error('broadcast response txid does not match original')
       }


### PR DESCRIPTION
### CHANGELOG

- Fixed: Throw DustSpendError instead of obscure blockbook error message for dust spend transaction broadcasts.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204859092318979