### PR TITLE
Remove BSV from BCH's split options

### DIFF
--- a/src/common/utxobased/info/bitcoincash.ts
+++ b/src/common/utxobased/info/bitcoincash.ts
@@ -56,7 +56,7 @@ const currencyInfo: EdgeCurrencyInfo = {
 
 const engineInfo: EngineInfo = {
   formats: ['bip44', 'bip32'],
-  forks: ['bitcoinsv'],
+  forks: [], // 'bitcoinsv' is currently disabled, so not included in the forks
   gapLimit: 10,
   defaultFee: 10000,
   feeUpdateInterval: 60000,


### PR DESCRIPTION
BSV is currently disabled, so shouldn't be able to split into it.

### CHANGELOG

- removed: BSV from BCH's split options

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205443361322801