### PR TITLE
Add optional fallback generic parameter to asFeeInfo cleaner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Bug with new `maximumFeeRate` entry in `FeeInfo` not applying due to disk/info-server overwriting the field.
+
 ## 2.4.0 (2023-10-23)
 
 - changed: Re-enabled maximum fee rate checks from AltcoinJS.

--- a/src/common/fees/makeFees.ts
+++ b/src/common/fees/makeFees.ts
@@ -65,7 +65,7 @@ export const makeFees = async (config: MakeFeesConfig): Promise<Fees> => {
       const edgeFees = await fetchFees({
         ...common,
         uri: `${INFO_SERVER_URI}/v1/networkFees/${currencyInfo.pluginId}`,
-        cleaner: asMaybe(asFeeInfo, null)
+        cleaner: asMaybe(asFeeInfo(feeInfo), null)
       })
       Object.assign(feeInfo, edgeFees)
       await updateVendorFees()
@@ -122,7 +122,7 @@ const fetchCachedFees = async (
   fallback: FeeInfo
 ): Promise<FeeInfo> => {
   const data = await memlet.getJson(FEES_PATH).catch(() => undefined)
-  const feeSettings = asMaybe(asFeeInfo, fallback)(data)
+  const feeSettings = asMaybe(asFeeInfo(fallback), fallback)(data)
   return feeSettings
 }
 

--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -161,21 +161,28 @@ export type FeeInfo = FeeRates & {
   standardFeeHighAmount: string
   maximumFeeRate?: string
 }
-export const asFeeInfo = asObject<FeeInfo>({
-  ...asFeeRates.shape,
+export const asFeeInfo = (fallback?: FeeInfo): Cleaner<FeeInfo> =>
+  asObject<FeeInfo>({
+    ...asFeeRates.shape,
 
-  lowFeeFudgeFactor: asMaybe(asString),
-  standardFeeLowFudgeFactor: asMaybe(asString),
-  standardFeeHighFudgeFactor: asMaybe(asString),
-  highFeeFudgeFactor: asMaybe(asString),
+    lowFeeFudgeFactor: asMaybe(asString, fallback?.lowFeeFudgeFactor),
+    standardFeeLowFudgeFactor: asMaybe(
+      asString,
+      fallback?.standardFeeLowFudgeFactor
+    ),
+    standardFeeHighFudgeFactor: asMaybe(
+      asString,
+      fallback?.standardFeeHighFudgeFactor
+    ),
+    highFeeFudgeFactor: asMaybe(asString, fallback?.highFeeFudgeFactor),
 
-  // The amount of satoshis which will be charged the standardFeeLow
-  standardFeeLowAmount: asString,
-  // The amount of satoshis which will be charged the standardFeeHigh
-  standardFeeHighAmount: asString,
-  // A safe-guard for any potential software bugs:
-  maximumFeeRate: asOptional(asString)
-})
+    // The amount of satoshis which will be charged the standardFeeLow
+    standardFeeLowAmount: asString,
+    // The amount of satoshis which will be charged the standardFeeHigh
+    standardFeeHighAmount: asString,
+    // A safe-guard for any potential software bugs:
+    maximumFeeRate: asOptional(asString, fallback?.maximumFeeRate)
+  }).withRest
 
 export interface EngineConfig {
   walletInfo: EdgeWalletInfo


### PR DESCRIPTION
In order to apply defaults to new entry additions to the FeeInfo type
(such as 'maximumFeeRate') without the fee info from disk/info-server
overwriting, we must apply the fallback values at the cleaner level.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205823029134351