### PR TITLE
Disable accelerate for legacy bip32 Airbitz wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- removed: Disable `accelerate` for bip32 (Airbitz) wallets
+
 ## 2.5.1 (2023-11-10)
 
 - changed: Disabled RBF for Litecoin

--- a/src/common/utxobased/engine/makeUtxoEngine.ts
+++ b/src/common/utxobased/engine/makeUtxoEngine.ts
@@ -144,6 +144,9 @@ export async function makeUtxoEngine(
       const { canReplaceByFee = false } = currencyInfo
       if (!canReplaceByFee) return null
 
+      // Accelerate for legacy Airbitz wallets is not supported
+      if (privateKeyFormat === 'bip32') return null
+
       // Get the replaced transaction from the processor:
       const replacedTxid = edgeTx.txid
       const [replacedTx] = await processor.fetchTransactions({


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206302598410433