### PR TITLE
Update DOGE minRelayFeeRate to the recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Change DOGE minimum relay fee to 0.01 DOGE/kB.
+
 ## 3.4.0 (2024-09-24)
 
 - changed: No longer allow for the custom server list to be empty; fallback to default servers if no custom servers are provided.

--- a/src/common/utxobased/info/utxoPickers/dogeUtxoPicker.ts
+++ b/src/common/utxobased/info/utxoPickers/dogeUtxoPicker.ts
@@ -8,8 +8,12 @@ import { forceUseUtxo } from '../../keymanager/utxopicker/forceUseUtxo'
 import { subtractFee } from '../../keymanager/utxopicker/subtractFee'
 
 export function makeDogeUtxoPicker(): UtxoPicker {
-  // According to https://github.com/dogecoin/dogecoin/discussions/2347 the min fee rate is now 0.001 Doge per Kilobyte
-  const minRelayFeeRate = 0.001 / 1000
+  /*
+  According to https://github.com/dogecoin/dogecoin/blob/master/doc/fee-recommendation.md
+  the min fee rate is now 0.01 DOGE/kB which is 0.00001 DOGE/byte or 
+  1,000 sats/vByte .
+  */
+  const minRelayFeeRate = 1000
 
   return {
     forceUseUtxo: (args: UtxoPickerArgs): UtxoPickerResult => {


### PR DESCRIPTION
Since Dogecoin Core 1.14.5, the fee rate recommendation has become
0.01 DOGE/kB (https://github.com/dogecoin/dogecoin/releases/tag/v1.14.5).

The prior implementation was wrong to assume `minRelayFeeRate` was units
of DOGE when it should have been sats.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201359074214640