### PR TITLE
Fix checkpoint initialization on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Update the last-seen checkpoint when the sync finishes, even if we haven't seen any new transactions.
+
 ## 3.5.1 (2025-01-22)
 
 - changed: Remove Blockbook servers from persisted internal servers list when updating this list from payload/default servers.

--- a/src/common/utxobased/engine/UtxoEngineProcessor.ts
+++ b/src/common/utxobased/engine/UtxoEngineProcessor.ts
@@ -168,6 +168,7 @@ export function makeUtxoEngineProcessor(
         `processed changed, percent: ${percent}, processedCount: ${processedCount}, totalCount: ${expectedProcessCount}`
       )
       processedPercent = percent
+      common.updateSeenTxCheckpoint()
       emitter.emit(EngineEvent.ADDRESSES_CHECKED, percent)
     }
   }


### PR DESCRIPTION
We were only updating the checkpoint in response to incoming transactions, which doesn't happen if the phone is already synced. The next incoming transaction after the upgrade will encounter and `undefined` checkpoint, and won't generate a notifiation. Instead, also update the checkpoint when the sync finishes, to ensure that existing accounts will detect incoming funds without needing a full resync.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209313363246606