### PR TITLE
Fix crash when memletConfig not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Crash when running under NodeJS due to missing memletConfig
+
 ## 3.8.2 (2025-06-09)
 
 - changed: Remove NOWNodes blockbook connection for Firo.

--- a/src/common/plugin/CurrencyPlugin.ts
+++ b/src/common/plugin/CurrencyPlugin.ts
@@ -42,14 +42,20 @@ export function makeCurrencyPlugin(
   })
 
   if (!hasMemletBeenSet) {
-    const { memletConfig } = nativeIo[
+    const pluginConfig = nativeIo[
       'edge-currency-plugins'
     ] as EdgeCurrencyPluginNativeIo
 
+    const memletConfig = pluginConfig?.memletConfig
+
     if (memletConfig != null) {
-      hasMemletBeenSet = true
       setMemletConfig(memletConfig)
+    } else {
+      setMemletConfig({
+        maxMemoryUsage: 50 * 1024 * 1024 // 50MB
+      })
     }
+    hasMemletBeenSet = true
   }
 
   const instance: EdgeCurrencyPlugin = {


### PR DESCRIPTION
This is necessary on NodeJS deployments when there's no nativeIo

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210778486915222