### PR TITLE
Initialize ECC library eagerly so Taproot sends work

### DIFF
--- a/src/common/utxobased/keymanager/keymanager.ts
+++ b/src/common/utxobased/keymanager/keymanager.ts
@@ -32,6 +32,15 @@ import { InsufficientFundsErrorPlus } from './types'
 import * as utxopicker from './utxopicker'
 import * as pickerUtils from './utxopicker/utils'
 
+// Eagerly initialize the ECC library at module load. Taproot (p2tr) address
+// parsing in `addressToScriptPubkey` (via `payments.p2tr`) requires the ECC
+// library, and that code path can run before any ECPair/signing operation
+// triggers the lazy `getECPair` init below — e.g. when `makeSpend` converts a
+// Taproot recipient address to a scriptPubkey. Without this, sending to a
+// `bc1p…` address fails with "No ECC Library provided".
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+initEccLib(require('@bitcoinerlab/secp256k1'))
+
 let ECPairCache: ECPairAPI
 const getECPair = (): ECPairAPI => {
   if (ECPairCache != null) return ECPairCache


### PR DESCRIPTION
## Summary

`initEccLib(secp256k1)` was only called **lazily**, inside `getECPair()`. But Taproot (p2tr) address handling in `addressToScriptPubkey` → `guessAddressTypeFromAddress` → `payments.p2tr` also requires the ECC library, and that path can run **before** any ECPair/signing operation — most notably when `makeSpend` converts a Taproot **recipient** address to a scriptPubkey.

As a result, sending to a `bc1p…` (Taproot / bech32m) address failed: `payments.p2tr` threw `"No ECC Library provided. You must call initEccLib()"`, which `guessAddressTypeFromAddress` swallowed, surfacing as `unable to convert address … to script pubkey`. SegWit v0 (`bc1q…`) sends were unaffected because they don't need ECC for address conversion.

Fix: initialize the ECC library **once at module load** (using the already-present `@bitcoinerlab/secp256k1` dep), so Taproot address handling works regardless of call order. The existing lazy init in `getECPair()` is left in place (idempotent).

## How it was found

Integrating the Breez SDK - Spark for Bitcoin Lightning sends in edge-react-gui (EdgeApp/edge-react-gui#6017). Spark deposit addresses are Taproot (`bc1p…`), so funding a Spark wallet from an Edge BTC wallet requires sending to one — which failed until this fix.

## Testing

Verified on iOS: with this change, `makeSpend` to a Taproot address succeeds and broadcasts a valid P2TR-output transaction (confirmed on mainnet), which the prior code could not do. Isolated repro: `payments.p2tr({ address: 'bc1p…', network })` throws without `initEccLib`, succeeds with it.

Asana: https://app.asana.com/0/1215088146871429/1215168882923123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single startup init using an existing dependency; no auth or transaction-logic changes beyond enabling p2tr address parsing.
> 
> **Overview**
> **Fixes Taproot (`bc1p…`) sends** by calling `initEccLib` with `@bitcoinerlab/secp256k1` when `keymanager` loads, instead of relying only on lazy init inside `getECPair()`.
> 
> Spend building can run `addressToScriptPubkey` / `guessAddressTypeFromAddress` / `payments.p2tr` **before** any signing path runs; without ECC registered, that failed with *No ECC Library provided* and surfaced as unable to convert the address to script pubkey. SegWit v0 (`bc1q…`) was unaffected. Lazy `getECPair()` init is unchanged and remains idempotent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1717cb2d5e35521c78c3a1d9cdc7168b124093c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->