### PR TITLE
Replace defunct PIVX explorer with explorer.duddino.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - changed: Convert the build tooling from Yarn to npm.
 - changed: Replace git dependencies with @edge.app-scoped npm packages (ecpair, groestl-hash-js, bs58grscheck).
 - security: Upgrade dependencies per Socket security recommendations.
+- fixed: Replace defunct PIVX explorer (zkbitcoin.com) with explorer.duddino.com and remove zkbitcoin.com from the PIVX blockbook server list
 
 ## 3.9.0 (2026-03-10)
 

--- a/src/common/utxobased/info/pivx.ts
+++ b/src/common/utxobased/info/pivx.ts
@@ -18,9 +18,9 @@ const currencyInfo: EdgeCurrencyInfo = {
   walletType: 'wallet:pivx',
 
   // Explorers:
-  addressExplorer: 'https://zkbitcoin.com/address/%s',
-  blockExplorer: 'https://zkbitcoin.com/block/%s',
-  transactionExplorer: 'https://zkbitcoin.com/tx/%s',
+  addressExplorer: 'https://explorer.duddino.com/address/%s',
+  blockExplorer: 'https://explorer.duddino.com/block/%s',
+  transactionExplorer: 'https://explorer.duddino.com/tx/%s',
 
   denominations: [
     {
@@ -34,7 +34,7 @@ const currencyInfo: EdgeCurrencyInfo = {
   ...legacyMemoInfo,
   defaultSettings: {
     customFeeSettings: ['satPerByte'],
-    blockbookServers: ['wss://pivx-eusa1.edge.app', 'wss://zkbitcoin.com'],
+    blockbookServers: ['wss://pivx-eusa1.edge.app'],
     enableCustomServers: false
   },
   displayName: 'PIVX',


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1211661955067895/f)

The `zkbitcoin.com` PIVX block explorer is no longer functional, so "Show in Explorer" on a PIVX address or transaction fails to load.

- Repoint the PIVX `addressExplorer`, `blockExplorer`, and `transactionExplorer` from `zkbitcoin.com` to `explorer.duddino.com`, an in-sync PIVX Blockbook instance. Verified live: `/api/v2` reports `coin: PIVX`, `inSync: true`, and the `/address/`, `/block/`, `/tx/` routes all return HTTP 200.
- Remove `wss://zkbitcoin.com` from the default PIVX `blockbookServers` list (the "Custom servers" entry called out in the task), leaving the Edge-hosted `wss://pivx-eusa1.edge.app`.

#### Testing

- `yarn types` (tsc) clean; husky pre-commit (`lint-staged` + `types` + `mocha`) passed; `verify-repo.sh` green.
- Confirmed each new explorer URL template resolves against the live duddino PIVX Blockbook (address/block/tx all HTTP 200).
- The GUI consumes these strings through currency-agnostic shared code (`sprintf(currencyInfo.transactionExplorer, txid)` in `TransactionListRow`/`TransactionDetailsScene`), so there is no PIVX-specific app path to change; the fix is entirely in the plugin info data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static PIVX plugin metadata only; no changes to signing, fees, or shared engine logic beyond default server and explorer strings.
> 
> **Overview**
> **PIVX “Show in Explorer” and default sync endpoints** no longer point at the dead `zkbitcoin.com` host.
> 
> In `pivx.ts`, the three explorer URL templates (`addressExplorer`, `blockExplorer`, `transactionExplorer`) now use `https://explorer.duddino.com/...` instead of `zkbitcoin.com`. Default `blockbookServers` drops `wss://zkbitcoin.com`, leaving only `wss://pivx-eusa1.edge.app`. The unreleased **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20cae22da661501fb69a76926a1f46119e105260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="1" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-currency-plugins/pull/451/commits/20cae22da661501fb69a76926a1f46119e105260"><code>20cae22</code></a><br><sub>Replace defunct PIVX explorer with explorer.duddino.com</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-451/20260612-152633-01-pivx-transaction-list.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-451/20260612-152633-01-pivx-transaction-list.png" width="200"></a><br><sub>pivx transaction list</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-451/20260612-152633-02-in-app-show-in-explorer.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-451/20260612-152633-02-in-app-show-in-explorer.png" width="200"></a><br><sub>in app show in explorer</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-451/20260612-152633-03-duddino-explorer-loaded-transaction.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-451/20260612-152633-03-duddino-explorer-loaded-transaction.png" width="200"></a><br><sub>duddino explorer loaded transaction</sub></td>
</tr>
</table>
<!-- agent-test-evidence:end -->