### PR TITLE
Support bch-wif: protohandler for sweeping CashStamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
-## 3.10.0 (2026-06-13)
-
+- added: Support the `<code>-wif:` protohandler prefix (e.g. `bch-wif:`) in `parseUri` so CashStamps private keys can be swept.
 - changed: Convert the build tooling from Yarn to npm.
 - changed: Replace git dependencies (ecpair, groestl-hash-js, bs58grscheck) with @edge.app-scoped npm packages so installs no longer require git/SSH access.
 - security: Upgrade dependencies per Socket security recommendations.
+## 3.10.0 (2026-06-13)
+
 
 ## 3.9.0 (2026-03-10)
 

--- a/src/common/plugin/CurrencyTools.ts
+++ b/src/common/plugin/CurrencyTools.ts
@@ -107,6 +107,16 @@ export function makeCurrencyTools(
     },
 
     async parseUri(uri: string): Promise<ExtendedParseUri> {
+      // CashStamps and similar paper-wallet tools prefix a WIF private key with
+      // a "<code>-wif:" protohandler (e.g. "bch-wif:<WIF>"). Strip it so the
+      // bare WIF is handled by the private-key detection in parsePathname. The
+      // prefix is derived from the wallet's own currency code, so it can only
+      // ever match this coin.
+      const wifPrefix = `${currencyInfo.currencyCode.toLowerCase()}-wif:`
+      if (uri.toLowerCase().startsWith(wifPrefix)) {
+        uri = uri.slice(wifPrefix.length)
+      }
+
       const isGateway = uri
         .toLocaleLowerCase()
         .startsWith(`${coinInfo.name}://`)

--- a/test/common/plugin/CurrencyPlugin.fixtures/currencies/bitcoincash.ts
+++ b/test/common/plugin/CurrencyPlugin.fixtures/currencies/bitcoincash.ts
@@ -264,6 +264,27 @@ export const bitcoincash: FixtureType = {
         metadata: {},
         privateKeys: ['5JJY5LkdXsRSh1X2pLMezk3f11wHkSBJM1AmJ6zKJyzJtQnAe3F']
       }
+    ],
+    'bch-wif protohandler - Compressed': [
+      'bch-wif:L5FyMaAPJGqivZmCzFAEATptdvgha4UqwVWbLLZgr5iLGtQRo4x2',
+      {
+        metadata: {},
+        privateKeys: ['L5FyMaAPJGqivZmCzFAEATptdvgha4UqwVWbLLZgr5iLGtQRo4x2']
+      }
+    ],
+    'bch-wif protohandler - Non Compressed': [
+      'bch-wif:5Kb8kLf9zgWQnogidDA76MzPL6TsZZY36hWXMssSzNydYXYB9KF',
+      {
+        metadata: {},
+        privateKeys: ['5Kb8kLf9zgWQnogidDA76MzPL6TsZZY36hWXMssSzNydYXYB9KF']
+      }
+    ],
+    'bch-wif protohandler - Uppercase prefix': [
+      'BCH-WIF:L5FyMaAPJGqivZmCzFAEATptdvgha4UqwVWbLLZgr5iLGtQRo4x2',
+      {
+        metadata: {},
+        privateKeys: ['L5FyMaAPJGqivZmCzFAEATptdvgha4UqwVWbLLZgr5iLGtQRo4x2']
+      }
     ]
   },
   encodeUri: {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1215306367142288/f)

Support sweeping CashStamps, which encode their private key as `bch-wif:${WIF}` — a normal WIF with a `bch-wif:` protohandler prefix. Edge already supports sweeping a bare WIF, but `parseUri` rejected anything with an unrecognized URI scheme, so `bch-wif:...` threw `InvalidUriError` and the sweep never started.

`parseUri` now strips a leading `<currencyCode>-wif:` prefix (e.g. `bch-wif:` for BCH) before parsing, so the remaining bare WIF flows through the existing private-key detection in `parsePathname` and the standard sweep path. The prefix is derived from the wallet's own currency code, so it can only ever match its own coin. A bare WIF and all other URIs are unaffected.

No GUI change is required: the app's sweep flow already consumes `parsedUri.privateKeys`.

Token (CashToken) sweeping is intentionally out of scope here — it depends on broader CashToken support that is still incoming — and is left as a follow-up.

**Tests:** added `parseUri` fixtures for the BCH plugin covering `bch-wif:` (compressed, non-compressed, and uppercase-prefix) → `{ privateKeys: [<bare WIF>] }`.

**Verified end-to-end on iOS sim** against the patched plugin (DEBUG_CURRENCY_PLUGINS dev-server): entering `bch-wif:<WIF>` in Scan → Enter is recognized as a BCH private key (wallet picker filtered to BCH), advances to the "Sweep Funds From Private Key" modal, and on confirm the sweep executes against the key (returning "Private key has no funds" for the empty test WIF). Screenshots attached.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, early guard in URI parsing that reuses existing WIF sweep logic; no changes to signing or broadcast.
> 
> **Overview**
> **`parseUri`** in shared **`CurrencyTools`** now removes a leading **`<currencyCode>-wif:`** prefix (e.g. **`bch-wif:`**) before URI parsing, so CashStamps-style strings no longer hit **`InvalidUriError`** and the bare WIF is handled by existing **`parsePathname`** private-key detection. Matching is scoped to each plugin’s own currency code (case-insensitive on the prefix).
> 
> BCH **`parseUri`** fixtures were added for compressed, non-compressed, and uppercase-prefix **`bch-wif:`** inputs. **CHANGELOG** documents the feature under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b8321d6f843c67470a2d717f7c033826c7d4cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->