### PR TITLE
Add NowNodes blockbook server to eCash for sync/send recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Add the NowNodes blockbook websocket server to eCash (XEC) so wallets can sync and send when the primary `blockbook.fabien.cash` server is unavailable.
+
 ## 3.10.0 (2026-06-13)
 
 - changed: Convert the build tooling from Yarn to npm.

--- a/src/common/utxobased/info/ecash.ts
+++ b/src/common/utxobased/info/ecash.ts
@@ -32,7 +32,10 @@ const currencyInfo: EdgeCurrencyInfo = {
   ...legacyMemoInfo,
   defaultSettings: {
     customFeeSettings: ['satPerByte'],
-    blockbookServers: ['wss://blockbook.fabien.cash/websocket'],
+    blockbookServers: [
+      'wss://blockbook.fabien.cash/websocket',
+      'wss://xec-blockbook.nownodes.io/wss/%{nowNodesApiKey}'
+    ],
     enableCustomServers: false
   },
   displayName: 'eCash',


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

eCash (XEC) wallets could not resync or send: the plugin's only blockbook sync server, `wss://blockbook.fabien.cash/websocket`, is down, so resync hangs and sends fail. This is an active support issue and a regression.

The NowNodes XEC blockbook host was already referenced in `engineInfo.serverConfigs`, but only as an HTTP broadcast fallback — it was never in `defaultSettings.blockbookServers`, so it was never used for the websocket sync. This adds it, with the `%{nowNodesApiKey}` template that `Socket.ts` substitutes from the plugin's init options, matching the pattern Bitcoin Cash, Bitcoin and Dogecoin already use.

```diff
   blockbookServers: [
-    'wss://blockbook.fabien.cash/websocket'
+    'wss://blockbook.fabien.cash/websocket',
+    'wss://xec-blockbook.nownodes.io/wss/%{nowNodesApiKey}'
   ],
```

The consuming app already wires `ECASH_INIT.nowNodesApiKey` through to the `ecash` plugin (`edge-react-gui` `corePlugins.ts`), using the same NowNodes key as the other UTXO coins; production env just needs that key populated for eCash (a deploy-config change, like every other NowNodes-backed coin).

**Verification**
- Server check: `blockbook.fabien.cash` no longer serves the blockbook API; `xec-blockbook.nownodes.io` returns `401` without an API key and `200` with the key, reporting a live, in-sync eCash node (`"coin":"ECash","network":"XEC","inSync":true`).
- In-app (iOS sim, edge-react-gui with this plugin linked in and `ECASH_INIT.nowNodesApiKey` set): resynced a funded XEC wallet ("My eCash", 126,536.16 XEC). Resync completed and the wallet stayed synced with a live balance — data that can only come from the NowNodes server, since the old server is down. Screenshots attached.

Asana: https://app.asana.com/0/1215088146871429/1213046875952149

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition of a fallback sync server using an established NowNodes URL pattern; no changes to spending, key handling, or sync logic beyond server list selection.
> 
> **Overview**
> Adds a **second default blockbook websocket** for eCash so wallets can fall back when `wss://blockbook.fabien.cash/websocket` is down.
> 
> `defaultSettings.blockbookServers` in `ecash.ts` now includes `wss://xec-blockbook.nownodes.io/wss/%{nowNodesApiKey}` alongside the existing Fabien server. That mirrors Bitcoin, Bitcoin Cash, and Dogecoin and wires the same NowNodes host that was already listed in `engineInfo.serverConfigs` for HTTP broadcast into **websocket sync**. The `%{nowNodesApiKey}` placeholder is filled from plugin init options at connection time.
> 
> CHANGELOG records the fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da1d2fd20363f27c40140bbb8db94d0d2dac5d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="2" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-currency-plugins/pull/453/commits/3da1d2fd20363f27c40140bbb8db94d0d2dac5d8"><code>3da1d2f</code></a><br><sub>Add NowNodes blockbook server to eCash for sync/send recovery</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-453/20260624-185435-agent-proof-1213046875952149-01-xec-wallets-funded.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-453/20260624-185435-agent-proof-1213046875952149-01-xec-wallets-funded.png" width="200"></a><br><sub>agent proof 1213046875952149 01 xec wallets funded</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-453/20260624-185435-agent-proof-1213046875952149-02-xec-wallet-balance.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-453/20260624-185435-agent-proof-1213046875952149-02-xec-wallet-balance.png" width="200"></a><br><sub>agent proof 1213046875952149 02 xec wallet balance</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-453/20260624-185435-agent-proof-1213046875952149-03-resync-confirm.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-453/20260624-185435-agent-proof-1213046875952149-03-resync-confirm.png" width="200"></a><br><sub>agent proof 1213046875952149 03 resync confirm</sub></td>
</tr>
<tr>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-453/20260624-185435-agent-proof-1213046875952149-04-resync-complete-synced.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-currency-plugins/pr-453/20260624-185435-agent-proof-1213046875952149-04-resync-complete-synced.png" width="200"></a><br><sub>agent proof 1213046875952149 04 resync complete synced</sub></td>
<td width="210"></td>
<td width="210"></td>
</tr>
</table>
<!-- agent-test-evidence:end -->