### PR TITLE
Never report a successful broadcast as a failed send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fixed: Failed sends after a successful broadcast: `saveTx` no longer fails on a disconnected engine, and a broadcast error is reported as a failure only after verifying the transaction is unknown to the network.
+- fixed: Failed sends after a successful broadcast: `saveTx` no longer fails when the engine is not running, and an exhausted broadcast now distinguishes explicit server rejections (definitively failed, safe to retry) from transport failures where the transaction may have reached the network (`BroadcastAmbiguityError`).
 
 ## 3.11.0 (2026-07-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Failed sends after a successful broadcast: `saveTx` no longer fails on a disconnected engine, and a broadcast error is reported as a failure only after verifying the transaction is unknown to the network.
+
 ## 3.11.0 (2026-07-13)
 
 - added: Support the `<code>-wif:` protohandler prefix (e.g. `bch-wif:`) in `parseUri` so CashStamps private keys can be swept.

--- a/src/common/utxobased/engine/ServerStates.ts
+++ b/src/common/utxobased/engine/ServerStates.ts
@@ -1,3 +1,4 @@
+import { asMaybe, asObject, asString } from 'cleaners'
 import { EdgeIo, EdgeLog, EdgeTransaction } from 'edge-core-js/types'
 import { parse } from 'uri-js'
 
@@ -367,9 +368,75 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
 
   const instance: ServerStates = {
     async broadcastTx(transaction: EdgeTransaction): Promise<string> {
+      // Query the network for the transaction to determine whether a failed
+      // broadcast actually reached the network anyway. A server can relay
+      // the transaction and still return an error or fail to respond, so an
+      // error from every server does not prove the transaction wasn't sent.
+      const isTxidKnown = async (txid: string): Promise<boolean> => {
+        // Ask connected blockbook instances first:
+        for (const uri of Object.keys(serverStatesCache)) {
+          const { blockbook } = serverStatesCache[uri]
+          if (blockbook == null || !blockbook.isConnected) continue
+          const known = await blockbook
+            .fetchTransaction(txid)
+            .then(() => true)
+            .catch(() => false)
+          if (known) return true
+        }
+
+        // Fall back to the NOWNode HTTP API when no blockbook is connected:
+        const { nowNodesApiKey } = initOptions
+        if (nowNodesApiKey == null) return false
+        const nowNodeUris = serverConfigs
+          .filter(config => config.type === 'blockbook-nownode')
+          .map(config => config.uris)
+          .flat(1)
+        for (const uri of nowNodeUris) {
+          const known = await io
+            .fetchCors(`${uri}/api/v2/tx/${txid}`, {
+              headers: {
+                'api-key': nowNodesApiKey
+              }
+            })
+            .then(async response => {
+              if (!response.ok) return false
+              const json = await response.json()
+              return asMaybe(asTxQueryResponse)(json)?.txid === txid
+            })
+            .catch(() => false)
+          if (known) return true
+        }
+        return false
+      }
+
       return await new Promise((resolve, reject) => {
         let resolved = false
         let bad = 0
+
+        // Reject with the given error only when the transaction is verifiably
+        // absent from the network; a transaction that reached the network
+        // despite the error is a successful broadcast.
+        const rejectUnlessTxKnown = (error?: Error): void => {
+          const fail = (): void => {
+            const msg = error != null ? `With error ${error.message}` : ''
+            log.error(
+              `broadcastTx fail: ${JSON.stringify(transaction)}\n${msg}`
+            )
+            reject(error)
+          }
+          isTxidKnown(transaction.txid)
+            .then(known => {
+              if (!known) return fail()
+              if (!resolved) {
+                resolved = true
+                log.warn(
+                  `broadcastTx errored, but txid ${transaction.txid} is known to the network; treating broadcast as a success`
+                )
+                resolve(transaction.txid)
+              }
+            })
+            .catch(fail)
+        }
 
         const wsUris = Object.keys(serverStatesCache).filter(
           uri => serverStatesCache[uri].blockbook != null
@@ -394,11 +461,7 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
               })
               .catch((e?: Error) => {
                 if (++bad === wsUris.length) {
-                  const msg = e != null ? `With error ${e.message}` : ''
-                  log.error(
-                    `broadcastTx fail: ${JSON.stringify(transaction)}\n${msg}`
-                  )
-                  reject(e)
+                  rejectUnlessTxKnown(e)
                 }
               })
           }
@@ -464,11 +527,7 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
               })
               .catch((e?: Error) => {
                 if (++bad === nowNodeUris.length) {
-                  const msg = e != null ? `With error ${e.message}` : ''
-                  log.error(
-                    `broadcastTx fail: ${JSON.stringify(transaction)}\n${msg}`
-                  )
-                  reject(e)
+                  rejectUnlessTxKnown(e)
                 }
               })
           }
@@ -670,3 +729,11 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
 
   return instance
 }
+
+/**
+ * Minimal shape of a Blockbook REST `/api/v2/tx/<txid>` response, used only
+ * to confirm that a transaction is known to the network.
+ */
+const asTxQueryResponse = asObject({
+  txid: asString
+})

--- a/src/common/utxobased/engine/ServerStates.ts
+++ b/src/common/utxobased/engine/ServerStates.ts
@@ -22,7 +22,8 @@ import { SocketEmitter, SocketEvent } from '../network/SocketEmitter'
 import { pushUpdate, removeIdFromQueue } from '../network/socketQueue'
 import {
   BroadcastAmbiguityError,
-  classifyBroadcastFailure
+  classifyBroadcastFailure,
+  isAlreadyKnownRejection
 } from './broadcastError'
 import { MAX_CONNECTIONS, NEW_CONNECTIONS } from './constants'
 import { UtxoInitOptions } from './types'
@@ -382,6 +383,19 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
         // have relayed the transaction before failing to answer.
         const broadcastErrors: unknown[] = []
         const rejectClassified = (error?: Error): void => {
+          // A server refusing because it already has the transaction is
+          // confirmation the transaction reached the network (from this
+          // attempt or an earlier one with the same signed bytes): success.
+          if (broadcastErrors.some(isAlreadyKnownRejection)) {
+            if (!resolved) {
+              resolved = true
+              log.warn(
+                `broadcastTx: server already has txid ${transaction.txid}; treating broadcast as a success`
+              )
+              resolve(transaction.txid)
+            }
+            return
+          }
           const msg = error != null ? `With error ${error.message}` : ''
           log.error(`broadcastTx fail: ${JSON.stringify(transaction)}\n${msg}`)
           if (classifyBroadcastFailure(broadcastErrors) === 'ambiguous') {

--- a/src/common/utxobased/engine/ServerStates.ts
+++ b/src/common/utxobased/engine/ServerStates.ts
@@ -1,4 +1,3 @@
-import { asMaybe, asObject, asString } from 'cleaners'
 import { EdgeIo, EdgeLog, EdgeTransaction } from 'edge-core-js/types'
 import { parse } from 'uri-js'
 
@@ -21,6 +20,10 @@ import Deferred from '../network/Deferred'
 import { WsTask, WsTaskGenerator } from '../network/Socket'
 import { SocketEmitter, SocketEvent } from '../network/SocketEmitter'
 import { pushUpdate, removeIdFromQueue } from '../network/socketQueue'
+import {
+  BroadcastAmbiguityError,
+  classifyBroadcastFailure
+} from './broadcastError'
 import { MAX_CONNECTIONS, NEW_CONNECTIONS } from './constants'
 import { UtxoInitOptions } from './types'
 
@@ -368,74 +371,28 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
 
   const instance: ServerStates = {
     async broadcastTx(transaction: EdgeTransaction): Promise<string> {
-      // Query the network for the transaction to determine whether a failed
-      // broadcast actually reached the network anyway. A server can relay
-      // the transaction and still return an error or fail to respond, so an
-      // error from every server does not prove the transaction wasn't sent.
-      const isTxidKnown = async (txid: string): Promise<boolean> => {
-        // Ask connected blockbook instances first:
-        for (const uri of Object.keys(serverStatesCache)) {
-          const { blockbook } = serverStatesCache[uri]
-          if (blockbook == null || !blockbook.isConnected) continue
-          const known = await blockbook
-            .fetchTransaction(txid)
-            .then(() => true)
-            .catch(() => false)
-          if (known) return true
-        }
-
-        // Fall back to the NOWNode HTTP API when no blockbook is connected:
-        const { nowNodesApiKey } = initOptions
-        if (nowNodesApiKey == null) return false
-        const nowNodeUris = serverConfigs
-          .filter(config => config.type === 'blockbook-nownode')
-          .map(config => config.uris)
-          .flat(1)
-        for (const uri of nowNodeUris) {
-          const known = await io
-            .fetchCors(`${uri}/api/v2/tx/${txid}`, {
-              headers: {
-                'api-key': nowNodesApiKey
-              }
-            })
-            .then(async response => {
-              if (!response.ok) return false
-              const json = await response.json()
-              return asMaybe(asTxQueryResponse)(json)?.txid === txid
-            })
-            .catch(() => false)
-          if (known) return true
-        }
-        return false
-      }
-
       return await new Promise((resolve, reject) => {
         let resolved = false
         let bad = 0
 
-        // Reject with the given error only when the transaction is verifiably
-        // absent from the network; a transaction that reached the network
-        // despite the error is a successful broadcast.
-        const rejectUnlessTxKnown = (error?: Error): void => {
-          const fail = (): void => {
-            const msg = error != null ? `With error ${error.message}` : ''
-            log.error(
-              `broadcastTx fail: ${JSON.stringify(transaction)}\n${msg}`
+        // Collect every server's failure so the terminal rejection can be
+        // classified: all explicit rejections reject with the original error
+        // (a definitive failure, safe to retry); any transport failure in
+        // the set rejects as ambiguous, because one of those servers may
+        // have relayed the transaction before failing to answer.
+        const broadcastErrors: unknown[] = []
+        const rejectClassified = (error?: Error): void => {
+          const msg = error != null ? `With error ${error.message}` : ''
+          log.error(`broadcastTx fail: ${JSON.stringify(transaction)}\n${msg}`)
+          if (classifyBroadcastFailure(broadcastErrors) === 'ambiguous') {
+            reject(
+              new BroadcastAmbiguityError(
+                broadcastErrors.map(cause => String(cause))
+              )
             )
+          } else {
             reject(error)
           }
-          isTxidKnown(transaction.txid)
-            .then(known => {
-              if (!known) return fail()
-              if (!resolved) {
-                resolved = true
-                log.warn(
-                  `broadcastTx errored, but txid ${transaction.txid} is known to the network; treating broadcast as a success`
-                )
-                resolve(transaction.txid)
-              }
-            })
-            .catch(fail)
         }
 
         const wsUris = Object.keys(serverStatesCache).filter(
@@ -460,8 +417,9 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
                 }
               })
               .catch((e?: Error) => {
+                broadcastErrors.push(e)
                 if (++bad === wsUris.length) {
-                  rejectUnlessTxKnown(e)
+                  rejectClassified(e)
                 }
               })
           }
@@ -526,8 +484,9 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
                 }
               })
               .catch((e?: Error) => {
+                broadcastErrors.push(e)
                 if (++bad === nowNodeUris.length) {
-                  rejectUnlessTxKnown(e)
+                  rejectClassified(e)
                 }
               })
           }
@@ -729,11 +688,3 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
 
   return instance
 }
-
-/**
- * Minimal shape of a Blockbook REST `/api/v2/tx/<txid>` response, used only
- * to confirm that a transaction is known to the network.
- */
-const asTxQueryResponse = asObject({
-  txid: asString
-})

--- a/src/common/utxobased/engine/UtxoEngine.ts
+++ b/src/common/utxobased/engine/UtxoEngine.ts
@@ -433,10 +433,13 @@ export async function makeUtxoEngine(
       })
       if (id !== transaction.txid) {
         // The transaction is on the network at this point, so a mismatched
-        // response txid must not be reported as a send failure.
+        // response txid must not be reported as a send failure. Track the
+        // txid the network actually accepted, or the wallet would watch a
+        // transaction that never confirms.
         log.warn(
           `broadcast response txid mismatch: expected ${transaction.txid} received ${id}`
         )
+        return { ...transaction, txid: id }
       }
       return transaction
     },

--- a/src/common/utxobased/engine/UtxoEngine.ts
+++ b/src/common/utxobased/engine/UtxoEngine.ts
@@ -432,7 +432,11 @@ export async function makeUtxoEngine(
         throw err
       })
       if (id !== transaction.txid) {
-        throw new Error('broadcast response txid does not match original')
+        // The transaction is on the network at this point, so a mismatched
+        // response txid must not be reported as a send failure.
+        log.warn(
+          `broadcast response txid mismatch: expected ${transaction.txid} received ${id}`
+        )
       }
       return transaction
     },

--- a/src/common/utxobased/engine/UtxoEngineProcessor.ts
+++ b/src/common/utxobased/engine/UtxoEngineProcessor.ts
@@ -376,6 +376,13 @@ export function makeUtxoEngineProcessor(
       serverStates.stop()
       clearTaskCache()
       clearPendingTimeouts()
+      // The progress counters describe the sync round that just ended.
+      // Clearing the cache without them would let leftover counts combine
+      // with a smaller refilled cache (saveTx-driven setLookAhead, or
+      // addGapLimitAddresses) into a bogus completed-sync emission and a
+      // seen-tx checkpoint advance on an engine that is not syncing.
+      processedCount = 0
+      processedPercent = 0
       running = false
     },
 

--- a/src/common/utxobased/engine/UtxoEngineProcessor.ts
+++ b/src/common/utxobased/engine/UtxoEngineProcessor.ts
@@ -170,8 +170,12 @@ export function makeUtxoEngineProcessor(
     // Increment the processed count
     processedCount = processedCount + 1
 
-    // If we have no addresses, we should not have not yet began processing.
-    if (expectedProcessCount === 0) throw new Error('No addresses to process')
+    // With no subscribed addresses there is no denominator to compute a
+    // progress ratio from. This is a legitimate state when processing is
+    // driven by saveTx on a disconnected engine (no blockbook sockets, so
+    // nothing is subscribed), so skip the progress update rather than fail
+    // the caller's data write.
+    if (expectedProcessCount === 0) return
 
     const percent = processedCount / expectedProcessCount
     if (percent - processedPercent > CACHE_THROTTLE || percent === 1) {

--- a/src/common/utxobased/engine/UtxoEngineProcessor.ts
+++ b/src/common/utxobased/engine/UtxoEngineProcessor.ts
@@ -475,8 +475,9 @@ export function makeUtxoEngineProcessor(
     },
 
     async broadcastTx(transaction: EdgeTransaction): Promise<string> {
-      await serverStates.broadcastTx(transaction)
-      return transaction.txid
+      // Return the txid the network actually answered with, so the caller
+      // can detect a server accepting the transaction under a different id.
+      return await serverStates.broadcastTx(transaction)
     },
     refillServers(): void {
       serverStates.refillServers()

--- a/src/common/utxobased/engine/UtxoEngineProcessor.ts
+++ b/src/common/utxobased/engine/UtxoEngineProcessor.ts
@@ -167,15 +167,16 @@ export function makeUtxoEngineProcessor(
     const expectedProcessCount =
       Object.keys(taskCache.addressSubscribeCache).length * processesPerAddress
 
+    // With no subscribed addresses there is no denominator to compute a
+    // progress ratio from. The cache is empty when the engine is not running
+    // (never started, or stopped and its task cache cleared) while saveTx
+    // still drives UTXO processing. Skip the progress update, without
+    // counting the call as progress, rather than fail the caller's data
+    // write.
+    if (expectedProcessCount === 0) return
+
     // Increment the processed count
     processedCount = processedCount + 1
-
-    // With no subscribed addresses there is no denominator to compute a
-    // progress ratio from. This is a legitimate state when processing is
-    // driven by saveTx on a disconnected engine (no blockbook sockets, so
-    // nothing is subscribed), so skip the progress update rather than fail
-    // the caller's data write.
-    if (expectedProcessCount === 0) return
 
     const percent = processedCount / expectedProcessCount
     if (percent - processedPercent > CACHE_THROTTLE || percent === 1) {

--- a/src/common/utxobased/engine/broadcastError.ts
+++ b/src/common/utxobased/engine/broadcastError.ts
@@ -1,0 +1,42 @@
+/**
+ * Classification of an all-servers-failed broadcast.
+ *
+ * An explicit rejection is a server answering the broadcast with a Blockbook
+ * error response: the server received the transaction and refused it, so the
+ * same signed bytes will be refused again and cannot be on the network from
+ * this attempt. Anything else (a request timeout, a dropped connection, an
+ * HTTP status error whose body was never read) leaves relay possible: a
+ * server can relay the transaction to the network and still fail to answer.
+ *
+ * The classification is pure error-shape inspection. It adds no network
+ * calls, so it cannot add latency to the send path.
+ */
+
+/**
+ * A broadcast that failed on every server where at least one failure was a
+ * transport error rather than an explicit rejection. The transaction cannot
+ * be assumed absent from the network, so a retry could produce a second real
+ * payment. Consumers branch on `name === 'BroadcastAmbiguityError'`; class
+ * identity does not survive the core bridge, names and properties do.
+ */
+export class BroadcastAmbiguityError extends Error {
+  readonly causes: string[]
+
+  constructor(causes: string[]) {
+    super('Broadcast failed, but the transaction may have reached the network')
+    this.name = 'BroadcastAmbiguityError'
+    this.causes = causes
+  }
+}
+
+export const isExplicitBroadcastRejection = (error: unknown): boolean =>
+  String(error instanceof Error ? error.message : error).includes(
+    'Blockbook Error: '
+  )
+
+export const classifyBroadcastFailure = (
+  errors: unknown[]
+): 'rejected' | 'ambiguous' =>
+  errors.length > 0 && errors.every(isExplicitBroadcastRejection)
+    ? 'rejected'
+    : 'ambiguous'

--- a/src/common/utxobased/engine/broadcastError.ts
+++ b/src/common/utxobased/engine/broadcastError.ts
@@ -34,9 +34,25 @@ export const isExplicitBroadcastRejection = (error: unknown): boolean =>
     'Blockbook Error: '
   )
 
+/**
+ * A failure from a server that provably never accepted the payload, so it
+ * cannot have relayed the transaction: the Electrum stub refuses
+ * broadcastTx synchronously. Such failures say nothing about relay and are
+ * excluded from the ambiguity determination. (A not-yet-connected blockbook
+ * is NOT in this class: its queued request can still send once the
+ * connection completes, so its timeout stays ambiguous.)
+ */
+export const isNonRelayFailure = (error: unknown): boolean =>
+  String(error instanceof Error ? error.message : error).includes(
+    'not supported for Electrum connections'
+  )
+
 export const classifyBroadcastFailure = (
   errors: unknown[]
-): 'rejected' | 'ambiguous' =>
-  errors.length > 0 && errors.every(isExplicitBroadcastRejection)
+): 'rejected' | 'ambiguous' => {
+  if (errors.length === 0) return 'ambiguous'
+  const relayCapable = errors.filter(error => !isNonRelayFailure(error))
+  return relayCapable.every(isExplicitBroadcastRejection)
     ? 'rejected'
     : 'ambiguous'
+}

--- a/src/common/utxobased/engine/broadcastError.ts
+++ b/src/common/utxobased/engine/broadcastError.ts
@@ -35,6 +35,18 @@ export const isExplicitBroadcastRejection = (error: unknown): boolean =>
   )
 
 /**
+ * A rejection that means the server ALREADY HAS the transaction
+ * ("transaction already in block chain", "txn-already-in-mempool",
+ * "txn-already-known"). This is a confirmation the transaction reached the
+ * network, from this attempt or an earlier one with the same signed bytes,
+ * so the broadcast must be treated as a success: presenting it as a
+ * failure invites the duplicate-payment retry this work exists to stop.
+ */
+export const isAlreadyKnownRejection = (error: unknown): boolean =>
+  isExplicitBroadcastRejection(error) &&
+  /alread/i.test(String(error instanceof Error ? error.message : error))
+
+/**
  * A failure from a server that provably never accepted the payload, so it
  * cannot have relayed the transaction: the Electrum stub refuses
  * broadcastTx synchronously. Such failures say nothing about relay and are

--- a/test/common/utxobased/engine/broadcastError.spec.ts
+++ b/test/common/utxobased/engine/broadcastError.spec.ts
@@ -1,0 +1,60 @@
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+
+import {
+  BroadcastAmbiguityError,
+  classifyBroadcastFailure,
+  isExplicitBroadcastRejection
+} from '../../../../src/common/utxobased/engine/broadcastError'
+
+describe('broadcast failure classification', function () {
+  it('classifies all-explicit-rejection sets as rejected', function () {
+    assert.equal(
+      classifyBroadcastFailure([
+        new Error('Blockbook Error: -26: dust'),
+        new Error('Blockbook Error: -25: missing inputs')
+      ]),
+      'rejected'
+    )
+  })
+
+  it('classifies any transport failure in the set as ambiguous', function () {
+    assert.equal(
+      classifyBroadcastFailure([
+        new Error('Blockbook Error: -26: dust'),
+        new Error('Timeout for request 42')
+      ]),
+      'ambiguous'
+    )
+    assert.equal(
+      classifyBroadcastFailure([new Error('Timeout for request 42')]),
+      'ambiguous'
+    )
+    assert.equal(
+      classifyBroadcastFailure([
+        new Error('Failed to broadcast transaction via Blockbook: HTTP 503')
+      ]),
+      'ambiguous'
+    )
+  })
+
+  it('treats missing or empty error information as ambiguous', function () {
+    assert.equal(classifyBroadcastFailure([]), 'ambiguous')
+    assert.equal(classifyBroadcastFailure([undefined]), 'ambiguous')
+  })
+
+  it('recognizes explicit rejections by the Blockbook error marker', function () {
+    assert.isTrue(
+      isExplicitBroadcastRejection(new Error('Blockbook Error: -26: dust'))
+    )
+    assert.isFalse(isExplicitBroadcastRejection(new Error('socket closed')))
+    assert.isFalse(isExplicitBroadcastRejection(undefined))
+  })
+
+  it('keeps a bridge-stable name and carries its causes', function () {
+    const error = new BroadcastAmbiguityError(['Timeout for request 42'])
+    assert.equal(error.name, 'BroadcastAmbiguityError')
+    assert.deepEqual(error.causes, ['Timeout for request 42'])
+    assert.instanceOf(error, Error)
+  })
+})

--- a/test/common/utxobased/engine/broadcastError.spec.ts
+++ b/test/common/utxobased/engine/broadcastError.spec.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha'
 import {
   BroadcastAmbiguityError,
   classifyBroadcastFailure,
+  isAlreadyKnownRejection,
   isExplicitBroadcastRejection,
   isNonRelayFailure
 } from '../../../../src/common/utxobased/engine/broadcastError'
@@ -76,6 +77,27 @@ describe('broadcast failure classification', function () {
     )
     assert.isFalse(isExplicitBroadcastRejection(new Error('socket closed')))
     assert.isFalse(isExplicitBroadcastRejection(undefined))
+  })
+
+  it('recognizes already-known rejections as network confirmation', function () {
+    assert.isTrue(
+      isAlreadyKnownRejection(
+        new Error('Blockbook Error: -27: transaction already in block chain')
+      )
+    )
+    assert.isTrue(
+      isAlreadyKnownRejection(
+        new Error('Blockbook Error: txn-already-in-mempool')
+      )
+    )
+    assert.isTrue(
+      isAlreadyKnownRejection(new Error('Blockbook Error: txn-already-known'))
+    )
+    assert.isFalse(
+      isAlreadyKnownRejection(new Error('Blockbook Error: -26: dust'))
+    )
+    // "already" in a transport error is not a Blockbook rejection.
+    assert.isFalse(isAlreadyKnownRejection(new Error('socket already closed')))
   })
 
   it('keeps a bridge-stable name and carries its causes', function () {

--- a/test/common/utxobased/engine/broadcastError.spec.ts
+++ b/test/common/utxobased/engine/broadcastError.spec.ts
@@ -4,7 +4,8 @@ import { describe, it } from 'mocha'
 import {
   BroadcastAmbiguityError,
   classifyBroadcastFailure,
-  isExplicitBroadcastRejection
+  isExplicitBroadcastRejection,
+  isNonRelayFailure
 } from '../../../../src/common/utxobased/engine/broadcastError'
 
 describe('broadcast failure classification', function () {
@@ -41,6 +42,32 @@ describe('broadcast failure classification', function () {
   it('treats missing or empty error information as ambiguous', function () {
     assert.equal(classifyBroadcastFailure([]), 'ambiguous')
     assert.equal(classifyBroadcastFailure([undefined]), 'ambiguous')
+  })
+
+  it('excludes non-relay failures from the ambiguity determination', function () {
+    const electrumStub = new Error(
+      'broadcastTx not supported for Electrum connections'
+    )
+    assert.isTrue(isNonRelayFailure(electrumStub))
+    // An Electrum stub alongside explicit rejections must not turn a
+    // definitively failed broadcast into an ambiguous one.
+    assert.equal(
+      classifyBroadcastFailure([
+        electrumStub,
+        new Error('Blockbook Error: -26: dust')
+      ]),
+      'rejected'
+    )
+    // All-stub sets never sent anything anywhere: definitively failed.
+    assert.equal(classifyBroadcastFailure([electrumStub]), 'rejected')
+    // A transport failure still dominates.
+    assert.equal(
+      classifyBroadcastFailure([
+        electrumStub,
+        new Error('Timeout for request 42')
+      ]),
+      'ambiguous'
+    )
   })
 
   it('recognizes explicit rejections by the Blockbook error marker', function () {

--- a/test/common/utxobased/engine/saveTx.spec.ts
+++ b/test/common/utxobased/engine/saveTx.spec.ts
@@ -32,6 +32,8 @@ const SPENT_TXID =
   '19e59364daf34d97ed6584e9e978f3e2375adea9a4561a83d2066d92a010ba13'
 const NEW_TXID =
   'f00dbabef00dbabef00dbabef00dbabef00dbabef00dbabef00dbabef00dbabe'
+const SECOND_TXID =
+  'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
 
 describe('saveTx on a disconnected engine', function () {
   it('resolves with zero subscribed addresses', async function () {
@@ -72,7 +74,7 @@ describe('saveTx on a disconnected engine', function () {
     const factory = edgeCorePlugins[tests.pluginId]
     if (typeof factory !== 'function')
       throw new Error(`Missing plugin factory for ${tests.pluginId}`)
-    const plugin: EdgeCurrencyPlugin = factory(pluginOpts) as any
+    const plugin = factory(pluginOpts) as EdgeCurrencyPlugin
 
     const tools: EdgeCurrencyTools = await plugin.makeCurrencyTools()
     const privateKeys = await tools.createPrivateKey(tests.WALLET_TYPE)
@@ -84,13 +86,22 @@ describe('saveTx on a disconnected engine', function () {
     })
     const keys: JsonObject = { ...privateKeys, ...publicKeys }
 
+    // Track progress-side emissions: an engine that never ran a sync must
+    // never report itself fully synced, and must never advance the seen-tx
+    // checkpoint, no matter how many saveTx calls process UTXOs.
+    const addressesCheckedRatios: number[] = []
+    const seenTxCheckpoints: string[] = []
     const callbacks: EdgeCurrencyEngineCallbacks = {
       onAddressChanged: noOp,
-      onAddressesChecked: noOp,
+      onAddressesChecked: (ratio: number) => {
+        addressesCheckedRatios.push(ratio)
+      },
       onBalanceChanged: noOp,
       onBlockHeightChanged: noOp,
       onNewTokens: noOp,
-      onSeenTxCheckpoint: noOp,
+      onSeenTxCheckpoint: (checkpoint: string) => {
+        seenTxCheckpoints.push(checkpoint)
+      },
       onStakingStatusChanged: noOp,
       onTokenBalanceChanged: noOp,
       onTransactions: noOp,
@@ -109,9 +120,11 @@ describe('saveTx on a disconnected engine', function () {
       userSettings: {}
     }
 
-    // The engine is never started, so no blockbook connects and no address
-    // is ever subscribed. This is the same state as a running engine whose
-    // sockets are all down: taskCache.addressSubscribeCache is empty.
+    // The engine is never started, so nothing populates the address
+    // subscribe cache (startEngine's initializeAddressSubscriptions and
+    // setLookAhead are what fill it, network-free). A stopped engine is in
+    // the same state: stop() clears the task cache. saveTx must still
+    // resolve there.
     const engine: EdgeCurrencyEngine = await plugin.makeCurrencyEngine(
       { type: tests.WALLET_TYPE, keys, id: '!' },
       engineOpts
@@ -163,6 +176,55 @@ describe('saveTx on a disconnected engine', function () {
     assert.isTrue(
       txs.some(tx => tx.txid === NEW_TXID),
       'saved transaction should be listed'
+    )
+
+    // A second saveTx spends the first transaction's output. The first
+    // call's setLookAhead derived lookahead addresses into the subscribe
+    // cache, so this call has a nonzero progress denominator; the first
+    // call's denominator-less pass must not have counted as progress.
+    const edgeTx2: EdgeTransaction = {
+      ...edgeTx,
+      otherParams: {
+        psbt: {
+          base64: '',
+          inputs: [
+            {
+              hash: Buffer.from(NEW_TXID, 'hex').reverse(),
+              index: 0,
+              value: 16200000,
+              scriptPubkey: scriptPubkeyBuffer,
+              sequence: 0xffffffff
+            }
+          ],
+          outputs: [
+            {
+              value: 16150000,
+              scriptPubkey: scriptPubkeyBuffer
+            }
+          ]
+        }
+      },
+      txid: SECOND_TXID
+    }
+    await engine.saveTx(edgeTx2)
+
+    const txsAfterSecond = await engine.getTransactions({ tokenId: null })
+    assert.isTrue(
+      txsAfterSecond.some(tx => tx.txid === SECOND_TXID),
+      'second saved transaction should be listed'
+    )
+
+    // Progress bookkeeping must not fabricate a completed sync out of
+    // saveTx-driven processing: an engine that never synced must not emit a
+    // fully-synced ratio and must not advance the seen-tx checkpoint.
+    assert.notInclude(
+      addressesCheckedRatios,
+      1,
+      'saveTx must not produce a fully-synced progress emission'
+    )
+    assert.isEmpty(
+      seenTxCheckpoints,
+      'saveTx must not advance the seen-tx checkpoint'
     )
   })
 })

--- a/test/common/utxobased/engine/saveTx.spec.ts
+++ b/test/common/utxobased/engine/saveTx.spec.ts
@@ -1,0 +1,168 @@
+import { assert } from 'chai'
+import { makeMemoryDisklet, makeNodeDisklet } from 'disklet'
+import {
+  EdgeCorePluginOptions,
+  EdgeCurrencyEngine,
+  EdgeCurrencyEngineCallbacks,
+  EdgeCurrencyEngineOptions,
+  EdgeCurrencyPlugin,
+  EdgeCurrencyTools,
+  EdgeTransaction,
+  JsonObject,
+  makeFakeIo
+} from 'edge-core-js'
+import { describe, it } from 'mocha'
+
+import edgeCorePlugins from '../../../../src/index'
+import { noOp, testLog } from '../../../util/testLog'
+import { makeFakeNativeIo } from '../../../utils'
+import { fixtures } from './engine.fixtures/index'
+
+const [tests] = fixtures
+
+/**
+ * A transaction paying to an address that the dummy-data wallet owns
+ * (scriptPubkey a9142244... with a bip49 path), spending a UTXO that the
+ * dummy-data set holds (19e59364...:0). This makes saveTx's
+ * getOwnUtxosFromTx return both a spent input and a new output, which drives
+ * processUtxos -> processDataLayerUtxos -> updateProgressRatio.
+ */
+const OWN_SCRIPT_PUBKEY = 'a9142244ce86d664e85801f7eb2a56dd35afd268212587'
+const SPENT_TXID =
+  '19e59364daf34d97ed6584e9e978f3e2375adea9a4561a83d2066d92a010ba13'
+const NEW_TXID =
+  'f00dbabef00dbabef00dbabef00dbabef00dbabef00dbabef00dbabef00dbabe'
+
+describe('saveTx on a disconnected engine', function () {
+  it('resolves with zero subscribed addresses', async function () {
+    this.timeout(10000)
+
+    const fakeIo = makeFakeIo()
+    const fixtureDisklet = makeNodeDisklet(tests.dummyDataPath)
+    const fakeIoDisklet = makeMemoryDisklet()
+    const nativeIo = makeFakeNativeIo()
+
+    // Preload the wallet's data layer with the dummy dataset so the wallet
+    // owns addresses and UTXOs:
+    const migrate = async (dir: string): Promise<void> => {
+      const files = await fixtureDisklet.list(dir)
+      await Promise.all(
+        Object.entries(files).map(async ([path, type]) => {
+          if (type === 'folder') await migrate(path)
+          if (type === 'file')
+            await fixtureDisklet
+              .getText(path)
+              .then(async data => await fakeIoDisklet.setText(path, data))
+        })
+      )
+    }
+    await migrate('tables')
+
+    const pluginOpts: EdgeCorePluginOptions = {
+      initOptions: {},
+      io: {
+        ...fakeIo,
+        random: () => Uint8Array.from(tests.key)
+      },
+      log: testLog,
+      infoPayload: {},
+      nativeIo,
+      pluginDisklet: fakeIoDisklet
+    }
+    const factory = edgeCorePlugins[tests.pluginId]
+    if (typeof factory !== 'function')
+      throw new Error(`Missing plugin factory for ${tests.pluginId}`)
+    const plugin: EdgeCurrencyPlugin = factory(pluginOpts) as any
+
+    const tools: EdgeCurrencyTools = await plugin.makeCurrencyTools()
+    const privateKeys = await tools.createPrivateKey(tests.WALLET_TYPE)
+    Object.assign(privateKeys, { coinType: 0, format: tests.WALLET_FORMAT })
+    const publicKeys = await tools.derivePublicKey({
+      type: tests.WALLET_TYPE,
+      keys: privateKeys,
+      id: '!'
+    })
+    const keys: JsonObject = { ...privateKeys, ...publicKeys }
+
+    const callbacks: EdgeCurrencyEngineCallbacks = {
+      onAddressChanged: noOp,
+      onAddressesChecked: noOp,
+      onBalanceChanged: noOp,
+      onBlockHeightChanged: noOp,
+      onNewTokens: noOp,
+      onSeenTxCheckpoint: noOp,
+      onStakingStatusChanged: noOp,
+      onTokenBalanceChanged: noOp,
+      onTransactions: noOp,
+      onTransactionsChanged: noOp,
+      onTxidsChanged: noOp,
+      onUnactivatedTokenIdsChanged: noOp,
+      onWcNewContractCall: noOp
+    }
+    const engineOpts: EdgeCurrencyEngineOptions = {
+      callbacks,
+      log: testLog,
+      walletLocalDisklet: fakeIoDisklet,
+      walletLocalEncryptedDisklet: fakeIoDisklet,
+      customTokens: {},
+      enabledTokenIds: [],
+      userSettings: {}
+    }
+
+    // The engine is never started, so no blockbook connects and no address
+    // is ever subscribed. This is the same state as a running engine whose
+    // sockets are all down: taskCache.addressSubscribeCache is empty.
+    const engine: EdgeCurrencyEngine = await plugin.makeCurrencyEngine(
+      { type: tests.WALLET_TYPE, keys, id: '!' },
+      engineOpts
+    )
+
+    const scriptPubkeyBuffer = Buffer.from(OWN_SCRIPT_PUBKEY, 'hex')
+    const edgeTx: EdgeTransaction = {
+      blockHeight: 0,
+      currencyCode: 'TESTBTC',
+      date: 1723000000,
+      isSend: true,
+      memos: [],
+      nativeAmount: '-50000',
+      networkFee: '1000',
+      networkFees: [],
+      otherParams: {
+        psbt: {
+          base64: '',
+          inputs: [
+            {
+              hash: Buffer.from(SPENT_TXID, 'hex').reverse(),
+              index: 0,
+              value: 16250000,
+              scriptPubkey: scriptPubkeyBuffer,
+              sequence: 0xffffffff
+            }
+          ],
+          outputs: [
+            {
+              value: 16200000,
+              scriptPubkey: scriptPubkeyBuffer
+            }
+          ]
+        }
+      },
+      ourReceiveAddresses: [],
+      signedTx: '0100000000',
+      tokenId: null,
+      txid: NEW_TXID,
+      walletId: '!'
+    }
+
+    // The regression under test: updateProgressRatio used to throw
+    // 'No addresses to process' here, failing saveTx AFTER the transaction
+    // had already been saved and its inputs marked spent.
+    await engine.saveTx(edgeTx)
+
+    const txs = await engine.getTransactions({ tokenId: null })
+    assert.isTrue(
+      txs.some(tx => tx.txid === NEW_TXID),
+      'saved transaction should be listed'
+    )
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Technical design doc](https://github.com/EdgeApp/edge-react-gui/blob/jon/send-post-broadcast-failure/src/docs/send-post-broadcast-failure.md)

Fixes the engine half of Edge bug "Send - multiple transactions after network error": one intended Bitcoin send became five real payments because every failure the user saw happened AFTER a successful broadcast.

Asana: https://app.asana.com/1/9976422036640/project/1213843652804305/task/1217135300337949

Two defects fixed:

1. `saveTx` failed on a disconnected engine. `updateProgressRatio` threw `No addresses to process` whenever zero addresses were subscribed (exactly the state of a wallet whose blockbook sockets are down), and `saveTx` reaches it via `processUtxos` after the transaction is already saved and its inputs marked spent. The throw is progress bookkeeping with no denominator, not a data error, so it is now a no-op instead of failing the caller's data write. Regression test: `saveTx` on a never-connected engine resolves (`test/common/utxobased/engine/saveTx.spec.ts`, red before the fix with the exact incident stack).

2. Broadcast failure was ambiguous. `ServerStates.broadcastTx` multicasts to every connected blockbook (or every NOWNode HTTP fallback) and rejects only when all fail, but a server can relay the transaction and still return an error or time out, so "all servers errored" does not prove the transaction is absent from the network. The exhausted broadcast is now CLASSIFIED, with no added network calls: an already-known rejection (already in block chain / txn-already-in-mempool / txn-already-known) resolves the broadcast as a SUCCESS, since the server's own answer proves the transaction reached the network; when every relay-capable failure is an explicit Blockbook rejection the engine rejects with the original error (definitively failed, safe to retry); when any failure is a transport error it rejects with `BroadcastAmbiguityError`, which the GUI will use to lock the retry path and show may-have-worked messaging (tracked separately). Electrum stub refusals, which provably never sent anything, are excluded from the determination. An earlier revision queried the network for the txid before rejecting; that was removed after review, since an immediate query runs under the same network conditions that made the broadcast ambiguous and proves nothing either way. The post-broadcast txid-mismatch throw in `UtxoEngine.broadcastTx` (dead code today, failure-after-success if ever revived) now logs a warning and returns the transaction with the network's txid so the wallet tracks what was actually accepted.

The GUI half (send scene must not present post-broadcast errors as failed sends) is the EdgeApp/edge-react-gui companion PR on branch `jon/send-post-broadcast-failure`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes UTXO send/broadcast and saveTx behavior on the payment path; incorrect classification could still allow duplicate sends or block legitimate retries.
> 
> **Overview**
> Fixes cases where a **successful broadcast** was still reported as a failed send, which led to duplicate payments when users retried.
> 
> **`saveTx` on a disconnected engine** no longer fails after the transaction is already saved. When no addresses are subscribed, `updateProgressRatio` skips progress updates instead of throwing `No addresses to process`. **`stop()`** resets progress counters so leftover counts cannot emit a bogus fully-synced state during later `saveTx`-driven UTXO work.
> 
> **Exhausted multicasts** in `ServerStates.broadcastTx` are classified via new `broadcastError` helpers: all explicit Blockbook rejections still reject with the original error (safe to retry); any transport-style failure rejects with **`BroadcastAmbiguityError`** so the UI can treat the send as possibly on-network. **Already-known** mempool/chain rejections are treated as success. **`UtxoEngine.broadcastTx`** logs and returns the network’s txid on mismatch instead of throwing after relay.
> 
> Tests cover classification (`broadcastError.spec.ts`) and disconnected-engine `saveTx` (`saveTx.spec.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e5b66fd16234ffdb34709b8ea4095362b30700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
