### PR TITLE
Broadcast to every server at once, and stop leaking the NOWNodes key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Stop sending the NOWNodes API key to Edge's own Blockbook HTTP servers. They are now configured as plain `blockbook` servers, which are also used when no NOWNodes key is configured.
+
 ## 3.12.0 (2026-08-05)
 
 - added: `signatureFormat` option on `signMessage`, accepting `electrum` (the default) or `bip137`. Existing callers keep the legacy Electrum header byte; BIP137 is opt-in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- changed: `broadcastTx` now sends to every cached Blockbook socket and every Edge Blockbook HTTP server at once, then to the NOWNodes HTTP servers two seconds later or as soon as that first wave has failed, resolving on the first success and rejecting only when all attempts fail or time out (30 seconds per attempt, matching the socket layer). Previously the HTTP fallback ran only when no socket reported itself connected, so one unresponsive socket could fail the whole broadcast without any HTTP attempt.
 - fixed: Stop sending the NOWNodes API key to Edge's own Blockbook HTTP servers. They are now configured as plain `blockbook` servers, which are also used when no NOWNodes key is configured.
 
 ## 3.12.0 (2026-08-05)

--- a/src/common/plugin/types.ts
+++ b/src/common/plugin/types.ts
@@ -158,7 +158,13 @@ export interface EngineInfo {
 }
 
 export interface ServerConfig {
-  type: 'blockbook-nownode'
+  /**
+   * - `blockbook`: a public Blockbook HTTP server. No credentials are sent.
+   * - `blockbook-nownode`: a NOWNodes Blockbook HTTP server. Requests carry
+   *   the `nowNodesApiKey` init option as the `api-key` header, and the
+   *   server is skipped when no key is configured.
+   */
+  type: 'blockbook' | 'blockbook-nownode'
   uris: string[]
 }
 

--- a/src/common/utxobased/engine/ServerStates.ts
+++ b/src/common/utxobased/engine/ServerStates.ts
@@ -39,6 +39,11 @@ interface ServerStateConfig {
   pluginInfo: PluginInfo
   pluginState: PluginState
   walletInfo: SafeWalletInfo
+  /**
+   * Upper bound on any single broadcast attempt. Defaults to the same 30
+   * seconds the socket layer uses for a request. Exposed for tests.
+   */
+  broadcastTimeoutMs?: number
 }
 
 export interface ServerStates {
@@ -92,6 +97,42 @@ interface ServerStatesCache {
   [uri: string]: ServerState
 }
 
+/**
+ * How long broadcastTx gives the first wave (our sockets and Edge's own HTTP
+ * servers) before it also sends the transaction to the NOWNodes HTTP servers.
+ * NOWNodes is a third party, so it should only see a transaction when our own
+ * infrastructure has not already carried it. A first wave that fails outright
+ * does not wait this long; the second wave fires as soon as it has all failed.
+ */
+export const NOWNODES_BROADCAST_DELAY_MS = 2000
+
+/**
+ * Every broadcast attempt is counted toward "all attempts failed", so every
+ * attempt must settle. Sockets already expire a request after 30 seconds
+ * (Socket.ts); HTTP has no such bound of its own, and a server that accepts
+ * the connection and never answers would otherwise hold the whole broadcast
+ * open. This mirrors the socket figure.
+ */
+export const BROADCAST_ATTEMPT_TIMEOUT_MS = 30000
+
+const withTimeout = async <T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string
+): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(message))
+    }, ms)
+  })
+  try {
+    return await Promise.race([promise, timeout])
+  } finally {
+    if (timer != null) clearTimeout(timer)
+  }
+}
+
 export function makeServerStates(config: ServerStateConfig): ServerStates {
   const {
     engineEmitter,
@@ -103,6 +144,7 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
     walletInfo
   } = config
   const { serverConfigs = [] } = pluginInfo.engineInfo
+  const { broadcastTimeoutMs = BROADCAST_ATTEMPT_TIMEOUT_MS } = config
   log('Making server states')
 
   const serverStatesCache: ServerStatesCache = {}
@@ -366,131 +408,171 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
   }
 
   const instance: ServerStates = {
+    /**
+     * Broadcast in two waves:
+     *
+     * 1. Immediately: every blockbook in the connection cache (whether or not
+     *    its socket has finished connecting; a queued request transmits as
+     *    soon as the socket opens, and times out otherwise) and every
+     *    `blockbook` HTTP server, which are Edge's own.
+     * 2. After NOWNODES_BROADCAST_DELAY_MS, or as soon as every first-wave
+     *    attempt has failed, whichever comes first: the `blockbook-nownode`
+     *    HTTP servers. These are a third party and only see the transaction
+     *    when our own infrastructure has not already carried it.
+     *
+     * The first success wins. The promise rejects only after every attempt
+     * has failed. Earlier versions only used HTTP when no socket was
+     * connected, so a single socket that looked connected but never answered
+     * could fail the whole broadcast without any HTTP attempt.
+     */
     async broadcastTx(transaction: EdgeTransaction): Promise<string> {
       return await new Promise((resolve, reject) => {
-        let resolved = false
-        let bad = 0
-
-        const wsUris = Object.keys(serverStatesCache).filter(
-          uri => serverStatesCache[uri].blockbook != null
-        )
-
-        // Determine if there are any connected blockbook instances
-        const isAnyBlockbookConnected = wsUris.some(
-          uri => serverStatesCache[uri].blockbook.isConnected
-        )
-
-        if (isAnyBlockbookConnected) {
-          for (const uri of wsUris) {
-            const { blockbook } = serverStatesCache[uri]
-            if (blockbook == null) continue
-            blockbook
-              .broadcastTx(transaction)
-              .then(response => {
-                if (!resolved) {
-                  resolved = true
-                  resolve(response.result)
-                }
-              })
-              .catch((e?: Error) => {
-                if (++bad === wsUris.length) {
-                  const msg = e != null ? `With error ${e.message}` : ''
-                  log.error(
-                    `broadcastTx fail: ${JSON.stringify(transaction)}\n${msg}`
-                  )
-                  reject(e)
-                }
-              })
-          }
+        interface Attempt {
+          uri: string
+          run: () => Promise<string>
         }
 
-        // Broadcast through any HTTP URI that may be configured, only if no
-        // blockbook instances are connected.
-        if (!isAnyBlockbookConnected) {
-          // This is for the future when we want to get HTTP servers from the user
-          // settings:
-          // const httpUris = pluginState.getLocalServers(Infinity, [
-          //   /^http(?:s)?:/i
-          // ])
-
-          const { nowNodesApiKey } = initOptions
-
-          // Build the HTTP targets, attaching the NOWNodes key ONLY to
-          // NOWNodes servers. Edge's own Blockbook servers answer /api/v2
-          // unauthenticated and must not be sent the key.
-          const httpTargets: Array<{
-            uri: string
-            headers: { [key: string]: string }
-          }> = []
-          for (const config of serverConfigs) {
-            if (config.type === 'blockbook-nownode') {
-              // NOWNodes answers 401 without a key, so skip those servers
-              // rather than failing a broadcast the public servers could
-              // still carry.
-              if (nowNodesApiKey == null) {
-                log.warn(
-                  'broadcastTx: skipping NOWNodes HTTP servers (no nowNodesApiKey)'
-                )
-                continue
-              }
-              for (const uri of config.uris) {
-                httpTargets.push({
-                  uri,
-                  headers: { 'api-key': nowNodesApiKey }
-                })
-              }
-            } else {
-              for (const uri of config.uris) {
-                httpTargets.push({ uri, headers: {} })
-              }
-            }
-          }
-
-          // If there are no usable HTTP servers, reject the promise
-          if (httpTargets.length < 1) {
-            // If no HTTP servers are available, and we had no connected blockbook
-            // instances, reject the promise with a message indicating no
-            // available connections.
-            reject(
-              new Error('No available connections. Check your internet signal.')
-            )
-            return
-          }
-
-          for (const { uri, headers } of httpTargets) {
-            log.warn('Falling back to server broadcast over HTTP:', uri)
-
-            // HTTP Fallback
-            io.fetchCors(`${uri}/api/v2/sendtx/`, {
+        const httpAttempt = (
+          uri: string,
+          headers: { [key: string]: string }
+        ): Attempt => ({
+          uri,
+          run: async () => {
+            const response = await io.fetchCors(`${uri}/api/v2/sendtx/`, {
               method: 'POST',
               headers,
               body: transaction.signedTx
             })
-              .then(async response => {
-                if (!response.ok) {
-                  throw new Error(
-                    `Failed to broadcast transaction via Blockbook: HTTP ${response.status}`
-                  )
-                }
-                const json = await response.json()
-                return asBlockbookResponse(asBroadcastTxResponse)(json)
-              })
-              .then(response => {
-                if (!resolved) {
-                  resolved = true
-                  resolve(response.result)
-                }
-              })
-              .catch((e?: Error) => {
-                if (++bad === httpTargets.length) {
-                  const msg = e != null ? `With error ${e.message}` : ''
-                  log.error(
-                    `broadcastTx fail: ${JSON.stringify(transaction)}\n${msg}`
-                  )
-                  reject(e)
-                }
-              })
+            if (!response.ok) {
+              throw new Error(
+                `Failed to broadcast transaction via Blockbook: HTTP ${response.status}`
+              )
+            }
+            const json = await response.json()
+            return asBlockbookResponse(asBroadcastTxResponse)(json).result
           }
+        })
+
+        //
+        // Build both waves up front, so `attempts` is the full count and an
+        // all-fail first wave cannot reject before the second has run.
+        //
+        const firstWave: Attempt[] = []
+        const secondWave: Attempt[] = []
+
+        for (const uri of Object.keys(serverStatesCache)) {
+          const { blockbook } = serverStatesCache[uri]
+          if (blockbook == null) continue
+          firstWave.push({
+            uri,
+            run: async () => (await blockbook.broadcastTx(transaction)).result
+          })
+        }
+
+        // This is for the future when we want to get HTTP servers from the user
+        // settings:
+        // const httpUris = pluginState.getLocalServers(Infinity, [
+        //   /^http(?:s)?:/i
+        // ])
+        const { nowNodesApiKey } = initOptions
+        for (const config of serverConfigs) {
+          if (config.type === 'blockbook-nownode') {
+            // NOWNodes requires the key, and the key must not go anywhere else:
+            if (nowNodesApiKey == null) {
+              log.warn(
+                'broadcastTx: skipping NOWNodes HTTP servers (no nowNodesApiKey)'
+              )
+              continue
+            }
+            for (const uri of config.uris) {
+              secondWave.push(httpAttempt(uri, { 'api-key': nowNodesApiKey }))
+            }
+          } else {
+            for (const uri of config.uris) {
+              firstWave.push(httpAttempt(uri, {}))
+            }
+          }
+        }
+
+        const attempts = firstWave.length + secondWave.length
+        if (attempts === 0) {
+          reject(
+            new Error('No available connections. Check your internet signal.')
+          )
+          return
+        }
+
+        let resolved = false
+        let failures = 0
+        const failureMessages: string[] = []
+        let secondWaveFired = false
+        let secondWaveTimer: ReturnType<typeof setTimeout> | undefined
+
+        const onSuccess = (uri: string, txid: string): void => {
+          if (resolved) return
+          resolved = true
+          if (secondWaveTimer != null) clearTimeout(secondWaveTimer)
+          log(`broadcastTx succeeded via ${uri}: ${txid}`)
+          resolve(txid)
+        }
+        const onFailure = (uri: string, error: unknown): void => {
+          const message = error instanceof Error ? error.message : String(error)
+          failureMessages.push(`${uri}: ${message}`)
+          log.warn(`broadcastTx attempt failed for ${uri}: ${message}`)
+          failures++
+          if (resolved) return
+          if (failures === attempts) {
+            log.error(
+              `broadcastTx fail: ${JSON.stringify(
+                transaction
+              )}\n${failureMessages.join('\n')}`
+            )
+            reject(
+              error instanceof Error
+                ? error
+                : new Error(`Broadcast failed: ${failureMessages.join('; ')}`)
+            )
+            return
+          }
+          // Every first-wave attempt has failed, so there is nothing left to
+          // wait for. Fire the second wave now rather than sit out the delay.
+          if (!secondWaveFired && failures >= firstWave.length) {
+            fireSecondWave()
+          }
+        }
+        const fire = (attempt: Attempt): void => {
+          withTimeout(
+            attempt.run(),
+            broadcastTimeoutMs,
+            `Timeout for broadcast to ${attempt.uri}`
+          )
+            .then(txid => {
+              onSuccess(attempt.uri, txid)
+            })
+            .catch((error: unknown) => {
+              onFailure(attempt.uri, error)
+            })
+        }
+        const fireSecondWave = (): void => {
+          if (secondWaveFired) return
+          secondWaveFired = true
+          if (secondWaveTimer != null) clearTimeout(secondWaveTimer)
+          if (secondWave.length === 0) return
+          log.warn(
+            'broadcastTx: first wave has not resolved, trying NOWNodes servers'
+          )
+          for (const attempt of secondWave) fire(attempt)
+        }
+
+        for (const attempt of firstWave) fire(attempt)
+        if (firstWave.length === 0) {
+          // Nothing of our own to try first:
+          fireSecondWave()
+        } else if (secondWave.length > 0) {
+          secondWaveTimer = setTimeout(
+            fireSecondWave,
+            NOWNODES_BROADCAST_DELAY_MS
+          )
         }
       })
     },

--- a/src/common/utxobased/engine/ServerStates.ts
+++ b/src/common/utxobased/engine/ServerStates.ts
@@ -414,13 +414,40 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
           // ])
 
           const { nowNodesApiKey } = initOptions
-          const nowNodeUris = serverConfigs
-            .filter(config => config.type === 'blockbook-nownode')
-            .map(config => config.uris)
-            .flat(1)
 
-          // If there are no HTTP servers, reject the promise
-          if (nowNodeUris.length < 1) {
+          // Build the HTTP targets, attaching the NOWNodes key ONLY to
+          // NOWNodes servers. Edge's own Blockbook servers answer /api/v2
+          // unauthenticated and must not be sent the key.
+          const httpTargets: Array<{
+            uri: string
+            headers: { [key: string]: string }
+          }> = []
+          for (const config of serverConfigs) {
+            if (config.type === 'blockbook-nownode') {
+              // NOWNodes answers 401 without a key, so skip those servers
+              // rather than failing a broadcast the public servers could
+              // still carry.
+              if (nowNodesApiKey == null) {
+                log.warn(
+                  'broadcastTx: skipping NOWNodes HTTP servers (no nowNodesApiKey)'
+                )
+                continue
+              }
+              for (const uri of config.uris) {
+                httpTargets.push({
+                  uri,
+                  headers: { 'api-key': nowNodesApiKey }
+                })
+              }
+            } else {
+              for (const uri of config.uris) {
+                httpTargets.push({ uri, headers: {} })
+              }
+            }
+          }
+
+          // If there are no usable HTTP servers, reject the promise
+          if (httpTargets.length < 1) {
             // If no HTTP servers are available, and we had no connected blockbook
             // instances, reject the promise with a message indicating no
             // available connections.
@@ -430,21 +457,13 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
             return
           }
 
-          // If there is no key for the NowNode servers:
-          if (nowNodesApiKey == null) {
-            reject(new Error('Missing connection key for fallback servers.'))
-            return
-          }
-
-          for (const uri of nowNodeUris) {
-            log.warn('Falling back to NOWNode server broadcast over HTTP:', uri)
+          for (const { uri, headers } of httpTargets) {
+            log.warn('Falling back to server broadcast over HTTP:', uri)
 
             // HTTP Fallback
             io.fetchCors(`${uri}/api/v2/sendtx/`, {
               method: 'POST',
-              headers: {
-                'api-key': nowNodesApiKey
-              },
+              headers,
               body: transaction.signedTx
             })
               .then(async response => {
@@ -463,7 +482,7 @@ export function makeServerStates(config: ServerStateConfig): ServerStates {
                 }
               })
               .catch((e?: Error) => {
-                if (++bad === nowNodeUris.length) {
+                if (++bad === httpTargets.length) {
                   const msg = e != null ? `With error ${e.message}` : ''
                   log.error(
                     `broadcastTx fail: ${JSON.stringify(transaction)}\n${msg}`

--- a/src/common/utxobased/info/bitcoin.ts
+++ b/src/common/utxobased/info/bitcoin.ts
@@ -53,7 +53,7 @@ const currencyInfo: EdgeCurrencyInfo = {
 const engineInfo: EngineInfo = {
   serverConfigs: [
     {
-      type: 'blockbook-nownode',
+      type: 'blockbook',
       uris: ['https://btc-wusa1.edge.app', 'https://btc-eu1.edge.app']
     },
     {

--- a/src/common/utxobased/info/bitcoincash.ts
+++ b/src/common/utxobased/info/bitcoincash.ts
@@ -53,7 +53,7 @@ const currencyInfo: EdgeCurrencyInfo = {
 const engineInfo: EngineInfo = {
   serverConfigs: [
     {
-      type: 'blockbook-nownode',
+      type: 'blockbook',
       uris: ['https://bch-eusa1.edge.app']
     },
     {

--- a/src/common/utxobased/info/dash.ts
+++ b/src/common/utxobased/info/dash.ts
@@ -52,7 +52,7 @@ const currencyInfo: EdgeCurrencyInfo = {
 const engineInfo: EngineInfo = {
   serverConfigs: [
     {
-      type: 'blockbook-nownode',
+      type: 'blockbook',
       uris: ['https://dash-wusa1.edge.app']
     },
     {

--- a/src/common/utxobased/info/digibyte.ts
+++ b/src/common/utxobased/info/digibyte.ts
@@ -46,7 +46,7 @@ const currencyInfo: EdgeCurrencyInfo = {
 const engineInfo: EngineInfo = {
   serverConfigs: [
     {
-      type: 'blockbook-nownode',
+      type: 'blockbook',
       uris: ['https://dgb-eu1.edge.app']
     },
     {

--- a/src/common/utxobased/info/dogecoin.ts
+++ b/src/common/utxobased/info/dogecoin.ts
@@ -48,7 +48,7 @@ const currencyInfo: EdgeCurrencyInfo = {
 const engineInfo: EngineInfo = {
   serverConfigs: [
     {
-      type: 'blockbook-nownode',
+      type: 'blockbook',
       uris: ['https://doge-eusa1.edge.app']
     },
     {

--- a/src/common/utxobased/info/litecoin.ts
+++ b/src/common/utxobased/info/litecoin.ts
@@ -50,7 +50,7 @@ export const currencyInfo: EdgeCurrencyInfo = {
 export const engineInfo: EngineInfo = {
   serverConfigs: [
     {
-      type: 'blockbook-nownode',
+      type: 'blockbook',
       uris: ['https://ltc-wusa1.edge.app']
     },
     {

--- a/src/common/utxobased/info/pivx.ts
+++ b/src/common/utxobased/info/pivx.ts
@@ -44,7 +44,7 @@ const currencyInfo: EdgeCurrencyInfo = {
 const engineInfo: EngineInfo = {
   serverConfigs: [
     {
-      type: 'blockbook-nownode',
+      type: 'blockbook',
       uris: ['https://pivx-wusa1.edge.app']
     },
     {

--- a/src/common/utxobased/info/qtum.ts
+++ b/src/common/utxobased/info/qtum.ts
@@ -42,7 +42,7 @@ const currencyInfo: EdgeCurrencyInfo = {
 const engineInfo: EngineInfo = {
   serverConfigs: [
     {
-      type: 'blockbook-nownode',
+      type: 'blockbook',
       uris: ['https://qtum-wusa1.edge.app']
     }
   ],

--- a/src/common/utxobased/info/vertcoin.ts
+++ b/src/common/utxobased/info/vertcoin.ts
@@ -48,7 +48,7 @@ const currencyInfo: EdgeCurrencyInfo = {
 const engineInfo: EngineInfo = {
   serverConfigs: [
     {
-      type: 'blockbook-nownode',
+      type: 'blockbook',
       uris: ['https://vtc-wusa1.edge.app']
     }
   ],

--- a/src/common/utxobased/info/zcoin.ts
+++ b/src/common/utxobased/info/zcoin.ts
@@ -45,7 +45,7 @@ export const currencyInfo: EdgeCurrencyInfo = {
 export const engineInfo: EngineInfo = {
   serverConfigs: [
     {
-      type: 'blockbook-nownode',
+      type: 'blockbook',
       uris: ['https://firo-eusa1.edge.app']
     },
     {

--- a/src/common/utxobased/network/Blockbook.ts
+++ b/src/common/utxobased/network/Blockbook.ts
@@ -177,8 +177,16 @@ export function makeBlockbook(config: BlockbookConfig): Blockbook {
         false,
         T
       > {
-        const value = yield { ...message }
-        deferred.resolve(value)
+        try {
+          const value = yield { ...message }
+          deferred.resolve(value)
+        } catch (error: unknown) {
+          // The socket reports a failed request (an error response, the
+          // request timeout, the socket closing) by throwing into this
+          // generator. Without this catch the deferred stays pending forever
+          // and the caller hangs instead of seeing the failure.
+          deferred.reject(error)
+        }
         return false
       }
       const generator = taskGeneratorFn()

--- a/test/common/utxobased/engine/ServerStates.spec.ts
+++ b/test/common/utxobased/engine/ServerStates.spec.ts
@@ -5,20 +5,25 @@ import {
   EdgeFetchResponse,
   EdgeTransaction
 } from 'edge-core-js/types'
+import WS from 'ws'
 
 import { EngineEmitter } from '../../../../src/common/plugin/EngineEmitter'
 import { PluginState } from '../../../../src/common/plugin/PluginState'
 import { ServerConfig } from '../../../../src/common/plugin/types'
 import {
+  BROADCAST_ATTEMPT_TIMEOUT_MS,
   makeServerStates,
+  NOWNODES_BROADCAST_DELAY_MS,
   ServerStates
 } from '../../../../src/common/utxobased/engine/ServerStates'
 import { SafeWalletInfo } from '../../../../src/common/utxobased/keymanager/cleaners'
 import { makeFakeLog, makeFakePluginInfo } from '../../../utils'
 
 const TXID = 'deadbeef'
+const WS_PORT = 8556
+const WS_URI = `ws://localhost:${WS_PORT}`
 
-type HttpBehavior = 'ok' | 'fail'
+type HttpBehavior = 'ok' | 'fail' | 'hang'
 
 interface FakeHttp {
   calls: string[]
@@ -43,6 +48,10 @@ const makeFakeHttp = (behaviors: { [uri: string]: HttpBehavior }): FakeHttp => {
       headers[uri] = { ...(opts?.headers ?? {}) }
       const base = Object.keys(behaviors).find(key => uri.startsWith(key))
       const behavior = base != null ? behaviors[base] : 'fail'
+      if (behavior === 'hang') {
+        // Accepts the connection and never answers:
+        return await new Promise<EdgeFetchResponse>(() => {})
+      }
       if (behavior === 'ok') {
         return ({
           ok: true,
@@ -82,6 +91,7 @@ const makeTestServerStates = (
   options: {
     serverConfigs?: ServerConfig[]
     nowNodesApiKey?: string | null
+    broadcastTimeoutMs?: number
   } = {}
 ): ServerStates => {
   const { nowNodesApiKey = 'test-key' } = options
@@ -96,7 +106,8 @@ const makeTestServerStates = (
     log: makeFakeLog(),
     pluginInfo,
     pluginState: fakePluginState,
-    walletInfo: fakeWalletInfo
+    walletInfo: fakeWalletInfo,
+    broadcastTimeoutMs: options.broadcastTimeoutMs
   })
   // No engine tasks to run in these tests:
   serverStates.setPickNextTaskCB(async function* () {
@@ -178,7 +189,7 @@ describe('ServerStates.broadcastTx', function () {
     expect(http.calls).to.have.lengthOf(2)
   })
 
-  it('sends the api-key header only to NOWNodes servers', async () => {
+  it('does not contact NOWNodes when Edge servers carry the broadcast', async () => {
     const http = makeFakeHttp({
       'https://public.test': 'ok',
       'https://nownodes.test': 'ok'
@@ -190,9 +201,38 @@ describe('ServerStates.broadcastTx', function () {
       ]
     })
 
-    await serverStates.broadcastTx(transaction)
-    await waitFor(() => http.calls.length === 2)
+    const result = await serverStates.broadcastTx(transaction)
+    // Outlive the second-wave timer to prove it was cancelled:
+    await new Promise(resolve =>
+      setTimeout(resolve, NOWNODES_BROADCAST_DELAY_MS + 250)
+    )
 
+    expect(result).to.equal(TXID)
+    expect(http.calls).to.deep.equal(['https://public.test/api/v2/sendtx/'])
+  })
+
+  it('goes to NOWNodes at once when Edge servers fail, with the api-key only there', async () => {
+    const http = makeFakeHttp({
+      'https://public.test': 'fail',
+      'https://nownodes.test': 'ok'
+    })
+    const serverStates = makeTestServerStates(http, [], {
+      serverConfigs: [
+        { type: 'blockbook', uris: ['https://public.test'] },
+        { type: 'blockbook-nownode', uris: ['https://nownodes.test'] }
+      ]
+    })
+
+    const start = Date.now()
+    const result = await serverStates.broadcastTx(transaction)
+
+    expect(result).to.equal(TXID)
+    // The whole first wave failed fast, so the second did not sit out the delay:
+    expect(Date.now() - start).to.be.lessThan(NOWNODES_BROADCAST_DELAY_MS)
+    expect(http.calls).to.deep.equal([
+      'https://public.test/api/v2/sendtx/',
+      'https://nownodes.test/api/v2/sendtx/'
+    ])
     expect(http.headers['https://public.test/api/v2/sendtx/']).to.deep.equal({})
     expect(http.headers['https://nownodes.test/api/v2/sendtx/']).to.deep.equal({
       'api-key': 'test-key'
@@ -235,6 +275,34 @@ describe('ServerStates.broadcastTx', function () {
     expect(http.calls).to.have.lengthOf(0)
   })
 
+  it('times out an HTTP server that accepts and never answers', async () => {
+    const http = makeFakeHttp({
+      'https://http-a.test': 'hang',
+      'https://http-b.test': 'fail'
+    })
+    const serverStates = makeTestServerStates(
+      http,
+      ['https://http-a.test', 'https://http-b.test'],
+      { broadcastTimeoutMs: 300 }
+    )
+
+    const start = Date.now()
+    let error: unknown
+    try {
+      await serverStates.broadcastTx(transaction)
+    } catch (e) {
+      error = e
+    }
+
+    expect((error as Error).message).to.match(/Timeout for broadcast|HTTP 500/)
+    expect(Date.now() - start).to.be.lessThan(2000)
+    expect(http.calls).to.have.lengthOf(2)
+  })
+
+  it('defaults the attempt timeout to the socket request timeout', () => {
+    expect(BROADCAST_ATTEMPT_TIMEOUT_MS).to.equal(30000)
+  })
+
   it('rejects immediately when there is nothing to broadcast to', async () => {
     const http = makeFakeHttp({})
     const serverStates = makeTestServerStates(http, [])
@@ -248,5 +316,205 @@ describe('ServerStates.broadcastTx', function () {
 
     expect((error as Error).message).to.include('No available connections')
     expect(http.calls).to.have.lengthOf(0)
+  })
+
+  describe('with a connected socket', () => {
+    let websocketServer: WS.Server
+    let serverStates: ServerStates
+    const receivedMethods: string[] = []
+    // How the fake server treats sendTransaction: swallow it, or refuse it
+    // with a Blockbook error response.
+    let sendTransactionReply: 'silent' | 'refuse' = 'silent'
+
+    beforeEach(async () => {
+      receivedMethods.length = 0
+      sendTransactionReply = 'silent'
+      websocketServer = new WS.Server({ port: WS_PORT })
+      websocketServer.on('connection', (ws: WebSocket) => {
+        ws.onmessage = event => {
+          const data = JSON.parse(event.data)
+          receivedMethods.push(data.method)
+          switch (data.method) {
+            case 'ping':
+              ws.send(JSON.stringify({ id: data.id, data: {} }))
+              break
+            case 'getInfo':
+              ws.send(
+                JSON.stringify({
+                  id: data.id,
+                  data: {
+                    name: 'Bitcoin',
+                    shortcut: 'BTC',
+                    decimals: 8,
+                    version: '0.0.0',
+                    bestHeight: 1,
+                    bestHash: '00',
+                    block0Hash: '00',
+                    testnet: false
+                  }
+                })
+              )
+              break
+            case 'sendTransaction':
+              if (sendTransactionReply === 'refuse') {
+                ws.send(
+                  JSON.stringify({
+                    id: data.id,
+                    error: { message: 'Blockbook Error: -26: dust' }
+                  })
+                )
+              }
+              // Otherwise deliberately never answer: this socket looks
+              // healthy but swallows the broadcast.
+              break
+          }
+        }
+      })
+      await new Promise<void>(resolve =>
+        websocketServer.on('listening', () => {
+          resolve()
+        })
+      )
+    })
+
+    afterEach(async () => {
+      serverStates.stop()
+      await new Promise<void>(resolve => websocketServer.close(() => resolve()))
+    })
+
+    it('rejects instead of hanging when the socket refuses and there is no HTTP server', async () => {
+      sendTransactionReply = 'refuse'
+      const http = makeFakeHttp({})
+      serverStates = makeTestServerStates(http, [])
+      serverStates.setServerList([WS_URI])
+      serverStates.refillServers()
+      await waitFor(
+        () =>
+          serverStates.getServerState(WS_URI)?.blockbook.isConnected === true
+      )
+
+      const start = Date.now()
+      let error: unknown
+      try {
+        await serverStates.broadcastTx(transaction)
+      } catch (e) {
+        error = e
+      }
+
+      expect((error as Error).message).to.include('-26: dust')
+      // Settled by the server's refusal, not by the 30s request timeout:
+      expect(Date.now() - start).to.be.lessThan(5000)
+      expect(http.calls).to.have.lengthOf(0)
+    })
+
+    it('rejects instead of hanging when every socket and HTTP attempt fails', async () => {
+      sendTransactionReply = 'refuse'
+      const http = makeFakeHttp({ 'https://http-a.test': 'fail' })
+      serverStates = makeTestServerStates(http, ['https://http-a.test'])
+      serverStates.setServerList([WS_URI])
+      serverStates.refillServers()
+      await waitFor(
+        () =>
+          serverStates.getServerState(WS_URI)?.blockbook.isConnected === true
+      )
+
+      const start = Date.now()
+      let error: unknown
+      try {
+        await serverStates.broadcastTx(transaction)
+      } catch (e) {
+        error = e
+      }
+
+      expect(error).to.be.instanceOf(Error)
+      expect(Date.now() - start).to.be.lessThan(5000)
+      expect(receivedMethods).to.include('sendTransaction')
+      expect(http.calls).to.deep.equal(['https://http-a.test/api/v2/sendtx/'])
+    })
+
+    it('holds NOWNodes back for the delay, then resolves through HTTP rather than waiting on the socket', async () => {
+      const http = makeFakeHttp({ 'https://http-a.test': 'ok' })
+      serverStates = makeTestServerStates(http, ['https://http-a.test'])
+      serverStates.setServerList([WS_URI])
+      serverStates.refillServers()
+      await waitFor(
+        () =>
+          serverStates.getServerState(WS_URI)?.blockbook.isConnected === true
+      )
+
+      const start = Date.now()
+      const result = await serverStates.broadcastTx(transaction)
+      const elapsed = Date.now() - start
+
+      expect(result).to.equal(TXID)
+      // Not before the delay (allowing timer slop), and well under the 30s
+      // socket request timeout:
+      expect(elapsed).to.be.at.least(NOWNODES_BROADCAST_DELAY_MS - 100)
+      expect(elapsed).to.be.lessThan(5000)
+      // The socket was tried first, and the transaction reached it:
+      expect(receivedMethods).to.include('sendTransaction')
+      expect(http.calls).to.deep.equal(['https://http-a.test/api/v2/sendtx/'])
+    })
+
+    it('rejects when the socket has refused and the only HTTP server hangs', async () => {
+      // Bugbot's case: every socket attempt has settled as a failure, but a
+      // hung HTTP attempt must not be able to hold the broadcast open forever.
+      sendTransactionReply = 'refuse'
+      const http = makeFakeHttp({ 'https://public.test': 'hang' })
+      serverStates = makeTestServerStates(http, [], {
+        broadcastTimeoutMs: 300,
+        serverConfigs: [{ type: 'blockbook', uris: ['https://public.test'] }]
+      })
+      serverStates.setServerList([WS_URI])
+      serverStates.refillServers()
+      await waitFor(
+        () =>
+          serverStates.getServerState(WS_URI)?.blockbook.isConnected === true
+      )
+
+      const start = Date.now()
+      let error: unknown
+      try {
+        await serverStates.broadcastTx(transaction)
+      } catch (e) {
+        error = e
+      }
+
+      expect(error).to.be.instanceOf(Error)
+      expect(Date.now() - start).to.be.lessThan(2000)
+      expect(receivedMethods).to.include('sendTransaction')
+      expect(http.calls).to.deep.equal(['https://public.test/api/v2/sendtx/'])
+    })
+
+    it('fires NOWNodes at once when the socket and Edge servers have all failed', async () => {
+      sendTransactionReply = 'refuse'
+      const http = makeFakeHttp({
+        'https://public.test': 'fail',
+        'https://nownodes.test': 'ok'
+      })
+      serverStates = makeTestServerStates(http, [], {
+        serverConfigs: [
+          { type: 'blockbook', uris: ['https://public.test'] },
+          { type: 'blockbook-nownode', uris: ['https://nownodes.test'] }
+        ]
+      })
+      serverStates.setServerList([WS_URI])
+      serverStates.refillServers()
+      await waitFor(
+        () =>
+          serverStates.getServerState(WS_URI)?.blockbook.isConnected === true
+      )
+
+      const start = Date.now()
+      const result = await serverStates.broadcastTx(transaction)
+
+      expect(result).to.equal(TXID)
+      expect(Date.now() - start).to.be.lessThan(NOWNODES_BROADCAST_DELAY_MS)
+      expect(receivedMethods).to.include('sendTransaction')
+      expect(http.calls).to.deep.equal([
+        'https://public.test/api/v2/sendtx/',
+        'https://nownodes.test/api/v2/sendtx/'
+      ])
+    })
   })
 })

--- a/test/common/utxobased/engine/ServerStates.spec.ts
+++ b/test/common/utxobased/engine/ServerStates.spec.ts
@@ -1,0 +1,252 @@
+import { expect } from 'chai'
+import { makeFakeIo } from 'edge-core-js'
+import {
+  EdgeFetchOptions,
+  EdgeFetchResponse,
+  EdgeTransaction
+} from 'edge-core-js/types'
+
+import { EngineEmitter } from '../../../../src/common/plugin/EngineEmitter'
+import { PluginState } from '../../../../src/common/plugin/PluginState'
+import { ServerConfig } from '../../../../src/common/plugin/types'
+import {
+  makeServerStates,
+  ServerStates
+} from '../../../../src/common/utxobased/engine/ServerStates'
+import { SafeWalletInfo } from '../../../../src/common/utxobased/keymanager/cleaners'
+import { makeFakeLog, makeFakePluginInfo } from '../../../utils'
+
+const TXID = 'deadbeef'
+
+type HttpBehavior = 'ok' | 'fail'
+
+interface FakeHttp {
+  calls: string[]
+  headers: { [uri: string]: { [key: string]: string } }
+  fetchCors: (
+    uri: string,
+    opts?: EdgeFetchOptions
+  ) => Promise<EdgeFetchResponse>
+}
+
+const makeFakeHttp = (behaviors: { [uri: string]: HttpBehavior }): FakeHttp => {
+  const calls: string[] = []
+  const headers: FakeHttp['headers'] = {}
+  return {
+    calls,
+    headers,
+    async fetchCors(
+      uri: string,
+      opts?: EdgeFetchOptions
+    ): Promise<EdgeFetchResponse> {
+      calls.push(uri)
+      headers[uri] = { ...(opts?.headers ?? {}) }
+      const base = Object.keys(behaviors).find(key => uri.startsWith(key))
+      const behavior = base != null ? behaviors[base] : 'fail'
+      if (behavior === 'ok') {
+        return ({
+          ok: true,
+          status: 200,
+          json: async () => ({ result: TXID })
+        } as unknown) as EdgeFetchResponse
+      }
+      return ({
+        ok: false,
+        status: 500,
+        json: async () => ({})
+      } as unknown) as EdgeFetchResponse
+    }
+  }
+}
+
+const fakePluginState = ({
+  serverScoreUp: () => {},
+  serverScoreDown: () => {},
+  getLocalServers: () => []
+} as unknown) as PluginState
+
+const fakeWalletInfo = ({
+  id: 'fake-wallet-id',
+  type: 'wallet:bitcoin',
+  keys: {}
+} as unknown) as SafeWalletInfo
+
+const transaction = ({
+  txid: TXID,
+  signedTx: '0100000000'
+} as unknown) as EdgeTransaction
+
+const makeTestServerStates = (
+  http: FakeHttp,
+  httpUris: string[],
+  options: {
+    serverConfigs?: ServerConfig[]
+    nowNodesApiKey?: string | null
+  } = {}
+): ServerStates => {
+  const { nowNodesApiKey = 'test-key' } = options
+  const pluginInfo = makeFakePluginInfo()
+  pluginInfo.engineInfo.serverConfigs =
+    options.serverConfigs ??
+    (httpUris.length > 0 ? [{ type: 'blockbook-nownode', uris: httpUris }] : [])
+  const serverStates = makeServerStates({
+    engineEmitter: new EngineEmitter(),
+    initOptions: nowNodesApiKey == null ? {} : { nowNodesApiKey },
+    io: { ...makeFakeIo(), fetchCors: http.fetchCors },
+    log: makeFakeLog(),
+    pluginInfo,
+    pluginState: fakePluginState,
+    walletInfo: fakeWalletInfo
+  })
+  // No engine tasks to run in these tests:
+  serverStates.setPickNextTaskCB(async function* () {
+    return false
+  })
+  return serverStates
+}
+
+const waitFor = async (
+  predicate: () => boolean,
+  timeoutMs = 5000
+): Promise<void> => {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timed out')
+    }
+    await new Promise(resolve => setTimeout(resolve, 25))
+  }
+}
+
+describe('ServerStates.broadcastTx', function () {
+  this.timeout(15000)
+
+  it('broadcasts over every HTTP server when no sockets are cached', async () => {
+    const http = makeFakeHttp({
+      'https://http-a.test': 'ok',
+      'https://http-b.test': 'ok'
+    })
+    const serverStates = makeTestServerStates(http, [
+      'https://http-a.test',
+      'https://http-b.test'
+    ])
+
+    const result = await serverStates.broadcastTx(transaction)
+
+    expect(result).to.equal(TXID)
+    expect(http.calls).to.have.members([
+      'https://http-a.test/api/v2/sendtx/',
+      'https://http-b.test/api/v2/sendtx/'
+    ])
+  })
+
+  it('resolves when at least one HTTP server accepts', async () => {
+    const http = makeFakeHttp({
+      'https://http-a.test': 'fail',
+      'https://http-b.test': 'ok'
+    })
+    const serverStates = makeTestServerStates(http, [
+      'https://http-a.test',
+      'https://http-b.test'
+    ])
+
+    const result = await serverStates.broadcastTx(transaction)
+
+    expect(result).to.equal(TXID)
+    expect(http.calls).to.have.lengthOf(2)
+  })
+
+  it('rejects only after every HTTP attempt fails', async () => {
+    const http = makeFakeHttp({
+      'https://http-a.test': 'fail',
+      'https://http-b.test': 'fail'
+    })
+    const serverStates = makeTestServerStates(http, [
+      'https://http-a.test',
+      'https://http-b.test'
+    ])
+
+    let error: unknown
+    try {
+      await serverStates.broadcastTx(transaction)
+    } catch (e) {
+      error = e
+    }
+
+    expect(error).to.be.instanceOf(Error)
+    expect((error as Error).message).to.include('HTTP 500')
+    expect(http.calls).to.have.lengthOf(2)
+  })
+
+  it('sends the api-key header only to NOWNodes servers', async () => {
+    const http = makeFakeHttp({
+      'https://public.test': 'ok',
+      'https://nownodes.test': 'ok'
+    })
+    const serverStates = makeTestServerStates(http, [], {
+      serverConfigs: [
+        { type: 'blockbook', uris: ['https://public.test'] },
+        { type: 'blockbook-nownode', uris: ['https://nownodes.test'] }
+      ]
+    })
+
+    await serverStates.broadcastTx(transaction)
+    await waitFor(() => http.calls.length === 2)
+
+    expect(http.headers['https://public.test/api/v2/sendtx/']).to.deep.equal({})
+    expect(http.headers['https://nownodes.test/api/v2/sendtx/']).to.deep.equal({
+      'api-key': 'test-key'
+    })
+  })
+
+  it('skips NOWNodes servers but still uses public servers without a key', async () => {
+    const http = makeFakeHttp({
+      'https://public.test': 'ok',
+      'https://nownodes.test': 'ok'
+    })
+    const serverStates = makeTestServerStates(http, [], {
+      nowNodesApiKey: null,
+      serverConfigs: [
+        { type: 'blockbook', uris: ['https://public.test'] },
+        { type: 'blockbook-nownode', uris: ['https://nownodes.test'] }
+      ]
+    })
+
+    const result = await serverStates.broadcastTx(transaction)
+
+    expect(result).to.equal(TXID)
+    expect(http.calls).to.deep.equal(['https://public.test/api/v2/sendtx/'])
+  })
+
+  it('rejects when only NOWNodes servers exist and there is no key', async () => {
+    const http = makeFakeHttp({ 'https://nownodes.test': 'ok' })
+    const serverStates = makeTestServerStates(http, ['https://nownodes.test'], {
+      nowNodesApiKey: null
+    })
+
+    let error: unknown
+    try {
+      await serverStates.broadcastTx(transaction)
+    } catch (e) {
+      error = e
+    }
+
+    expect((error as Error).message).to.include('No available connections')
+    expect(http.calls).to.have.lengthOf(0)
+  })
+
+  it('rejects immediately when there is nothing to broadcast to', async () => {
+    const http = makeFakeHttp({})
+    const serverStates = makeTestServerStates(http, [])
+
+    let error: unknown
+    try {
+      await serverStates.broadcastTx(transaction)
+    } catch (e) {
+      error = e
+    }
+
+    expect((error as Error).message).to.include('No available connections')
+    expect(http.calls).to.have.lengthOf(0)
+  })
+})

--- a/test/common/utxobased/network/Blockbook.spec.ts
+++ b/test/common/utxobased/network/Blockbook.spec.ts
@@ -94,6 +94,27 @@ describe('Blockbook notifications tests with dummy server', function () {
     websocketServer.close()
   })
 
+  it('rejects a pending request when the server answers with an error', async () => {
+    websocketClient.onmessage = event => {
+      const data = JSON.parse(event.data)
+      if (data.method === 'getInfo') {
+        websocketClient.send(
+          JSON.stringify({ id: data.id, error: { message: 'boom' } })
+        )
+      }
+    }
+
+    let error: unknown
+    try {
+      await blockbook.fetchInfo()
+    } catch (e) {
+      error = e
+    }
+
+    expect(error).to.be.instanceOf(Error)
+    expect((error as Error).message).to.equal('boom')
+  })
+
   it('Test Blockbook watch address and watch block events', async () => {
     let test = false
     test.should.be.false


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Engine half of the "send failed in the UI but the money moved" incident. Asana: https://app.asana.com/1/9976422036640/project/1213880789473005/task/1217135300337949

GUI companion (independent, neither blocks the other): EdgeApp/edge-react-gui#6190

Three commits, review fixups squashed in. **The first commit stands alone** and can be reviewed, or landed, without the rest.

---

#### 1. `Send the NOWNodes API key only to NOWNodes servers`

`ServerConfig` had a single type, `blockbook-nownode`, so when Edge's own Blockbook hosts were added in Dec 2024 (9962d7e) they were filed under it alongside the real NOWNodes entries. Every HTTP broadcast therefore sent the NOWNodes key to Edge's servers too.

They are not the same kind of server:

```
GET https://btc-wusa1.edge.app/api/v2   -> 200, no key needed
GET https://btcbook.nownodes.io/api/v2  -> 401 Unknown API_key
```

The type becomes `blockbook | blockbook-nownode`. The ten `edge.app` HTTP entries are now plain `blockbook`, the `nownodes.io` entries are unchanged, and the key is attached per target instead of to the whole batch.

This also fixes the no-key case. A missing `nowNodesApiKey` previously rejected the entire HTTP path with "Missing connection key for fallback servers", even though the public servers need no key. NOWNodes targets are now skipped with a warning and the public servers still carry the broadcast.

#### 2. `Reject socket requests when the socket fails`

Found in review. `promisifyWsMessage` wraps each request in a `Deferred` that was only ever resolved from inside its own generator. The socket reports every failure (error response, 30s expiry, socket close) by throwing into that generator, which had no try/catch, so the deferred stayed pending forever and the caller hung. That applied to `fetchInfo`, `fetchAddress`, `fetchAddressUtxos`, `fetchTransaction` and `ping`, not only `broadcastTx`. The generator now rejects its deferred on throw.

This has to precede the fan-out: once every socket attempt is counted, an all-fail broadcast with a cached socket could never settle without it.

#### 3. `Broadcast to every server at once`

The HTTP servers were used only when no WebSocket reported itself connected. A socket that looks connected but never answers `sendTransaction` therefore failed the whole broadcast, after the 30 second request timeout, without a single HTTP attempt being made. That is the shape of the incident behind this task.

The gate is worse than it looks: the NOWNodes WebSocket URI is docked 400 points at score load (`ServerScores.serverScoresLoad` penalises any URI carrying key params) and so rarely wins one of the two connection slots. HTTP is the realistic route to those servers, and it was reachable only when every socket was visibly down.

`broadcastTx` now fires in two waves. The first goes out immediately to every cached blockbook (sockets still connecting included, since a queued request transmits as soon as the socket opens) and to every `blockbook` HTTP server, which are Edge's own. The second wave, the `blockbook-nownode` HTTP servers, fires after `NOWNODES_BROADCAST_DELAY_MS` (2s), or as soon as every first-wave attempt has failed, whichever comes first. The first success resolves; it rejects only once every attempt has failed, logging each failure against its server. Every attempt is bounded by `BROADCAST_ATTEMPT_TIMEOUT_MS` (30s, mirroring the socket request expiry), so a server that accepts the connection and never answers cannot hold the broadcast open; the socket layer already expired its own requests, HTTP had no bound until Bugbot pointed it out.

The two waves are the answer to the review thread on unconditional HTTP. NOWNodes is a third party, so it only sees a transaction when Edge's own infrastructure has not already carried it. In the incident every socket was down and the HTTP fallback that saved the broadcast included Edge's own servers, so the first wave would very likely have succeeded on its own; the delay costs anything only in the double-failure case, and two seconds against the old thirty-second hang is nothing. `attempts` counts both waves up front, so an all-fail first wave cannot reject before the second has run.

### Testing

`test/common/utxobased/engine/ServerStates.spec.ts` (new) and `Blockbook.spec.ts`:

- broadcasting over every HTTP server when no sockets are cached
- first success wins when one server fails and another succeeds
- rejecting only after every attempt fails
- rejecting immediately when there is nothing to broadcast to
- NOWNodes is not contacted at all when Edge's own servers carry the broadcast (waits out the delay to prove the timer was cancelled)
- NOWNodes fires at once, not after the delay, when Edge's servers fail fast, with the `api-key` header on the NOWNodes request and **not** on the public one
- skipping NOWNodes but still using public servers when no key is configured
- rejecting when only NOWNodes servers exist and no key is configured
- `fetchInfo` rejects when the server answers with an error (commit 2)
- a real WebSocket that accepts `sendTransaction` and never answers: NOWNodes is held back for the delay, then the broadcast resolves through it well inside the 30s socket timeout
- a socket that refuses alongside failing Edge servers: NOWNodes fires at once and the broadcast resolves in under the delay
- an HTTP server that accepts and never answers times out and the broadcast rejects
- a refusing socket plus a hung HTTP server rejects instead of hanging, Bugbot's case
- the default attempt timeout equals the socket layer's 30 seconds
- a socket that refuses `sendTransaction` with no HTTP server rejects instead of hanging
- a socket that refuses alongside a failing HTTP server rejects instead of hanging

Full suite: 1261 passing at commit 1, 1262 at commit 2, 1270 at HEAD (re-run after the squash; tree identical to the reviewed head). `tsc` and `eslint` clean.

### Note for reviewers

This deliberately does not include the broadcast-failure classification from #455. Per the direction agreed for this task, the app now hard-fails an ambiguous broadcast and says so, rather than trying to infer whether the transaction landed. The `saveTx` "No addresses to process" fix from #455 is still valid and is not in this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core transaction broadcast paths, third-party exposure timing, and API key handling—directly affects whether sends succeed or fail and whether txs leak to NOWNodes early.
> 
> **Overview**
> Fixes UTXO sends that could **fail in the UI while the transaction still propagated**, by changing how `broadcastTx` reaches Blockbook.
> 
> **`broadcastTx` now fans out in two waves.** The first wave immediately hits every cached Blockbook WebSocket (including sockets still connecting) and every Edge `blockbook` HTTP host. NOWNodes `blockbook-nownode` HTTP targets run in a second wave after **2 seconds**, or **immediately** once the first wave has all failed—whichever comes first. The **first success wins**; the call rejects only when **every** attempt fails or hits a **30s** per-attempt timeout (HTTP previously could hang indefinitely). This replaces the old rule that skipped HTTP whenever any socket looked connected, which let one silent socket block fallback entirely.
> 
> **Server typing and credentials:** `ServerConfig` is split into `blockbook` (no headers) vs `blockbook-nownode` (`api-key` only on NOWNodes). Edge `*.edge.app` HTTP entries across coin configs are reclassified as `blockbook`, so the NOWNodes key is no longer sent to Edge. Without a key, NOWNodes servers are skipped with a warning while public Edge HTTP still broadcasts.
> 
> **Socket hang fix:** `Blockbook.promisifyWsMessage` now **rejects** when the socket throws (errors, timeout, close), so broadcast and other WS calls settle instead of pending forever—required for counting all broadcast attempts.
> 
> New **`ServerStates.broadcastTx`** tests cover wave timing, header placement, timeouts, and socket+HTTP combinations; **`Blockbook.spec`** adds error-response rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d77cf4647a8f29f3d1db7b47d56c0675529b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


