### PR TITLE
Switch BTC/LTC explorer links to mempool.space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- changed: BTC and LTC explorer links now point to mempool.space and litecoinspace.org instead of Blockchair
 - changed: `broadcastTx` now sends to every cached Blockbook socket and every Edge Blockbook HTTP server at once, then to the NOWNodes HTTP servers two seconds later or as soon as that first wave has failed, resolving on the first success and rejecting only when all attempts fail or time out (30 seconds per attempt, matching the socket layer). Previously the HTTP fallback ran only when no socket reported itself connected, so one unresponsive socket could fail the whole broadcast without any HTTP attempt.
 - fixed: Stop sending the NOWNodes API key to Edge's own Blockbook HTTP servers. They are now configured as plain `blockbook` servers, which are also used when no NOWNodes key is configured.
 

--- a/src/common/utxobased/info/bitcoin.ts
+++ b/src/common/utxobased/info/bitcoin.ts
@@ -20,8 +20,8 @@ const currencyInfo: EdgeCurrencyInfo = {
 
   // Explorers:
   blockExplorer: 'https://blockchair.com/bitcoin/block/%s',
-  addressExplorer: 'https://blockchair.com/bitcoin/address/%s',
-  transactionExplorer: 'https://blockchair.com/bitcoin/transaction/%s',
+  addressExplorer: 'https://mempool.space/address/%s',
+  transactionExplorer: 'https://mempool.space/tx/%s',
 
   denominations: [
     { name: 'BTC', multiplier: '100000000', symbol: '₿' },

--- a/src/common/utxobased/info/litecoin.ts
+++ b/src/common/utxobased/info/litecoin.ts
@@ -20,8 +20,8 @@ export const currencyInfo: EdgeCurrencyInfo = {
 
   // Explorers:
   blockExplorer: 'https://blockchair.com/litecoin/block/%s',
-  addressExplorer: 'https://blockchair.com/litecoin/address/%s',
-  transactionExplorer: 'https://blockchair.com/litecoin/transaction/%s',
+  addressExplorer: 'https://litecoinspace.org/address/%s',
+  transactionExplorer: 'https://litecoinspace.org/tx/%s',
 
   denominations: [
     { name: 'LTC', multiplier: '100000000', symbol: 'Ł' },


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Switch BTC and LTC `addressExplorer`/`transactionExplorer` links from Blockchair to mempool.space and litecoinspace.org.

- BTC `transactionExplorer` -> `https://mempool.space/tx/%s`
- BTC `addressExplorer` -> `https://mempool.space/address/%s`
- LTC `transactionExplorer` -> `https://litecoinspace.org/tx/%s`
- LTC `addressExplorer` -> `https://litecoinspace.org/address/%s`
- `blockExplorer` left unchanged for both, out of scope for this task.

Companion PR in `edge-currency-accountbased` makes the matching XMR transaction-explorer change.

Asana: https://app.asana.com/0/1215088146871429/1211177181799241

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> URL-only changes to currency metadata with no effect on signing, sync, or broadcast behavior.
> 
> **Overview**
> **BTC and LTC in-wallet explorer links** for addresses and transactions now open **mempool.space** and **litecoinspace.org** instead of Blockchair. Only `addressExplorer` and `transactionExplorer` in the Bitcoin and Litecoin currency info were updated; **`blockExplorer` stays on Blockchair** for both chains.
> 
> The **Unreleased** CHANGELOG entry documents the switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b444694c8c17eda6b04fba1f93e2fe25368cedf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->